### PR TITLE
feat(ci,dx): non-vacuous CI, supply-chain gate, GHCR distribution, user guides, policy proptests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,40 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rust:
     runs-on: ubuntu-latest
+    # A real Postgres so the fluidbox-db tests actually run — without
+    # DATABASE_URL they self-skip and the persistence layer goes untested.
+    # Vanilla PG is fine here: Neon is only special in production, and
+    # LISTEN/NOTIFY + the migration path are stock Postgres.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fluidbox
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/fluidbox
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: debug
       - name: fmt
         run: cargo fmt --all -- --check
       - name: clippy
@@ -38,3 +63,97 @@ jobs:
           cache-dependency-path: apps/web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+
+  # Supply-chain gate: advisories, licenses, bans, sources (deny.toml).
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
+  # The full acceptance suite, no-model tier: builds BOTH runner images
+  # (base-image bumps can't be vacuously green — closes the #14 gap) and
+  # drives the real stack over HTTP. Live tiers are skipped — CI never
+  # spends model credits; run `just e2e` locally with keys for those.
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fluidbox
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: debug
+      - name: craft .env
+        run: |
+          cat > .env <<EOF
+          DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/fluidbox
+          FLUIDBOX_BIND=0.0.0.0:8787
+          FLUIDBOX_ADMIN_TOKEN=$(openssl rand -hex 32)
+          FLUIDBOX_CREDENTIAL_KEY=$(openssl rand -hex 32)
+          FLUIDBOX_PUBLIC_CONTROL_URL=http://host.docker.internal:8787
+          FLUIDBOX_DATA_DIR=./data
+          FLUIDBOX_SANDBOX_IMAGE=fluidbox-sandbox-runner:ci
+          FLUIDBOX_CODEX_SANDBOX_IMAGE=fluidbox-codex-runner:ci
+          LITELLM_MASTER_KEY=sk-litellm-ci-only
+          LLM_UPSTREAM_URL=http://127.0.0.1:4000
+          EOF
+      - name: acceptance suite (no live tiers)
+        env:
+          E2E_SKIP_LIVE: "1"
+        run: bash scripts/e2e.sh
+
+  # Coverage on main pushes only (it re-runs the whole test suite).
+  # The lcov report is an artifact; the summary lands in the job log.
+  coverage:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fluidbox
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-timeout 5s
+          --health-interval 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/fluidbox
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: coverage
+      - name: coverage
+        run: |
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          cargo llvm-cov report --summary-only
+      - uses: actions/upload-artifact@v7
+        with:
+          name: coverage-lcov
+          path: lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: release
+
+# Publishes the four fluidbox images to GHCR. Runs ONLY on version tags or a
+# manual dispatch — never automatically on PRs/pushes. Free for public repos;
+# no model credentials are involved anywhere in this workflow.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # Build each image natively per architecture (no QEMU — a QEMU'd release
+  # cargo build takes the better part of an hour) and push by digest.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [server, web, sandbox-runner, codex-runner]
+        platform:
+          - { os: ubuntu-latest, arch: amd64 }
+          - { os: ubuntu-24.04-arm, arch: arm64 }
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: resolve dockerfile + context
+        id: target
+        run: |
+          case "${{ matrix.image }}" in
+            server)         echo "file=deploy/server.Dockerfile" >> "$GITHUB_OUTPUT"; echo "context=." >> "$GITHUB_OUTPUT" ;;
+            web)            echo "file=deploy/web.Dockerfile"    >> "$GITHUB_OUTPUT"; echo "context=." >> "$GITHUB_OUTPUT" ;;
+            sandbox-runner) echo "file=images/sandbox-runner/Dockerfile" >> "$GITHUB_OUTPUT"; echo "context=images" >> "$GITHUB_OUTPUT" ;;
+            codex-runner)   echo "file=images/codex-runner/Dockerfile"   >> "$GITHUB_OUTPUT"; echo "context=images" >> "$GITHUB_OUTPUT" ;;
+          esac
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: build + push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ steps.target.outputs.context }}
+          file: ${{ steps.target.outputs.file }}
+          platforms: linux/${{ matrix.platform.arch }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository_owner }}/fluidbox-${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.platform.arch }}
+      - name: export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.image }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stitch the per-arch digests into one multi-arch manifest per image.
+  publish:
+    needs: build
+    strategy:
+      matrix:
+        image: [server, web, sandbox-runner, codex-runner]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+          path: /tmp/digests
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/fluidbox-${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=latest
+      - name: create manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/fluidbox-${{ matrix.image }}@sha256:%s ' *)
+      - name: inspect
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/fluidbox-${{ matrix.image }}:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ### Added
 
+- **CI now tells the truth** — the rust job runs against a real Postgres service (the DB tests no longer silently self-skip), a new `e2e` job builds both runner images and runs the full no-model acceptance suite on every PR (closes the vacuous-green gap of #14), and `cargo deny check` (advisories/licenses/bans/sources, `deny.toml`) gates the supply chain. Live model tiers stay local/manual — CI never spends credits. Coverage (lcov artifact) runs on main pushes.
+- **Property tests for the policy engine** — generated-input invariants in `fluidbox-core`: an autonomous run can never surface `RequireApproval`, autonomy rewrites exactly the approval verdicts (original always ledgered), the read-only tier denies any shell metacharacter and any unlisted tool, shell prefixes are token-bounded, first match wins.
+- **Try-it-with-Docker distribution** — `deploy/server.Dockerfile` + `deploy/web.Dockerfile` (Next standalone output), a `release` workflow publishing multi-arch images to GHCR on version tags or manual dispatch, and `deploy/docker-compose.eval.yml`: bundled Postgres + LiteLLM + server + dashboard in one `docker compose up`.
+- **User guides** (`docs/guides/`) — writing policies, triggers/schedules/signed results (with the HMAC verification recipe and a pinned test vector), and capabilities (sandbox vs brokered MCP tools, pinning, the connector catalog).
+- **`ROADMAP.md`** — the public distillation of `PLAN.md` §7.
+
 - **`just setup`** — one-command idempotent bootstrap for a fresh clone: tools check, `.env` with generated secrets (`FLUIDBOX_ADMIN_TOKEN`, `FLUIDBOX_CREDENTIAL_KEY`, `LITELLM_MASTER_KEY`), dashboard env (`apps/web/.env.local`) kept in sync, `pnpm install`, and the sandbox runner image build. Only fills placeholders — never overwrites values you set.
 - **`just doctor`** — environment preflight (#13): validates every documented gotcha (pooled vs direct `DATABASE_URL`, loopback `FLUIDBOX_BIND`, credential key shape, missing runner images, dashboard token drift, missing web deps) and prints the exact fix per failure; exits non-zero only on hard failures, never echoes secret values.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ just check    # cargo fmt + clippy -D warnings + cargo test + web build — must
 just e2e      # full acceptance suite — run it if you touched the permission/approval/trigger path
 ```
 
+CI runs all of that against a real Postgres **plus** the no-model e2e suite (it builds both runner images) and `cargo deny check` (advisories + licenses; config in `deny.toml`). The live model tiers never run in CI — they cost real credits and stay a local, maintainer-triggered concern (`just e2e` with keys in `.env`).
+
 Notes:
 
 - `cargo test -p fluidbox-core` is fast and needs no database.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +854,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +906,7 @@ dependencies = [
  "futures",
  "globset",
  "hex",
+ "proptest",
  "regex",
  "serde",
  "serde_json",
@@ -977,6 +999,12 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1679,6 +1707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2099,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,8 +2208,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2175,12 +2244,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2196,6 +2284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2336,6 +2433,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2526,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2968,6 +3090,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3494,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,20 @@ Coding agents are powerful and unaccountable: they run with your credentials, on
 - **Connector catalog + OAuth** — connect external services with PKCE, resource indicators, and dynamic client registration; refresh tokens sealed at rest with atomic rotation.
 - **Dashboard** — a Next.js UI (presentation-only; all logic lives in the Rust API).
 
-## Quickstart
+## Try it with Docker (no toolchain needed)
+
+Published images + a bundled Postgres — one pull, one up:
+
+```bash
+git clone https://github.com/hrishikeshdkakkad/fluidbox.git && cd fluidbox
+docker compose -f deploy/docker-compose.eval.yml --profile runners pull
+ANTHROPIC_API_KEY=sk-ant-... docker compose -f deploy/docker-compose.eval.yml up -d
+open http://localhost:3000
+```
+
+This is the eval configuration (well-known admin token, no webhook ingress) — for hacking on fluidbox, use the dev quickstart below.
+
+## Quickstart (dev)
 
 Prerequisites: [Rust](https://rustup.rs) (stable), [Docker](https://docs.docker.com/get-docker/), [just](https://github.com/casey/just), [pnpm](https://pnpm.io) + Node 24, and a free [Neon](https://neon.tech) account (or any direct-connection Postgres).
 
@@ -82,6 +95,12 @@ Something not working? **`just doctor`** checks every documented gotcha (pooled 
 
 - [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — how a run flows, the security model, and the extension seams.
 - [`PLAN.md`](./PLAN.md) — the authoritative design document: north star, convergence invariants, milestones.
+
+### Guides
+
+- [Writing policies](./docs/guides/policies.md) — the YAML rules, verdicts, autonomy fallbacks, and what the engine guarantees.
+- [Triggers, schedules & signed results](./docs/guides/triggers.md) — borrow the agent from an API, a cron, or a webhook, and verify the signed outcome.
+- [Capabilities (MCP tools)](./docs/guides/capabilities.md) — sandbox vs brokered tools, bundle pinning, and the connector catalog.
 
 ### Repository layout
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+The distilled version. [`PLAN.md`](./PLAN.md) is the authoritative design document — its §2 convergence invariants govern every change; this page just tells you where the project is and where help is welcome.
+
+## Shipped (v0.1.0)
+
+- **The governed vertical slice** — versioned agents, frozen RunSpecs, disposable Docker sandboxes, live SSE timelines, policy gate + human approvals + autonomous mode, budgets, diff + cost reports, append-only redacted ledger.
+- **Two harnesses** behind one runner contract: Claude Agent SDK and Codex.
+- **Credential inversion everywhere** — LLM facade, control-plane git fetches, brokered MCP tools, OAuth custody with sealed rotating refresh tokens.
+- **Borrow the agent, on demand** — scoped API triggers, cron schedules (exactly-once), signed result webhooks, GitHub App connect + PR fan-out with fork-PR read-only trust.
+- **Capability & connector catalogs** — versioned MCP tool bundles pinned at run creation; app-store-style connect.
+
+## Next
+
+| # | What | Why | Status |
+|---|------|-----|--------|
+| 1 | **Slack vertical** (Phase 7) | second event connector; validates the provider-ignorant event spine before any public connector SDK | next up |
+| 2 | **AWS Lambda MicroVM provider + BYOC** (M2) | the production execution substrate: 8h leases with rollover, idle-suspend for days-long autonomous agents, Terraform BYOC | designed (PLAN §7 M2), not started |
+| 3 | **Customer-built agents** (M3 remainder) | signed, versioned runner images implementing the runner contract — bring your own agent | after M2 |
+| 4 | **Brokered git writes** (design §17 #4) | push/PR-create as brokered operations riding the same broker gateway | explicitly deferred, seam ready |
+
+## Help wanted
+
+Good first contributions are labeled on the [issue tracker](https://github.com/hrishikeshdkakkad/fluidbox/issues) — currently: CI hardening, the codex execpolicy relative-path residual, GitHub App advisory locks, and an architecture diagram. Before picking up anything architectural, read `PLAN.md` §2 (the invariants) and [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+Changes land phase-by-phase, fully tested (`just check` + `just e2e`) — see the [changelog](./CHANGELOG.md) for what shipped when.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Self-contained server bundle for the Docker image (deploy/web.Dockerfile).
+  output: "standalone",
   // The 2026-07 IA consolidation moved pages around; keep old URLs working
   // (bookmarks, muscle memory). Capabilities (agent tools) and Integrations
   // (platforms agents work on) are deliberately separate pages.

--- a/crates/fluidbox-core/Cargo.toml
+++ b/crates/fluidbox-core/Cargo.toml
@@ -20,3 +20,6 @@ hex.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
 futures.workspace = true
+
+[dev-dependencies]
+proptest = "1"

--- a/crates/fluidbox-core/src/policy.rs
+++ b/crates/fluidbox-core/src/policy.rs
@@ -792,3 +792,240 @@ tools:
         .is_err());
     }
 }
+
+/// Property tests: the security invariants the example-based tests above pin
+/// point-wise, asserted over generated policies and adversarial inputs.
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::spec::Autonomy;
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    fn arb_action() -> impl Strategy<Value = RuleAction> {
+        prop_oneof![
+            Just(RuleAction::Allow),
+            Just(RuleAction::Approve),
+            Just(RuleAction::Deny),
+        ]
+    }
+
+    fn arb_fallback() -> impl Strategy<Value = AutonomousFallback> {
+        prop_oneof![
+            Just(AutonomousFallback::Deny),
+            Just(AutonomousFallback::Allow)
+        ]
+    }
+
+    /// Tool names as agents actually send them, plus arbitrary unknown ones.
+    fn arb_tool() -> impl Strategy<Value = String> {
+        prop_oneof![
+            prop::sample::select(vec![
+                "Read",
+                "Glob",
+                "Grep",
+                "LS",
+                "Bash",
+                "Edit",
+                "Write",
+                "MultiEdit",
+                "WebFetch",
+                "mcp__kb__search",
+                "mcp__ws__file_count",
+            ])
+            .prop_map(str::to_string),
+            "[A-Za-z][A-Za-z0-9_]{0,16}",
+        ]
+    }
+
+    /// Match patterns: exact names, `prefix*` wildcards, or the universal `*`.
+    fn arb_pattern() -> impl Strategy<Value = String> {
+        prop_oneof![
+            arb_tool(),
+            "[A-Za-z][A-Za-z0-9_]{0,6}".prop_map(|p| format!("{p}*")),
+            Just("*".to_string()),
+        ]
+    }
+
+    fn arb_shell() -> impl Strategy<Value = ShellRules> {
+        (
+            prop::collection::vec(
+                prop::sample::select(vec!["ls", "git status", "pytest", "python3", "rm"])
+                    .prop_map(str::to_string),
+                0..3,
+            ),
+            prop::collection::vec(
+                prop::sample::select(vec![r"rm\s+-rf\s+/", r"\bcurl\b", r"\bwget\b"])
+                    .prop_map(str::to_string),
+                0..3,
+            ),
+            arb_action(),
+        )
+            .prop_map(|(allow_prefixes, deny_regex, on_no_match)| ShellRules {
+                allow_prefixes,
+                deny_regex,
+                on_no_match,
+            })
+    }
+
+    fn arb_rule() -> impl Strategy<Value = ToolRule> {
+        (
+            prop::collection::vec(arb_pattern(), 1..3),
+            arb_action(),
+            prop::option::of(arb_shell()),
+            prop::bool::ANY,
+            prop::option::of(arb_fallback()),
+        )
+            .prop_map(|(m, action, shell, with_paths, on_autonomous)| ToolRule {
+                r#match: m,
+                action,
+                risk: None,
+                paths: with_paths.then(|| PathRules {
+                    allow: vec!["/workspace/**".into()],
+                    deny: vec!["**/.env".into()],
+                }),
+                shell,
+                on_autonomous,
+                approval_ttl_secs: None,
+                approval_scope: None,
+            })
+    }
+
+    fn arb_policy() -> impl Strategy<Value = Policy> {
+        (
+            prop::collection::vec(arb_rule(), 0..5),
+            arb_action(),
+            arb_fallback(),
+        )
+            .prop_map(|(tools, default_action, on_approval_rule)| Policy {
+                name: "prop".into(),
+                defaults: PolicyDefaults {
+                    tool_action: default_action,
+                },
+                egress: Egress::default(),
+                budgets: crate::spec::Budgets::default(),
+                approvals: ApprovalSettings::default(),
+                autonomy: AutonomySettings {
+                    permitted: true,
+                    on_approval_rule,
+                },
+                tools,
+            })
+    }
+
+    /// Arbitrary printable inputs in the shapes the gate actually receives.
+    fn arb_input() -> impl Strategy<Value = serde_json::Value> {
+        prop_oneof![
+            "[ -~]{0,40}".prop_map(|c| json!({ "command": c })),
+            "[ -~]{0,40}".prop_map(|p| json!({ "file_path": p })),
+            Just(json!({})),
+        ]
+    }
+
+    fn req(tool: String, input: serde_json::Value) -> ToolCallRequest {
+        ToolCallRequest { tool, input }
+    }
+
+    proptest! {
+        /// Invariant #6 (autonomous ≠ ungoverned, but also ≠ stuck): an
+        /// autonomous evaluation NEVER surfaces RequireApproval — the engine
+        /// rewrites it before it can leave, so an unattended run cannot hang
+        /// waiting for a human that isn't there.
+        #[test]
+        fn autonomous_never_requires_approval(
+            p in arb_policy(), tool in arb_tool(), input in arb_input()
+        ) {
+            let out = p.evaluate(&req(tool, input), Autonomy::Autonomous);
+            let requires_approval = matches!(out.effective, Verdict::RequireApproval { .. });
+            prop_assert!(!requires_approval);
+        }
+
+        /// Autonomy resolution touches EXACTLY the approval verdicts: Allow
+        /// and Deny pass through untouched, approvals are rewritten with the
+        /// flag set, and the supervised verdict is always preserved as
+        /// `original` (both are ledgered — the audit trail sees the truth).
+        #[test]
+        fn autonomy_rewrites_exactly_the_approvals(
+            p in arb_policy(), tool in arb_tool(), input in arb_input()
+        ) {
+            let supervised = p.evaluate(&req(tool.clone(), input.clone()), Autonomy::Supervised);
+            let autonomous = p.evaluate(&req(tool, input), Autonomy::Autonomous);
+            prop_assert_eq!(&autonomous.original, &supervised.effective);
+            match supervised.effective {
+                Verdict::RequireApproval { .. } => {
+                    prop_assert!(autonomous.autonomy_rewritten);
+                    let resolved = matches!(
+                        autonomous.effective,
+                        Verdict::Allow | Verdict::Deny { .. }
+                    );
+                    prop_assert!(resolved);
+                }
+                other => {
+                    prop_assert!(!autonomous.autonomy_rewritten);
+                    prop_assert_eq!(autonomous.effective, other);
+                }
+            }
+        }
+
+        /// The read-only trust tier fails safe against injection: ANY shell
+        /// metacharacter anywhere in the command defeats prefix reasoning and
+        /// must deny, no matter what the command otherwise looks like.
+        #[test]
+        fn read_only_tier_denies_any_metacharacter(
+            prefix in "[ -~]{0,20}", suffix in "[ -~]{0,20}",
+            meta in prop::sample::select(vec![';', '|', '&', '`', '$', '(', ')', '<', '>', '\n'])
+        ) {
+            let cmd = format!("{prefix}{meta}{suffix}");
+            let r = req("Bash".into(), json!({ "command": cmd }));
+            prop_assert!(read_only_denial(&r).is_some());
+        }
+
+        /// The read-only tier is an ALLOWLIST: any tool not explicitly listed
+        /// (and not Bash, which has its own prefix path) is denied — new or
+        /// unknown tools are read-only-unsafe by default.
+        #[test]
+        fn read_only_tier_denies_unlisted_tools(tool in "[A-Za-z][A-Za-z0-9_]{0,16}") {
+            prop_assume!(tool != "Bash" && !READ_SAFE_TOOLS.contains(&tool.as_str()));
+            let denied = read_only_denial(&req(tool, json!({}))).is_some();
+            prop_assert!(denied);
+        }
+
+        /// Shell prefix matching is token-bounded: `p` matches itself and
+        /// `p <anything>`, but never `p` glued to more word characters —
+        /// "git status" must not cover "git statusx".
+        #[test]
+        fn prefix_match_is_token_bounded(
+            p in "[a-z]{1,8}( [a-z]{1,8})?", glued in "[a-zA-Z0-9_-]{1,8}", rest in "[ -~]{0,20}"
+        ) {
+            let exact = prefix_matches(&p, &p);
+            let spaced = prefix_matches(&p, &format!("{p} {rest}"));
+            let glued_on = prefix_matches(&p, &format!("{p}{glued}"));
+            prop_assert!(exact);
+            prop_assert!(spaced);
+            prop_assert!(!glued_on);
+        }
+
+        /// First match wins: a deny rule prepended for the exact tool always
+        /// decides, regardless of everything below it.
+        #[test]
+        fn first_matching_rule_decides(
+            p in arb_policy(), tool in arb_tool(), input in arb_input()
+        ) {
+            let mut p2 = p;
+            p2.tools.insert(0, ToolRule {
+                r#match: vec![tool.clone()],
+                action: RuleAction::Deny,
+                risk: None,
+                paths: None,
+                shell: None,
+                on_autonomous: None,
+                approval_ttl_secs: None,
+                approval_scope: None,
+            });
+            let out = p2.evaluate(&req(tool, input), Autonomy::Supervised);
+            let denied = matches!(out.effective, Verdict::Deny { .. });
+            prop_assert!(denied);
+            prop_assert_eq!(out.matched_rule, Some(0));
+        }
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,43 @@
+# cargo-deny configuration — the supply-chain gate (`cargo deny check`, run in CI).
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# RUSTSEC advisories fail the build unless explicitly ignored WITH a reason.
+ignore = [
+    # rsa's Marvin timing sidechannel (via jsonwebtoken's RS256, used to mint
+    # GitHub App JWTs). No fixed rsa release exists yet. Accepted because the
+    # signing key is OUR app's own key, signing happens control-plane-side on
+    # operator-initiated flows, and no untrusted party can drive or precisely
+    # time signing operations. Re-evaluate when rsa 0.10 ships.
+    { id = "RUSTSEC-2023-0071", reason = "no patched rsa release; control-plane-side signing with our own key, not attacker-timeable" },
+]
+
+[licenses]
+# Permissive-only allowlist, matched to the current tree. Anything new that
+# isn't on this list (or is copyleft) fails CI and forces a conscious call.
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+[bans]
+# Duplicate crate versions are a fact of life in this tree (RustCrypto 0.10/0.11
+# straddle); surface them as warnings, not failures.
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/deploy/docker-compose.eval.yml
+++ b/deploy/docker-compose.eval.yml
@@ -1,0 +1,95 @@
+# Try fluidbox in one command — no Rust toolchain, no pnpm, no Neon account:
+#
+#   docker compose -f deploy/docker-compose.eval.yml --profile runners pull
+#   ANTHROPIC_API_KEY=sk-ant-... docker compose -f deploy/docker-compose.eval.yml up -d
+#   open http://localhost:3000
+#
+# The --profile runners pull fetches the sandbox runner images into the host
+# daemon (they are not services — the server spawns them as sibling containers
+# over the mounted Docker socket, so they must exist host-side).
+#
+# EVAL ONLY. Defaults favor zero-setup over hardening: a bundled Postgres, a
+# well-known admin token, no credential key (Connections/webhooks disabled).
+# For real use follow the README quickstart (`just setup`).
+name: fluidbox-eval
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: fluidbox
+      POSTGRES_DB: fluidbox
+    volumes:
+      - fluidbox-pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  litellm:
+    # Pinned family; only this container ever holds the real provider keys.
+    image: ${LITELLM_IMAGE:-ghcr.io/berriai/litellm:main-stable}
+    command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
+    environment:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-eval-only}
+    volumes:
+      - ./litellm/config.yaml:/etc/litellm/config.yaml:ro
+
+  server:
+    image: ${FLUIDBOX_SERVER_IMAGE:-ghcr.io/hrishikeshdkakkad/fluidbox-server:latest}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      litellm:
+        condition: service_started
+    ports:
+      - "8787:8787" # published: sandboxes reach it via host.docker.internal
+    environment:
+      DATABASE_URL: postgres://postgres:fluidbox@postgres:5432/fluidbox
+      FLUIDBOX_BIND: 0.0.0.0:8787
+      FLUIDBOX_ADMIN_TOKEN: ${FLUIDBOX_ADMIN_TOKEN:-fluidbox-eval-only}
+      FLUIDBOX_CREDENTIAL_KEY: ${FLUIDBOX_CREDENTIAL_KEY:-}
+      LLM_UPSTREAM_URL: http://litellm:4000
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-eval-only}
+      # The data dir must be the SAME absolute path on the host and in this
+      # container: workspace dirs under it are bind-mounted into sandbox
+      # containers by the HOST daemon, which resolves host paths.
+      FLUIDBOX_DATA_DIR: ${FLUIDBOX_EVAL_DATA:-/tmp/fluidbox-eval-data}
+      FLUIDBOX_SANDBOX_IMAGE: ${FLUIDBOX_SANDBOX_IMAGE:-ghcr.io/hrishikeshdkakkad/fluidbox-sandbox-runner:latest}
+      FLUIDBOX_CODEX_SANDBOX_IMAGE: ${FLUIDBOX_CODEX_SANDBOX_IMAGE:-ghcr.io/hrishikeshdkakkad/fluidbox-codex-runner:latest}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${FLUIDBOX_EVAL_DATA:-/tmp/fluidbox-eval-data}:${FLUIDBOX_EVAL_DATA:-/tmp/fluidbox-eval-data}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8787/v1/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  web:
+    image: ${FLUIDBOX_WEB_IMAGE:-ghcr.io/hrishikeshdkakkad/fluidbox-web:latest}
+    depends_on:
+      server:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    environment:
+      FLUIDBOX_API_URL: http://server:8787
+      FLUIDBOX_ADMIN_TOKEN: ${FLUIDBOX_ADMIN_TOKEN:-fluidbox-eval-only}
+
+  # Pull-only entries (never started): `--profile runners pull` fetches the
+  # runner images the server will spawn as sibling containers.
+  sandbox-runner:
+    image: ${FLUIDBOX_SANDBOX_IMAGE:-ghcr.io/hrishikeshdkakkad/fluidbox-sandbox-runner:latest}
+    profiles: ["runners"]
+    entrypoint: ["true"]
+  codex-runner:
+    image: ${FLUIDBOX_CODEX_SANDBOX_IMAGE:-ghcr.io/hrishikeshdkakkad/fluidbox-codex-runner:latest}
+    profiles: ["runners"]
+    entrypoint: ["true"]
+
+volumes:
+  fluidbox-pg:

--- a/deploy/server.Dockerfile
+++ b/deploy/server.Dockerfile
@@ -1,0 +1,32 @@
+# fluidbox control plane. Build context = repo root:
+#   docker build -t fluidbox-server -f deploy/server.Dockerfile .
+#
+# Migrations are embedded in the binary (sqlx::migrate!); the policies/ seed
+# directory is baked in because the boot seeder reads ./policies from cwd.
+FROM rust:1.96-bookworm AS build
+WORKDIR /src
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+COPY migrations ./migrations
+COPY policies ./policies
+RUN cargo build --release -p fluidbox-server
+
+FROM debian:bookworm-slim
+# git: control-plane-side workspace fetches (credentials ride GIT_CONFIG_* env,
+# never argv or on-disk config). ca-certificates: TLS to Neon/GitHub/LiteLLM.
+# curl: the compose healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /src/target/release/fluidbox-server /usr/local/bin/fluidbox-server
+COPY policies ./policies
+
+# The server orchestrates sibling sandbox containers over the mounted Docker
+# socket, so it is inherently daemon-privileged in this deployment — it runs
+# as root to reach the socket. Isolation comes from the sandboxes themselves
+# (cap_drop=ALL, no-new-privileges, egress-free), not from this process's uid.
+ENV FLUIDBOX_BIND=0.0.0.0:8787 \
+    FLUIDBOX_DATA_DIR=/var/lib/fluidbox
+EXPOSE 8787
+CMD ["fluidbox-server"]

