### PR TITLE
fix(e2e): make no-live mode zero-spend and deterministic (closes the CI flake class)

### DIFF
--- a/scripts/e2e-capabilities.sh
+++ b/scripts/e2e-capabilities.sh
@@ -166,7 +166,7 @@ class Gh(http.server.BaseHTTPRequestHandler):
 http.server.HTTPServer(("127.0.0.1", port), Gh).serve_forever()
 PYEOF
 GH_PID=$!
-trap 'kill $MCP_PID $GH_PID 2>/dev/null; stop_server' EXIT
+trap 'kill $MCP_PID $GH_PID ${LLM_STALL_PID:-} 2>/dev/null; stop_server' EXIT
 sleep 0.5
 
 # ── file:// fixtures ──────────────────────────────────────────────────────
@@ -376,6 +376,29 @@ send_event() { # payload-file delivery-id → http code (body in $B)
     -H "$CT" -H "x-github-delivery: $2" -H "x-github-event: pull_request" \
     -H "x-hub-signature-256: sha256=$sig" -d "$body"
 }
+# Keep the four event-derived runners ALIVE through the token probes below:
+# without a reachable model upstream their SDKs crash at nondeterministic
+# speed and the watchdog removes the containers before the probes can read
+# the session tokens (CI flakes 29222410561 / 29224265638). An accept-and-
+# stall stub on :4000 blocks their model call instead — killed again right
+# after extraction so later phases keep fail-fast semantics. No-op when a
+# real gateway is already serving (local dev).
+LLM_STALL_PID=""
+if ! curl -fsS -m 1 http://127.0.0.1:4000/health/liveliness >/dev/null 2>&1; then
+  python3 - >/dev/null 2>&1 <<'PYSTALL' &
+import http.server, socketserver, time
+class Stall(http.server.BaseHTTPRequestHandler):
+    def _stall(self):
+        time.sleep(600)
+    do_GET = do_POST = _stall
+    def log_message(self, *args):
+        pass
+socketserver.ThreadingTCPServer.allow_reuse_address = True
+socketserver.ThreadingTCPServer(("127.0.0.1", 4000), Stall).serve_forever()
+PYSTALL
+  LLM_STALL_PID=$!
+fi
+
 P_OPEN=$(pr_payload acme/site 500 1 "$HEAD1" 500)
 CODE=$(send_event "$P_OPEN" "cap-open-1")
 N=$(python3 -c "import json;print(len(json.load(open('$B'))['dispatched']))" 2>/dev/null)
@@ -439,6 +462,7 @@ wait "$PROBE_A" "$PROBE_B" "$PROBE_N"
 TA=$(cat "$PROBE_DIR/a"); TB=$(cat "$PROBE_DIR/b"); TN=$(cat "$PROBE_DIR/n")
 rm -rf "$PROBE_DIR"
 docker kill "$(docker ps -a --filter "label=fluidbox.session=$SC" --format '{{.ID}}' | head -1)" >/dev/null 2>&1
+[ -n "$LLM_STALL_PID" ] && kill "$LLM_STALL_PID" 2>/dev/null && LLM_STALL_PID=""
 if [ -n "$TA" ] && [ -n "$TB" ] && [ -n "$TN" ]; then
   ok "session tokens extracted; runners killed (we drive the contract)"
 else

--- a/scripts/e2e-git-workspace.sh
+++ b/scripts/e2e-git-workspace.sh
@@ -117,7 +117,7 @@ FROZEN_REF=$(cat /tmp/fbx-gitws-body.json | j "['session']['repo_source']['ref']
 [ "$FROZEN_KIND" = "git_repository" ] && [ "$FROZEN_REF" = "feature" ] \
   && ok "frozen workspace = revision default (git@feature)" || no "frozen repo_source wrong: kind=$FROZEN_KIND ref=$FROZEN_REF"
 
-FINAL_A=$(wait_terminal "$SA" 240) || true
+FINAL_A=$(wait_terminal "$SA" 420) || true
 case "$FINAL_A" in
   completed|failed) ok "run A terminal ($FINAL_A — live key optional here)" ;;
   *) no "run A did not reach terminal: $FINAL_A" ;;
@@ -141,7 +141,7 @@ SB=$(cat /tmp/fbx-gitws-body.json | j "['session']['id']")
 [ "$CODE" = "200" ] && [ -n "$SB" ] && ok "run started with explicit workspace override" || { no "session create failed ($CODE)"; exit 1; }
 OV_SHA=$(cat /tmp/fbx-gitws-body.json | j "['session']['repo_source']['commit_sha']")
 [ "$OV_SHA" = "$SHA1" ] && ok "override frozen into RunSpec (not the revision default)" || no "frozen commit_sha wrong: $OV_SHA"
-FINAL_B=$(wait_terminal "$SB" 240) || true
+FINAL_B=$(wait_terminal "$SB" 420) || true
 BCB=$(sfield "$SB" "['base_commit']")
 [ "$BCB" = "$SHA1" ] && ok "exact commit checked out (immune to branch movement)" \
   || no "base_commit '$BCB' ≠ pinned $SHA1 (terminal=$FINAL_B)"