--- a/deploy/web.Dockerfile
+++ b/deploy/web.Dockerfile
@@ -1,0 +1,22 @@
+# fluidbox dashboard (Next.js standalone output). Build context = repo root:
+#   docker build -t fluidbox-web -f deploy/web.Dockerfile .
+FROM node:24-bookworm-slim AS build
+RUN npm install -g pnpm@10
+WORKDIR /app
+COPY apps/web/package.json apps/web/pnpm-lock.yaml apps/web/pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY apps/web .
+RUN pnpm build
+
+FROM node:24-bookworm-slim
+WORKDIR /app
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+# Standalone output bundles the server + the traced node_modules subset.
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+USER node
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -1,0 +1,95 @@
+# Capabilities: giving agents MCP tools, safely
+
+A **capability bundle** is a versioned, append-only registry object describing MCP tools an agent may call. There are exactly **two tool classes**, and the split is the security model:
+
+| Class | Runs where | Credentials |
+|---|---|---|
+| `sandbox` | stdio subprocess **inside** the sandbox, packaged in the runner image | none by construction — contained by the container |
+| `brokered` | called **by the control plane** on the sandbox's behalf | a sealed credential that **never enters a sandbox** |
+
+A brokered call is the same inversion as the LLM facade and git fetch: the sandbox asks, the control plane holds the secret and executes. Either way, **every MCP call passes the same permission gate as Bash/Edit** — attaching a bundle makes tools *available*, never *allowed*.
+
+All examples assume `API=http://127.0.0.1:8787` and `H="authorization: Bearer $FLUIDBOX_ADMIN_TOKEN"`.
+
+## The easy path: the connector catalog
+
+`GET /v1/catalog` lists known connectors (Notion, Sentry, …). Connecting auto-registers the bundle:
+
+```bash
+# api_key connector: paste the key, get a connection + photographed bundle back
+curl -s -X POST $API/v1/catalog/fx-sentry/connect -H "$H" \
+  -H "content-type: application/json" -d '{"token": "sntrys_…"}'
+
+# oauth connector: returns {connection, authorize_url} — open the URL, approve,
+# the callback completes the connection and photographs the bundle
+curl -s -X POST $API/v1/catalog/fx-notion/connect -H "$H" \
+  -H "content-type: application/json" -d '{}'
+```
+
+A rejected api_key rolls the connection back; nothing half-connected survives. Custom entries can be added with `POST /v1/catalog` (they're forced to `tier=custom` — catalog data is reference data, not trust).
+
+## The explicit path: publish a bundle yourself
+
+**Brokered** — point at a streamable-HTTP MCP server; tools are **discovered** (photographed via `tools/list`), never declared:
+
+```bash
+# 1. a connection custodies the credential, audience-bound to base_url
+KBCONN=$(curl -s -X POST $API/v1/connections -H "$H" -H "content-type: application/json" -d '{
+  "provider": "mcp_http", "base_url": "https://mcp.example.com",
+  "token": "secret-upstream-token",
+  "header_name": "authorization", "scheme": "Bearer"
+}' | jq -r .connection.id)
+
+# 2. publishing photographs the server's tools at THIS moment
+curl -s -X POST $API/v1/capabilities -H "$H" -H "content-type: application/json" -d '{
+  "name": "knowledge-base",
+  "servers": [{ "class": "brokered", "name": "kb",
+                "url": "https://mcp.example.com/mcp", "connection_id": "'$KBCONN'" }]
+}'
+```
+
+(`scheme` also supports `"Basic"` — paste `email:api_token` as the token — and `""` for a bare-token header; `auth_kind: "oauth"` starts the PKCE dance instead of pasting a secret.)
+
+**Sandbox** — a stdio server that ships in the runner image; tools are **declared**, with schemas:
+
+```bash
+curl -s -X POST $API/v1/capabilities -H "$H" -H "content-type: application/json" -d '{
+  "name": "workspace-tools",
+  "servers": [{ "class": "sandbox", "name": "ws",
+    "command": "node", "args": ["/opt/fluidbox-runner/servers/workspace-info.mjs"],
+    "tools": [{ "name": "workspace_file_count",
+                "description": "Count files in the workspace",
+                "input_schema": {"type":"object","properties":{},"additionalProperties":false} }]
+  }]
+}'
+```
+
+Re-publishing the same `name` appends the next version — the registry is append-only, like agents.
+
+## Attach, pin, narrow
+
+Bundles attach to **agent revisions** and are **pinned at attach time**:
+
+```bash
+curl -s -X POST $API/v1/agents -H "$H" -H "content-type: application/json" -d '{
+  "name": "kb-reporter", "policy": "default",
+  "capability_bundles": ["knowledge-base", "workspace-tools@1"]
+}'
+```
+
+- `"name"` resolves to the newest version **at that moment**, then pins it; `"name@N"` pins explicitly. Nothing ever floats — upgrading = appending a new revision.
+- On `POST /v1/agents/{id}/revisions`: omit `capability_bundles` to inherit the previous revision's pins; `[]` clears them; a new list re-resolves (the upgrade path).
+
+Narrowing is **remove-only**, by bundle name, via the `capabilities` field in two places — the intersection of revision pins ∩ subscription keep-list ∩ per-run keep-list is what the run gets:
+
+```bash
+# a trigger subscription that keeps only one of the revision's bundles
+… -d '{ "agent": "kb-reporter", "name": "reporter-sub", "capabilities": ["workspace-tools"] }'
+# a single run that strips all MCP tools
+curl -s -X POST $API/v1/sessions -H "$H" -H "content-type: application/json" \
+  -d '{ "agent": "kb-reporter", "task": "…", "capabilities": [] }'
+```
+
+## What the run actually gets (and why drift can't hurt you)
+
+At run creation the RunSpec freezes the pinned versions **plus full tool-schema snapshots and digests**. At the gate, every `mcp__<server>__<tool>` call is checked against that frozen set *before* trust tier and policy — a tool that drifted upstream or was rug-pulled since registration is **denied** (`source=capability`), not silently forwarded. Brokered calls are decided and executed server-side (one decision per call — the sandbox can't self-approve), and the ledger records `tool.requested → tool.decision → tool.brokered` with latency and result digests, never payloads or secrets. Read-only trust tier (fork PRs) strips capabilities entirely.

--- a/docs/guides/policies.md
+++ b/docs/guides/policies.md
@@ -1,0 +1,84 @@
+# Writing policies
+
+A policy is a YAML document evaluated on **every tool call** an agent makes. The verdict is one of `allow`, `deny`, or `approve` (pause for a human). Policies live in the control plane (seeded from [`policies/*.yaml`](../../policies) at boot, managed via the API), and every run **freezes a snapshot** of its policy into the RunSpec — editing a policy only affects future runs, never in-flight ones.
+
+## The document
+
+```yaml
+name: default            # must match the API body's `name` on upsert
+
+defaults:
+  tool_action: approve   # verdict when NO rule matches; fail-safe = ask a human
+
+budgets:                 # per-run CEILING — revisions/runs may only tighten these
+  max_wall_clock_secs: 1800
+  max_tokens: 1000000
+  max_cost_usd: 2.5
+  max_tool_calls: 100
+
+approvals:
+  default_ttl_secs: 600  # unanswered approval expires (and denies) after this
+  scope: once            # once = re-ask every call | session = approve-once-per-scope-key
+  timeout_action: deny
+
+autonomy:
+  permitted: true        # false = autonomous runs of this policy are refused (400)
+  on_approval_rule: deny # what `approve` becomes when nobody is watching: deny | allow
+
+tools:                   # ORDERED rules; first rule whose `match` hits wins
+  - match: ["Read", "Glob", "Grep", "LS"]
+    action: allow
+
+  - match: ["Edit", "Write", "MultiEdit"]
+    action: allow
+    paths:
+      allow: ["/workspace/**"]              # outside the allow-set → escalates to approve
+      deny: ["**/.env", "**/.git/hooks/**"] # deny always wins, even inside allow
+
+  - match: ["Bash"]
+    action: allow
+    shell:
+      allow_prefixes: ["ls", "pytest", "git status", "git diff"]  # token-boundary matched
+      deny_regex: ["rm\\s+-rf\\s+/", "\\bcurl\\b", "\\bwget\\b"]  # checked FIRST, always deny
+      on_no_match: approve                  # anything else → ask a human
+
+  - match: ["WebFetch", "WebSearch"]
+    action: deny
+    risk: "network egress from sandbox"     # becomes the deny reason / approval context
+
+  - match: ["mcp__*"]                       # `*` suffix wildcard on tool names
+    action: approve
+    on_autonomous: allow                    # per-rule override of autonomy.on_approval_rule
+    approval_ttl_secs: 120                  # per-rule approval overrides
+    approval_scope: session
+```
+
+## Evaluation semantics (what the engine guarantees)
+
+- **First match wins.** Rules are checked top-down; the first rule whose `match` list hits the tool name decides. Order your specific rules above your broad ones.
+- **Shell rules:** `deny_regex` is checked before `allow_prefixes` — a deny match is final (`ls && curl evil` is denied even though `ls` is allowed). Prefixes are **token-boundary** matched: `git status` matches `git status -sb` but never `git statusx`. Anything that hits neither gets `on_no_match`.
+- **Path rules:** any `deny` glob match is a hard deny. If `allow` globs are set and a touched path falls outside them, the call **escalates to approval** rather than failing the run.
+- **Approvals:** `scope: once` re-asks per call; `scope: session` remembers by scope key — for Bash the key is the matched prefix (approving `git push` covers `git push`, not all shell), for other tools the tool name.
+- **Autonomy narrows, never widens.** On an autonomous run, an `approve` verdict is rewritten *inside the engine* to `autonomy.on_approval_rule` (or the rule's `on_autonomous` override). `allow` and `deny` verdicts are untouched, an autonomous run can never end up waiting on a human, and the ledger records **both** the original and rewritten verdict. There is no bypass mode: the permission callback stays wired in every autonomy mode.
+- **Fork PRs are stricter than any policy.** Runs from untrusted event sources (fork PRs) carry a hard read-only trust tier enforced *above* policy — reads only, no writes/exec/egress, and **no approval can widen it**.
+
+## Managing policies
+
+```bash
+# validate without saving (422 with the parse error on bad YAML)
+curl -s -X POST localhost:8787/v1/policies/validate \
+  -H "authorization: Bearer $FLUIDBOX_ADMIN_TOKEN" -H "content-type: application/json" \
+  -d "$(jq -n --rawfile y policies/default.yaml '{yaml: $y}')"
+
+# upsert (bumps the policy version; in-flight runs keep their frozen snapshot)
+curl -s -X POST localhost:8787/v1/policies \
+  -H "authorization: Bearer $FLUIDBOX_ADMIN_TOKEN" -H "content-type: application/json" \
+  -d "$(jq -n --rawfile y policies/default.yaml '{name: "default", yaml: $y}')"
+
+# or push every policies/*.yaml in one go
+just policy-sync
+```
+
+An agent revision names its policy; the policy's `budgets` are a ceiling the revision and each run may only tighten. Autonomy is chosen per run (`"autonomous": true` on `POST /v1/sessions`) or per trigger subscription — a policy with `autonomy.permitted: false` refuses those outright.
+
+The seed policy ([`policies/default.yaml`](../../policies/default.yaml)) is a good starting point: read-only tools allowed, workspace-scoped writes, a shell classifier derived from observed agent behavior (rationale in its comments), exfil/destructive commands denied, everything else paused for a human. Its exact semantics are pinned by the `seed_policy_semantics` test in `fluidbox-core`.

--- a/docs/guides/triggers.md
+++ b/docs/guides/triggers.md
@@ -1,0 +1,106 @@
+# Triggers, schedules & signed results — a cookbook
+
+"Borrow the agent, on demand": any external circumstance — an API call, a cron tick, a webhook — can start a run of a registered agent and get the outcome delivered back, signed. Every entry point converges on the same governed run path (frozen RunSpec, policy gate, budgets); a trigger never widens what an agent may do.
+
+All examples assume `API=http://127.0.0.1:8787` and `H="authorization: Bearer $FLUIDBOX_ADMIN_TOKEN"`.
+
+## 1. Create a subscription
+
+```bash
+curl -s -X POST $API/v1/triggers -H "$H" -H "content-type: application/json" -d '{
+  "agent": "claude-fixer",
+  "name": "incident-investigator",
+  "task_template": "Investigate {{ticket}} and write a report.",
+  "autonomous": true,
+  "callback_url": "https://ops.example.com/fluidbox-callback"
+}'
+```
+
+The response is the **only** time two secrets appear — store both:
+
+```json
+{
+  "subscription": { "id": "…", "…": "…" },
+  "token": "fbx_trig_…",           // invoke credential, scoped to THIS subscription
+  "callback_secret": "fbx_whsec_…" // HMAC key for verifying result deliveries
+}
+```
+
+Useful create-time fields: `budgets` (tighten below the policy ceiling), `workspace` (a default `git_repository`/`local_path`/`scratch` workspace), `pinned_revision_id` (pin a revision; default = latest at run time), `concurrency_policy` (`allow` default | `skip_if_running` | `replace`), `capabilities` (a remove-only keep-list of the revision's capability bundles). `callback_url` requires `FLUIDBOX_CREDENTIAL_KEY` on the server (the secret is sealed at rest).
+
+**Trigger tokens are subscription-scoped**: they can invoke their one subscription and poll the runs it created — never the admin API. The admin token, conversely, cannot invoke. Rotate with `POST /v1/triggers/{id}/rotate_token` (revokes all live tokens, returns one new one).
+
+## 2. Invoke it
+
+```bash
+curl -s -X POST $API/v1/triggers/$SUB_ID/invoke \
+  -H "authorization: Bearer fbx_trig_…" -H "content-type: application/json" \
+  -H "Idempotency-Key: incident-4711" \
+  -d '{"context": {"ticket": "INC-4711"}}'
+```
+
+```json
+{ "session_id": "…", "status": "queued", "replay": false,
+  "poll_url": "/v1/triggers/…/runs/…" }
+```
+
+- `context` values (strings/numbers/bools only) fill the `{{key}}` slots in the task template.
+- `Idempotency-Key`: same key + same body → the same run is returned (`"replay": true`); same key + different body → `422`. Retry-safe by construction.
+- Caller overrides are **opt-in per subscription and off by default**: with `allow_task_override` you may send `task`; with `allow_workspace_override` you may send `workspace: {repository, ref, commit_sha}` — which can only *narrow* within the subscription's authority (never a new connection or clone URL).
+- With `concurrency_policy: skip_if_running`, an invoke while a previous run is still active returns **409** (`skipped: run … is still active`).
+
+Poll the outcome with the same trigger token:
+
+```bash
+curl -s $API/v1/triggers/$SUB_ID/runs/$SESSION_ID -H "authorization: Bearer fbx_trig_…"
+```
+
+## 3. Put it on a clock
+
+A schedule is not a new object — it's the same subscription with a `schedule` block:
+
+```bash
+curl -s -X POST $API/v1/triggers -H "$H" -H "content-type: application/json" -d '{
+  "agent": "claude-fixer",
+  "name": "nightly-deps-audit",
+  "task_template": "Audit dependencies and open a report.",
+  "autonomous": true,
+  "concurrency_policy": "skip_if_running",
+  "schedule": { "cron": "0 3 * * *", "timezone": "America/Los_Angeles",
+                "missed_run_policy": "skip" }
+}'
+```
+
+- `cron` is standard 5-field (a 6/7-field form with seconds exists for tests).
+- Firing is **exactly-once** — a deterministic claim row per fire time makes restarts and racing workers safe.
+- `missed_run_policy`: `skip` (default) records one skip row for a gap (server down, subscription disabled); `catch_up` fires exactly **one** make-up run — never one per missed tick.
+- `concurrency_policy` is enforced for ALL invocation paths, not just the scheduler.
+- `POST /v1/triggers/{id}/disable` / `/enable` pause and resume; a disabled schedule does not advance, and re-enabling goes through the missed-run policy.
+
+## 4. Verify signed result deliveries
+
+When a run reaches a terminal state, subscriptions with a `callback_url` get a POST:
+
+| Header | Value |
+|---|---|
+| `x-fluidbox-event` | `run.finished` |
+| `x-fluidbox-delivery` | delivery UUID — **dedup on this** (delivery is at-least-once) |
+| `x-fluidbox-timestamp` | unix seconds |
+| `x-fluidbox-signature` | `v1=<hex hmac-sha256(secret, "{timestamp}.{body}")>` |
+
+Verification (constant-time compare in real code):
+
+```python
+import hmac, hashlib
+def verify(secret: str, ts: str, body: bytes, header: str) -> bool:
+    mac = hmac.new(secret.encode(), f"{ts}.".encode() + body, hashlib.sha256)
+    return hmac.compare_digest(f"v1={mac.hexdigest()}", header)
+```
+
+Pinned test vector (also asserted in the server's tests): secret `fbx_whsec_test`, timestamp `1752000000`, body `{"a":1}` → `v1=b519ceca5a07a724c2e3aef9decbc4420a5cd7f303bfdf1a28a8c2b63625aa72`. Reject stale timestamps to bound replay.
+
+The body carries `run` (id, status, task, summary, invocation, timestamps), `usage` (tokens, cost_usd, tool_calls), and `artifacts` (including the diff). Failed deliveries retry `5s → 30s → 2m → 10m → 30m → 1h` (6 attempts); a dead receiver can never affect the run itself. Inspect attempts at `GET /v1/sessions/{id}/deliveries`.
+
+## 5. Event-driven runs (GitHub)
+
+Webhook-driven runs ride the same subscription object: pass `connection` (a GitHub connection id) instead of `schedule`, plus optional `repositories` (`["owner/name"]`), `events` (default `opened`+`reopened`; `synchronize` is an explicit opt-in — it fires per push), and `publish` (`["pr_comment"]` default, `"check"` available). The create response then includes the `ingress_path` to configure as the webhook URL; the webhook signature against the connection's sealed secret is the authentication. Fork PRs are frozen to a read-only trust tier with no approval escape. Connect GitHub itself from the dashboard's Integrations page (the seamless GitHub App flow).

--- a/scripts/e2e-capabilities.sh
+++ b/scripts/e2e-capabilities.sh
@@ -407,13 +407,14 @@ FROZEN_EV=$(pq "select count(*) from events where session_id='$SA' and type='cap
 # ── The gate: availability (frozen set) then policy — probed for real ─────
 say "GATE — the ONE permission gate: frozen availability, then policy"
 token_for() { # session → token (kills the runner so probes own the contract)
-  # 120s window: four event-derived runs launch containers concurrently, and
-  # a 2-core CI runner can take >30s to get the first one up.
+  # The token must be read from the container env BEFORE the keyless runner
+  # fails fast and gets reaped (container removed) — poll tightly, and kill
+  # the runner the moment it's seen. 120s ceiling for slow CI runners.
   local sid=$1 cid tok=""
-  for _ in $(seq 1 120); do
+  for _ in $(seq 1 240); do
     cid=$(docker ps -a --filter "label=fluidbox.session=$sid" --format '{{.ID}}' | head -1)
     [ -n "$cid" ] && { tok=$(docker inspect "$cid" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^FLUIDBOX_SESSION_TOKEN=' | cut -d= -f2-); break; }
-    sleep 1
+    sleep 0.5
   done
   [ -n "$cid" ] && docker kill "$cid" >/dev/null 2>&1
   echo "$tok"
@@ -426,9 +427,29 @@ broke() { # session token id tool input
   curl -s -X POST -H "authorization: Bearer $2" -H "$CT" \
     -d "{\"tool_call_id\":\"$3\",\"tool\":\"$4\",\"input\":$5}" "$API/internal/sessions/$1/tools/call"
 }
-TA=$(token_for "$SA"); TB=$(token_for "$SB"); TN=$(token_for "$SN")
+# Probe the three runners in PARALLEL: sequentially scanning A→B→N loses
+# the race against fail-fast-and-reap on slow CI runners (a probe only has
+# to beat the reaping of ITS OWN runner). Explicit pids — a bare `wait`
+# would block on the phase's background fake servers.
+PROBE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fbx-cap-probe.XXXXXX")
+token_for "$SA" >"$PROBE_DIR/a" & PROBE_A=$!
+token_for "$SB" >"$PROBE_DIR/b" & PROBE_B=$!
+token_for "$SN" >"$PROBE_DIR/n" & PROBE_N=$!
+wait "$PROBE_A" "$PROBE_B" "$PROBE_N"
+TA=$(cat "$PROBE_DIR/a"); TB=$(cat "$PROBE_DIR/b"); TN=$(cat "$PROBE_DIR/n")
+rm -rf "$PROBE_DIR"
 docker kill "$(docker ps -a --filter "label=fluidbox.session=$SC" --format '{{.ID}}' | head -1)" >/dev/null 2>&1
-[ -n "$TA" ] && [ -n "$TB" ] && [ -n "$TN" ] && ok "session tokens extracted; runners killed (we drive the contract)" || { no "no tokens (A:${TA:+ok}${TA:-missing} B:${TB:+ok}${TB:-missing} N:${TN:+ok}${TN:-missing})"; exit 1; }
+if [ -n "$TA" ] && [ -n "$TB" ] && [ -n "$TN" ]; then
+  ok "session tokens extracted; runners killed (we drive the contract)"
+else
+  # Verdicts only — NEVER token values.
+  no "no tokens (A:$([ -n "$TA" ] && echo ok || echo missing) B:$([ -n "$TB" ] && echo ok || echo missing) N:$([ -n "$TN" ] && echo ok || echo missing))"
+  echo "  containers with a fluidbox.session label:"
+  docker ps -a --filter "label=fluidbox.session" --format '  {{.ID}} {{.Status}} {{.Label "fluidbox.session"}}' | head -10
+  echo "  last server log lines:"
+  tail -20 "$SERVER_LOG" | sed 's/^/    /'
+  exit 1
+fi
 
 D=$(perm "$SA" "$TA" g1 "mcp__kb__kb_search" '{"query":"x"}' | j "['decision']")
 [ "$D" = "allow" ] && ok "A: mcp__kb__kb_search → allow (attached + policy allows)" || no "kb_search: $D"

--- a/scripts/e2e-capabilities.sh
+++ b/scripts/e2e-capabilities.sh
@@ -407,8 +407,10 @@ FROZEN_EV=$(pq "select count(*) from events where session_id='$SA' and type='cap
 # ── The gate: availability (frozen set) then policy — probed for real ─────
 say "GATE — the ONE permission gate: frozen availability, then policy"
 token_for() { # session → token (kills the runner so probes own the contract)
+  # 120s window: four event-derived runs launch containers concurrently, and
+  # a 2-core CI runner can take >30s to get the first one up.
   local sid=$1 cid tok=""
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 120); do
     cid=$(docker ps -a --filter "label=fluidbox.session=$sid" --format '{{.ID}}' | head -1)
     [ -n "$cid" ] && { tok=$(docker inspect "$cid" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^FLUIDBOX_SESSION_TOKEN=' | cut -d= -f2-); break; }
     sleep 1
@@ -426,7 +428,7 @@ broke() { # session token id tool input
 }
 TA=$(token_for "$SA"); TB=$(token_for "$SB"); TN=$(token_for "$SN")
 docker kill "$(docker ps -a --filter "label=fluidbox.session=$SC" --format '{{.ID}}' | head -1)" >/dev/null 2>&1
-[ -n "$TA" ] && [ -n "$TB" ] && [ -n "$TN" ] && ok "session tokens extracted; runners killed (we drive the contract)" || { no "no tokens"; exit 1; }
+[ -n "$TA" ] && [ -n "$TB" ] && [ -n "$TN" ] && ok "session tokens extracted; runners killed (we drive the contract)" || { no "no tokens (A:${TA:+ok}${TA:-missing} B:${TB:+ok}${TB:-missing} N:${TN:+ok}${TN:-missing})"; exit 1; }
 
 D=$(perm "$SA" "$TA" g1 "mcp__kb__kb_search" '{"query":"x"}' | j "['decision']")
 [ "$D" = "allow" ] && ok "A: mcp__kb__kb_search → allow (attached + policy allows)" || no "kb_search: $D"

--- a/scripts/e2e-codex.sh
+++ b/scripts/e2e-codex.sh
@@ -120,8 +120,8 @@ bash "$(dirname "$0")/e2e-codex-replay.sh" "$SB" && ok "supervisor protocol-repl
 
 # ═══ TIER 2 — live §12 demo (self-skips without OPENAI_API_KEY) ═════════════
 say "TIER 2 — live codex run (§12)"
-if [ -z "${OPENAI_API_KEY:-}" ]; then
-  ok "SKIP live tier — OPENAI_API_KEY not set (by design)"
+if [ "${E2E_SKIP_LIVE:-0}" = "1" ] || [ -z "${OPENAI_API_KEY:-}" ]; then
+  ok "SKIP live tier — E2E_SKIP_LIVE=${E2E_SKIP_LIVE:-0} / OPENAI_API_KEY $([ -n "${OPENAI_API_KEY:-}" ] && echo set || echo unset) (live spend is opt-in by design)"
 else
   bash "$(dirname "$0")/e2e-codex-live.sh" && ok "live codex run completed + governed" || no "live codex run FAILED"
 fi

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -32,11 +32,15 @@ docker build -q -t "$FLUIDBOX_SANDBOX_IMAGE" \
   -f "$ROOT/images/sandbox-runner/Dockerfile" "$ROOT/images" >/dev/null || exit 1
 echo "building server + cli"
 cargo build -q -p fluidbox-server -p fluidbox-cli || exit 1
-docker compose -f "$ROOT/deploy/docker-compose.dev.yml" up -d litellm >/dev/null 2>&1 || true
-for _ in $(seq 1 40); do
-  curl -fsS -m 2 http://127.0.0.1:4000/health/liveliness >/dev/null 2>&1 && break
-  sleep 0.5
-done
+# The gateway only serves live model tiers — skip the pull/boot entirely
+# when they're disabled (CI runs with E2E_SKIP_LIVE=1 and no keys).
+if [ "${E2E_SKIP_LIVE:-0}" != "1" ]; then
+  docker compose -f "$ROOT/deploy/docker-compose.dev.yml" up -d litellm >/dev/null 2>&1 || true
+  for _ in $(seq 1 40); do
+    curl -fsS -m 2 http://127.0.0.1:4000/health/liveliness >/dev/null 2>&1 && break
+    sleep 0.5
+  done
+fi
 trap 'stop_server' EXIT
 start_server || exit 1
 ok "stack up (gateway + control plane)"


### PR DESCRIPTION
## What & why

Closes #14.

The hardening + adoption pass discussed after v0.1.0, in one PR (nightly e2e deliberately excluded — live model tiers stay a manual, maintainer-triggered concern):

**1. CI now tells the truth.** `cargo test` ran with no `DATABASE_URL` — every `fluidbox-db` test silently self-skipped on every PR, and the 10-phase acceptance suite never ran in CI at all. Now: a Postgres 16 service on the rust job (recipe proven locally on vanilla `postgres:16` — 13/13 DB tests in 0.57s), plus a new **e2e job** that builds BOTH runner images (the #14 gap) and drives the complete no-model suite on every PR. `E2E_SKIP_LIVE=1`, no keys in CI — **CI can never spend model credits**.

**2. Money paths are explicit everywhere.** Found and fixed a real gap while verifying: `e2e-codex.sh`'s live tier gated only on `OPENAI_API_KEY` *presence*, ignoring `E2E_SKIP_LIVE` — a local no-live run with keys in `.env` would still spend OpenAI credits. It now honors the flag; `e2e.sh` also skips the LiteLLM boot entirely when live tiers are off.

**3. Supply-chain gate.** `cargo deny check` in CI with `deny.toml`: RUSTSEC advisories (one justified ignore: RUSTSEC-2023-0071, rsa Marvin via jsonwebtoken RS256 — control-plane-side signing with our own key, no patched release exists), a permissive-license allowlist, and source checks.

**4. Try-it-with-Docker distribution.** `deploy/server.Dockerfile` (migrations embedded, `policies/` baked for the boot seeder, git + CA certs for control-plane fetches), `deploy/web.Dockerfile` (Next `output: "standalone"`), a `release` workflow publishing multi-arch (amd64 + arm64, native runners — no QEMU'd cargo builds) images to GHCR **only on version tags or manual dispatch**, and `deploy/docker-compose.eval.yml` — bundled Postgres + LiteLLM + server + dashboard.

**5. Policy-engine property tests** (`proptest`, ~1500 generated cases per run): an autonomous evaluation can never surface `RequireApproval`; autonomy rewrites exactly the approval verdicts (original always preserved for the ledger); the read-only tier denies any shell metacharacter and any unlisted tool; shell prefix matching is token-bounded; first match wins.

**6. User-facing docs.** `docs/guides/{policies,triggers,capabilities}.md` (curl-first, field names verified against the code, incl. the delivery HMAC recipe + pinned test vector), `ROADMAP.md` (PLAN §7 distilled), README "Try it with Docker" + guide links, CONTRIBUTING quality-bar update. Coverage (lcov artifact) runs on main pushes.

## How was this tested?

- `just check` green (fmt, clippy `-D warnings`, workspace tests against real Postgres, web build incl. the new standalone output).
- Full no-live `just e2e`: **ALL 10 PHASES PASSED, 416 assertions, 0 failures** (one earlier run had a transient phase flake; the clean re-run passed end-to-end on identical code).
- `fluidbox-db` tests proven against vanilla `postgres:16` in Docker — validates the CI service-container recipe.
- `cargo deny check`: advisories/bans/licenses/sources all ok locally.
- Eval compose smoke-tested with locally-built images: fresh container boot → migrations + policy/agent seeding → healthy authenticated API → dashboard 200 → clean teardown.
- The new e2e CI job runs on THIS PR — its green check is the live verification.
- `release.yml` will be verified by manual dispatch after merge (it only runs on tags/dispatch).

## Checklist

- [x] `just check` passes (fmt, clippy `-D warnings`, tests, web build)
- [x] Touched the permission/approval/trigger path → ran `just e2e` — full suite, all 10 phases (no-live)
- [x] Behavior change → tests added/updated — 6 property tests; CI itself is the test for the workflow changes
- [x] User-visible change → `CHANGELOG.md` (Unreleased) and docs updated
- [ ] Architectural change → preserves the convergence invariants (`PLAN.md` §2) — N/A (no runtime architecture touched; proptests *assert* the invariants)
- [x] No secrets in code, tests, fixtures, or logs — CI secrets are generated per-run; eval defaults are documented as eval-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016T1MaG2PuSXEQsjwP9BtDu