--- a/scripts/e2e-trigger.sh
+++ b/scripts/e2e-trigger.sh
@@ -182,7 +182,7 @@ CODE=$(tpost "$TOK1_NEW" "/triggers/$SUB1/invoke" '{"context":{"ticket":"INC-42"
 [ "$CODE" = "200" ] && ok "new token works (and key-A still replays)" || no "wanted 200, got $CODE"
 
 say "SIGNED CALLBACK — terminal run → one verified delivery"
-FINAL1=$(wait_terminal "$S1" 240) || true
+FINAL1=$(wait_terminal "$S1" 420) || true
 case "$FINAL1" in completed|failed) ok "S1 terminal ($FINAL1)";; *) no "S1 not terminal: $FINAL1";; esac
 DFILE=""
 for _ in $(seq 1 30); do
@@ -214,7 +214,7 @@ say "DEAD DESTINATION — the run stays terminal; only the delivery retries"
 CODE=$(tpost "$TOK3" "/triggers/$SUB3/invoke" '{"workspace":{"ref":"feature"},"context":{}}')
 S3=$(cat "$B" | j "['session_id']")
 [ "$CODE" = "200" ] && ok "SUB3 invoke accepted" || no "SUB3 invoke → $CODE: $(cat "$B")"
-FINAL3=$(wait_terminal "$S3" 240) || true
+FINAL3=$(wait_terminal "$S3" 420) || true
 case "$FINAL3" in completed|failed) ok "S3 terminal ($FINAL3) despite dead callback";; *) no "S3 terminal: $FINAL3";; esac
 D3A=""; D3S=""
 for _ in $(seq 1 10); do

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -32,14 +32,22 @@ docker build -q -t "$FLUIDBOX_SANDBOX_IMAGE" \
   -f "$ROOT/images/sandbox-runner/Dockerfile" "$ROOT/images" >/dev/null || exit 1
 echo "building server + cli"
 cargo build -q -p fluidbox-server -p fluidbox-cli || exit 1
-# The gateway only serves live model tiers — skip the pull/boot entirely
-# when they're disabled (CI runs with E2E_SKIP_LIVE=1 and no keys).
+# The gateway only serves live model tiers. In no-live mode it is taken OFF
+# :4000 entirely — two load-bearing consequences:
+#   1. NO-SPEND GUARANTEE: even with real keys in .env nothing can reach a
+#      model — live spend is strictly opt-in.
+#   2. CI PARITY: keyless runners fail fast on connection-refused exactly
+#      like in CI, so the no-model phases exercise the same lifecycle
+#      locally that they will in the e2e CI job. (The capability phase
+#      scopes its own stall stub around its token probes.)
 if [ "${E2E_SKIP_LIVE:-0}" != "1" ]; then
   docker compose -f "$ROOT/deploy/docker-compose.dev.yml" up -d litellm >/dev/null 2>&1 || true
   for _ in $(seq 1 40); do
     curl -fsS -m 2 http://127.0.0.1:4000/health/liveliness >/dev/null 2>&1 && break
     sleep 0.5
   done
+else
+  docker compose -f "$ROOT/deploy/docker-compose.dev.yml" stop litellm >/dev/null 2>&1 || true
 fi
 trap 'stop_server' EXIT
 start_server || exit 1


### PR DESCRIPTION
## What & why

Main's post-merge e2e run (29224265638) and PR #22's run (29222410561) flaked on the same class of problem: **keyless runners fail at nondeterministic speed**, and the suite's assumptions sat on both sides of that variance. Debugged to three concrete mechanisms, each fixed at its root:

1. **No-live mode now stops the gateway instead of starting it** (`e2e.sh`). Two load-bearing wins: nothing can reach a real model even with keys in `.env` (live spend is strictly opt-in — a hard guarantee, not a convention), and local no-live runs now reproduce CI's connection-refused environment exactly, which is how this whole class finally became debuggable locally.

2. **Phase 7's token probes get a scoped accept-and-stall stub** (`e2e-capabilities.sh`). The probes must read session tokens out of living containers, but keyless runners crash and get reaped at variable speed (forensics: `502 upstream` storms → `watchdog: heartbeat stale + sandbox dead`). A stub on :4000 raised *only* around the probe window makes runners block on their model call — containers deterministically alive, killed right after extraction. A suite-wide stall was tried and **rejected with evidence**: phases 3/4 need fail-fast runs and broke 8 assertions under it.

3. **Four 240s terminal-wait windows widened to 420s** (`e2e-git-workspace.sh`, `e2e-trigger.sh`). The SDK's give-up envelope for a dead upstream is ~3–4 minutes; a local run reached `failed` at **4m04s — four seconds past the 240s window** (DB-verified timestamps). CI passed the same assertion by seconds. 420s is the convention the suite's live runs already use.

## How was this tested?

All under exact CI conditions (gateway stopped, `E2E_SKIP_LIVE=1`, keys present but unreachable):

- Full 10-phase suite with the scoped design: phase 7's probe **passed** (`✓ session tokens extracted`), phases 5–10 all green; the only failure was the pre-fix 240s window this PR widens.
- Phases 3 and 4 standalone with the widened windows: **22/22** and **46/46**.
- Suite-wide-stall alternative empirically rejected (8 failures in phases 3/4) — the scoped design is not a guess.
- This PR's own e2e job is the CI-side proof.

## Checklist

- [x] `just check` passes — shell + test-window changes only; scripts `bash -n` clean, no compiled code touched
- [x] Touched the permission/approval/trigger path → ran `just e2e` — full suite + targeted phases as above
- [ ] Behavior change → tests added/updated — N/A (this *is* test infrastructure)
- [ ] User-visible change → CHANGELOG — N/A (dev/CI tooling behavior)
- [ ] Architectural change — N/A
- [x] No secrets in code, tests, fixtures, or logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016T1MaG2PuSXEQsjwP9BtDu