### PR TITLE
docs(web): run-composer pickers — unleak connections, one card vocabulary, working + new

### DIFF
--- a/apps/web/app/capabilities/page.tsx
+++ b/apps/web/app/capabilities/page.tsx
@@ -22,6 +22,7 @@ import {
   CatalogConnectResult,
   CatalogEntry,
   Connection,
+  isToolConnection,
 } from "../lib/api";
 import { GitHubMark, LoadingRows, ModalShell, PageHead } from "../components/bits";
 import { AddServerWizard } from "./AddServerWizard";
@@ -100,11 +101,7 @@ function Capabilities() {
     });
   };
 
-  // Tool-server credentials only — git platform connections live on the
-  // Integrations page.
-  const toolConnections = connections.filter(
-    (c) => c.provider === "mcp_http" && c.status !== "revoked"
-  );
+  const toolConnections = connections.filter((c) => isToolConnection(c) && c.status !== "revoked");
 
   return (
     <>

--- a/apps/web/app/components/BundlePicker.tsx
+++ b/apps/web/app/components/BundlePicker.tsx
@@ -38,6 +38,16 @@ export function BundlePicker({
   const names = [...byName.keys()];
   const pinOf = (name: string) => pins.find((p) => p.name === name);
 
+  // A zero-tool bundle contributes nothing to a run, so attaching one is
+  // always a mistake. They are almost always test residue: fluidbox-db's
+  // tests mint `pmt-bundle-<uuid>` against REAL Neon (see CLAUDE.md), so a
+  // dev database accumulates them. The cure is `just db-clean`; this is a
+  // guard. A pinned bundle stays visible even at zero tools — hiding
+  // something already attached would strand it.
+  const attachable = (name: string) => (byName.get(name)![0].tool_count ?? 0) > 0 || !!pinOf(name);
+  const shownNames = names.filter(attachable);
+  const hiddenCount = names.length - shownNames.length;
+
   const toggle = (name: string) => {
     const cur = pinOf(name);
     if (cur) {
@@ -76,8 +86,8 @@ export function BundlePicker({
           <button className="btn ghost sm" type="button" onClick={onAddServer}>Connect new MCP</button>
         )}
       </div>
-      <div style={{ display: "grid", gap: 6, maxHeight: 340, overflowY: "auto", paddingRight: 2 }}>
-        {names.map((name) => {
+      <div className="opt-list">
+        {shownNames.map((name) => {
           const versions = byName.get(name)!;
           const latest = versions[0];
           const pin = pinOf(name);
@@ -119,6 +129,11 @@ export function BundlePicker({
           );
         })}
       </div>
+      {hiddenCount > 0 && (
+        <p className="helper" style={{ margin: "6px 0 0" }}>
+          {hiddenCount} bundle{hiddenCount === 1 ? "" : "s"} hidden — no tools to attach.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/app/components/ResourceOverview.tsx
+++ b/apps/web/app/components/ResourceOverview.tsx
@@ -9,6 +9,8 @@ import {
   CapabilityBundle,
   Connection,
   GithubAppRegistration,
+  isGitConnection,
+  isToolConnection,
 } from "../lib/api";
 import { LoadingRows } from "./bits";
 
@@ -79,10 +81,10 @@ export function ResourceOverview({
   };
 
   const activeConnections = snapshot.connections.filter(
-    (connection) => connection.status === "active" && connection.provider !== "mcp_http"
+    (connection) => connection.status === "active" && isGitConnection(connection)
   );
   const activeToolConnections = snapshot.connections.filter(
-    (connection) => connection.status === "active" && connection.provider === "mcp_http"
+    (connection) => connection.status === "active" && isToolConnection(connection)
   );
   const activeRegistrations = snapshot.registrations.filter(
     (registration) => registration.status === "active"

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -463,13 +463,27 @@ export function RunComposer({
             )}
 
             {agentChoice === "existing" ? (
-              <label className="field">
+              <div className="field">
                 <span className="lab">Agent</span>
-                <select className="inp" value={selectedAgentName} onChange={(event) => setSelectedAgentName(event.target.value)}>
-                  {agents.map((candidate) => <option key={candidate.id} value={candidate.name}>{candidate.name}</option>)}
-                </select>
+                <div className="opt-grid">
+                  {agents.map((candidate) => (
+                    <button
+                      key={candidate.id}
+                      type="button"
+                      className={`opt ${selectedAgentName === candidate.name ? "on" : ""}`}
+                      onClick={() => setSelectedAgentName(candidate.name)}
+                    >
+                      <span className="t">
+                        {candidate.name}
+                        {selectedAgentName === candidate.name && (
+                          <span className="selected-label">Selected</span>
+                        )}
+                      </span>
+                    </button>
+                  ))}
+                </div>
                 <span className="field-hint">Changes below append a new revision; active runs keep their original frozen revision.</span>
-              </label>
+              </div>
             ) : (
               <div className="agent-creator-grid">
                 <label className="field">

--- a/apps/web/app/components/WorkspacePicker.tsx
+++ b/apps/web/app/components/WorkspacePicker.tsx
@@ -90,6 +90,7 @@ export function WorkspacePicker({
   const [registrations, setRegistrations] = useState<GithubAppRegistration[]>([]);
   const [repos, setRepos] = useState<Repo[]>([]);
   const [repoErr, setRepoErr] = useState("");
+  const [reposLoading, setReposLoading] = useState(false);
   const [repoFilter, setRepoFilter] = useState("");
   const [flowErr, setFlowErr] = useState("");
   const [org, setOrg] = useState("");
@@ -145,10 +146,19 @@ export function WorkspacePicker({
     const refresh = window.setTimeout(() => {
       setRepos([]);
       setRepoErr("");
-      if (draft.mode !== "git" || !draft.connectionId) return;
+      if (draft.mode !== "git" || !draft.connectionId) {
+        setReposLoading(false);
+        return;
+      }
+      // The fetch round-trips to GitHub. Track it explicitly: an empty `repos`
+      // means BOTH "in flight" and "genuinely none", and telling someone their
+      // App sees no repositories while we are still asking would send them off
+      // to install one they already have.
+      setReposLoading(true);
       apiGet<{ repos: Repo[] }>(`/connections/${draft.connectionId}/repos?per_page=100`)
         .then((r) => setRepos(r.repos))
-        .catch((e) => setRepoErr(String(e)));
+        .catch((e) => setRepoErr(String(e)))
+        .finally(() => setReposLoading(false));
     }, 0);
     return () => clearTimeout(refresh);
   }, [draft.mode, draft.connectionId]);
@@ -281,6 +291,8 @@ export function WorkspacePicker({
               <span className="lab">Repository</span>
               {repoErr ? (
                 <div className="err">{repoErr}</div>
+              ) : reposLoading ? (
+                <span className="helper">Loading repositories…</span>
               ) : repos.length === 0 ? (
                 <span className="helper">
                   No repositories visible to this connection

--- a/apps/web/app/components/WorkspacePicker.tsx
+++ b/apps/web/app/components/WorkspacePicker.tsx
@@ -5,7 +5,7 @@
 // clone-URL derivation, and credential handling live in the Rust API.
 
 import { useEffect, useState } from "react";
-import { apiGet, Connection, Repo, WorkspaceSpec } from "../lib/api";
+import { apiGet, Connection, isGitConnection, Repo, WorkspaceSpec } from "../lib/api";
 
 export interface WorkspaceDraft {
   mode: "default" | "scratch" | "local" | "git";
@@ -78,7 +78,11 @@ export function WorkspacePicker({
 
   useEffect(() => {
     apiGet<{ connections: Connection[] }>("/connections")
-      .then((r) => setConnections(r.connections.filter((c) => c.status === "active")))
+      // isGitConnection, not `!== "mcp_http"`: this list feeds a git checkout,
+      // so a provider stays out until it is deliberately classified as git.
+      .then((r) =>
+        setConnections(r.connections.filter((c) => c.status === "active" && isGitConnection(c)))
+      )
       .catch(() => {});
   }, []);
 

--- a/apps/web/app/components/WorkspacePicker.tsx
+++ b/apps/web/app/components/WorkspacePicker.tsx
@@ -4,8 +4,22 @@
 // Presentation only: it emits the `workspace` input JSON; all validation,
 // clone-URL derivation, and credential handling live in the Rust API.
 
-import { useEffect, useState } from "react";
-import { apiGet, Connection, isGitConnection, Repo, WorkspaceSpec } from "../lib/api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  apiGet,
+  apiPost,
+  Connection,
+  GithubAppRegistration,
+  isGitConnection,
+  Repo,
+  WorkspaceSpec,
+} from "../lib/api";
+import {
+  GITHUB_ACTION_LABEL,
+  nextGithubAction,
+  openVia,
+  pickNewConnection,
+} from "../lib/github-flows";
 
 export interface WorkspaceDraft {
   mode: "default" | "scratch" | "local" | "git";
@@ -73,18 +87,59 @@ export function WorkspacePicker({
   defaultOptionLabel?: string;
 }) {
   const [connections, setConnections] = useState<Connection[]>([]);
+  const [registrations, setRegistrations] = useState<GithubAppRegistration[]>([]);
   const [repos, setRepos] = useState<Repo[]>([]);
   const [repoErr, setRepoErr] = useState("");
+  const [repoFilter, setRepoFilter] = useState("");
+  const [flowErr, setFlowErr] = useState("");
+  const [org, setOrg] = useState("");
+  // Ids seen before a GitHub round-trip, so we can spot what it produced.
+  const beforeIds = useRef<string[] | null>(null);
+
+  // The refocus handler must see the CURRENT draft without re-subscribing the
+  // listener on every keystroke.
+  const onChangeRef = useRef(onChange);
+  const draftRef = useRef(draft);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+    draftRef.current = draft;
+  });
+
+  const load = useCallback(async () => {
+    const [c, r] = await Promise.allSettled([
+      apiGet<{ connections: Connection[] }>("/connections"),
+      apiGet<{ registrations: GithubAppRegistration[] }>("/github/app"),
+    ]);
+    if (r.status === "fulfilled") setRegistrations(r.value.registrations);
+    if (c.status !== "fulfilled") return;
+    // isGitConnection, not `!== "mcp_http"`: this list feeds a git checkout,
+    // so a provider stays out until it is deliberately classified as git.
+    const git = c.value.connections.filter((x) => x.status === "active" && isGitConnection(x));
+    setConnections(git);
+
+    // Returning from a GitHub tab: adopt what the dance produced. The modal
+    // kept the task text and agent choice in RunComposer state throughout.
+    const before = beforeIds.current;
+    if (!before) return;
+    beforeIds.current = null;
+    const picked = pickNewConnection(before, git);
+    if (picked && !draftRef.current.connectionId) {
+      onChangeRef.current({ ...draftRef.current, connectionId: picked, repository: "" });
+    }
+  }, []);
 
   useEffect(() => {
-    apiGet<{ connections: Connection[] }>("/connections")
-      // isGitConnection, not `!== "mcp_http"`: this list feeds a git checkout,
-      // so a provider stays out until it is deliberately classified as git.
-      .then((r) =>
-        setConnections(r.connections.filter((c) => c.status === "active" && isGitConnection(c)))
-      )
-      .catch(() => {});
-  }, []);
+    // Deferred, not called inline: setState synchronously inside an effect
+    // cascades renders. Same shape as integrations/page.tsx.
+    const first = window.setTimeout(() => void load(), 0);
+    // The GitHub dances happen in another tab; refocus is our only signal
+    // that they finished.
+    window.addEventListener("focus", load);
+    return () => {
+      clearTimeout(first);
+      window.removeEventListener("focus", load);
+    };
+  }, [load]);
 
   useEffect(() => {
     const refresh = window.setTimeout(() => {
@@ -99,6 +154,28 @@ export function WorkspacePicker({
   }, [draft.mode, draft.connectionId]);
 
   const set = (patch: Partial<WorkspaceDraft>) => onChange({ ...draft, ...patch });
+
+  const action = nextGithubAction(registrations, connections);
+
+  // Open the tab synchronously (popup blockers eat a late window.open), and
+  // remember what we had so the refocus handler can spot what appeared.
+  const runGithubAction = () => {
+    setFlowErr("");
+    beforeIds.current = connections.map((c) => c.id);
+    void openVia(async () => {
+      if (action.kind === "create") {
+        const r = await apiPost<{ go_url: string }>("/github/app/manifest/start", {
+          organization: org.trim() || null,
+        });
+        return r.go_url;
+      }
+      const r = await apiPost<{ go_url: string }>(`/github/app/${action.regId}/install/start`, {});
+      return r.go_url;
+    }).catch((e) => {
+      beforeIds.current = null;
+      setFlowErr(String(e));
+    });
+  };
 
   const modes: { value: WorkspaceDraft["mode"]; label: string }[] = [
     ...(defaultOptionLabel
@@ -146,43 +223,111 @@ export function WorkspacePicker({
 
       {draft.mode === "git" && (
         <>
-          <label className="field">
-            <span className="lab">Connection</span>
-            <select
-              className="inp"
-              value={draft.connectionId}
-              onChange={(e) => set({ connectionId: e.target.value, repository: "" })}
-            >
-              <option value="">public URL (no credential)</option>
+          <div className="field">
+            <div className="bundle-picker-head">
+              <span className="lab">Connection</span>
+              <button className="btn ghost sm" type="button" onClick={runGithubAction}>
+                + {GITHUB_ACTION_LABEL[action.kind]}
+              </button>
+            </div>
+            {action.kind === "create" && (
+              <input
+                className="inp"
+                style={{ marginBottom: 6 }}
+                placeholder="GitHub organization (optional — blank installs on your account)"
+                value={org}
+                onChange={(e) => setOrg(e.target.value)}
+              />
+            )}
+            {flowErr && <div className="err">{flowErr}</div>}
+            <div className="opt-grid">
+              {/* "Public repository" is a MODE, not an identity: it is the
+                  absence of a connection. connectionId === "" still means
+                  exactly that — WorkspaceDraft is unchanged. */}
+              <button
+                type="button"
+                className={`opt ${draft.connectionId === "" ? "on" : ""}`}
+                onClick={() => set({ connectionId: "", repository: "" })}
+              >
+                <span className="t">
+                  Public repository
+                  {draft.connectionId === "" && <span className="selected-label">Selected</span>}
+                </span>
+                <span className="id">no credential</span>
+                <span className="d">Clone by URL. Public repositories only.</span>
+              </button>
               {connections.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.provider} · {c.display_name}
-                </option>
+                <button
+                  key={c.id}
+                  type="button"
+                  className={`opt ${draft.connectionId === c.id ? "on" : ""}`}
+                  onClick={() => set({ connectionId: c.id, repository: "" })}
+                >
+                  <span className="t">
+                    {c.display_name}
+                    {draft.connectionId === c.id && <span className="selected-label">Selected</span>}
+                  </span>
+                  <span className="id">{c.provider}</span>
+                  <span className="d">
+                    {c.metadata?.account_login ? `→ ${c.metadata.account_login}` : " "}
+                  </span>
+                </button>
               ))}
-            </select>
-          </label>
+            </div>
+          </div>
 
           {draft.connectionId ? (
-            <label className="field">
+            <div className="field">
               <span className="lab">Repository</span>
               {repoErr ? (
                 <div className="err">{repoErr}</div>
+              ) : repos.length === 0 ? (
+                <span className="helper">
+                  No repositories visible to this connection
+                  {action.kind === "add_repos"
+                    ? " — use “+ Add repositories” above to install the App somewhere."
+                    : /* A legacy connection (registration_id === null) has no
+                         registration to install into. Never synthesise one. */
+                      " — manage this connection from Integrations."}
+                </span>
               ) : (
-                <select
-                  className="inp"
-                  value={draft.repository}
-                  onChange={(e) => set({ repository: e.target.value })}
-                >
-                  <option value="">— select a repository —</option>
-                  {repos.map((r) => (
-                    <option key={r.id} value={r.full_name}>
-                      {r.full_name}
-                      {r.private ? " (private)" : ""}
-                    </option>
-                  ))}
-                </select>
+                <>
+                  {repos.length > 8 && (
+                    <input
+                      className="inp"
+                      style={{ marginBottom: 6 }}
+                      placeholder="Filter repositories…"
+                      value={repoFilter}
+                      onChange={(e) => setRepoFilter(e.target.value)}
+                    />
+                  )}
+                  <div className="opt-list">
+                    {repos
+                      .filter((r) =>
+                        r.full_name.toLowerCase().includes(repoFilter.trim().toLowerCase())
+                      )
+                      .map((r) => (
+                        <button
+                          key={r.id}
+                          type="button"
+                          className={`opt ${draft.repository === r.full_name ? "on" : ""}`}
+                          onClick={() => set({ repository: r.full_name })}
+                        >
+                          <span className="t">
+                            {r.full_name}
+                            {draft.repository === r.full_name && (
+                              <span className="selected-label">Selected</span>
+                            )}
+                          </span>
+                          <span className="id">
+                            {r.private ? "private" : "public"} · {r.default_branch}
+                          </span>
+                        </button>
+                      ))}
+                  </div>
+                </>
               )}
-            </label>
+            </div>
           ) : (
             <label className="field">
               <span className="lab">Clone URL</span>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2534,6 +2534,17 @@ fieldset.seg:disabled label {
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 8px;
 }
+/* Single-column scrolling container for .opt / .cap-row lists too long for
+   .opt-grid's auto-fit columns (repositories: up to 100). Promoted from
+   BundlePicker's inline style so the repo list and the bundle list share one
+   container. */
+.opt-list {
+  display: grid;
+  gap: 6px;
+  max-height: 340px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
 .opt {
   text-align: left;
   background: var(--bg);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2584,13 +2584,19 @@ fieldset.seg:disabled label {
   height: 13px;
   color: var(--accent);
 }
+/* display:block is load-bearing: these are spans, and vertical margins do not
+   apply to inline elements — the margin-top below was silently dropped, so
+   .id and .d ran together on one line (visible in the Model picker long
+   before the connection picker adopted this card). */
 .opt .id {
+  display: block;
   font-family: var(--font-mono);
   font-size: 10.5px;
   color: var(--ink-3);
   margin-top: 2px;
 }
 .opt .d {
+  display: block;
   font-size: 11.5px;
   margin-top: 4px;
   color: var(--ink-2);

--- a/apps/web/app/integrations/page.tsx
+++ b/apps/web/app/integrations/page.tsx
@@ -15,6 +15,7 @@ import {
   ingressPath,
   isGitConnection,
 } from "../lib/api";
+import { openVia } from "../lib/github-flows";
 import { GitHubMark, ModalShell, PageHead } from "../components/bits";
 
 export default function Integrations() {
@@ -56,38 +57,27 @@ export default function Integrations() {
     }
   };
 
-  // Browsers void the click gesture across an await (popup blockers eat a
-  // late window.open) — open the tab synchronously, then point it at the
-  // URL the API returns.
-  const openVia = (getUrl: () => Promise<string>) => {
-    const tab = window.open("", "_blank");
-    act(async () => {
-      try {
-        const url = await getUrl();
-        if (tab) tab.location.href = url;
-        else window.location.href = url;
-      } catch (e) {
-        tab?.close();
-        throw e;
-      }
-    });
-  };
-
-  // The manifest dance: the server mints a one-time flow; the browser tab
-  // we open is what gets bound to it (cookie), then continues to GitHub.
+  // The manifest dance: the server mints a one-time flow; the browser tab we
+  // open is what gets bound to it (cookie), then continues to GitHub.
+  // act() invokes its fn synchronously, so openVia's window.open stays inside
+  // the click gesture — a late window.open gets eaten by popup blockers.
   const setupApp = () =>
-    openVia(async () => {
-      const r = await apiPost<{ go_url: string }>("/github/app/manifest/start", {
-        organization: org.trim() || null,
-      });
-      return r.go_url;
-    });
+    act(() =>
+      openVia(async () => {
+        const r = await apiPost<{ go_url: string }>("/github/app/manifest/start", {
+          organization: org.trim() || null,
+        });
+        return r.go_url;
+      })
+    );
 
   const connectGithub = (regId: string) =>
-    openVia(async () => {
-      const r = await apiPost<{ go_url: string }>(`/github/app/${regId}/install/start`, {});
-      return r.go_url;
-    });
+    act(() =>
+      openVia(async () => {
+        const r = await apiPost<{ go_url: string }>(`/github/app/${regId}/install/start`, {});
+        return r.go_url;
+      })
+    );
 
   const syncReg = (regId: string) =>
     act(async () => {

--- a/apps/web/app/integrations/page.tsx
+++ b/apps/web/app/integrations/page.tsx
@@ -13,6 +13,7 @@ import {
   Connection,
   GithubAppRegistration,
   ingressPath,
+  isGitConnection,
 } from "../lib/api";
 import { GitHubMark, ModalShell, PageHead } from "../components/bits";
 
@@ -106,11 +107,7 @@ export default function Integrations() {
   // Revoked rows are history, not workspace (the DB keeps them).
   const visibleRegs = registrations.filter((r) => r.status !== "revoked");
   const activeRegs = visibleRegs.filter((r) => r.status === "active");
-  // Git platform connections only — mcp_http tool credentials live on the
-  // Capabilities page.
-  const gitConnections = connections.filter(
-    (c) => c.provider !== "mcp_http" && c.status !== "revoked"
-  );
+  const gitConnections = connections.filter((c) => isGitConnection(c) && c.status !== "revoked");
 
   return (
     <>

--- a/apps/web/app/lib/api.test.ts
+++ b/apps/web/app/lib/api.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { Connection, isGitConnection, isToolConnection } from "./api";
+
+// Only `provider` is read by the predicates; the rest of Connection is noise.
+const conn = (provider: string): Connection => ({ provider }) as Connection;
+
+describe("connection provider classification", () => {
+  it("routes both github providers to the git surface", () => {
+    expect(isGitConnection(conn("github"))).toBe(true);
+    expect(isGitConnection(conn("github_app"))).toBe(true);
+    expect(isToolConnection(conn("github"))).toBe(false);
+    expect(isToolConnection(conn("github_app"))).toBe(false);
+  });
+
+  it("routes mcp_http to the tool surface, never the git one", () => {
+    expect(isToolConnection(conn("mcp_http"))).toBe(true);
+    // The reported bug: `mcp_http · Cloudflare` was offered as a source for a
+    // git checkout. The broker calls that server; it has no repositories.
+    expect(isGitConnection(conn("mcp_http"))).toBe(false);
+  });
+
+  it("keeps an unclassified provider out of BOTH surfaces", () => {
+    // Phase 7 lands `slack` on the server before this client knows the word.
+    // The old `provider !== "mcp_http"` form would have admitted it straight
+    // into the repo picker. An allowlist fails safe instead.
+    expect(isGitConnection(conn("slack"))).toBe(false);
+    expect(isToolConnection(conn("slack"))).toBe(false);
+  });
+});

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -149,7 +149,9 @@ export function workspaceLabel(ws: WorkspaceSpec | null | undefined): string {
 
 export interface Connection {
   id: string;
-  provider: string; // github (PAT) | github_app | mcp_http
+  /** Wire value, server-controlled. See ConnectionProvider for the ones this
+   *  client has classified; unknown values fail safe (neither git nor tool). */
+  provider: string;
   external_account_id: string;
   display_name: string;
   granted_scopes: string[];
@@ -180,6 +182,42 @@ export interface Connection {
   } | null;
   created_at: string;
 }
+
+/** Every connection provider this dashboard has classified. The server is the
+ *  source of truth for what exists; this union states what we have decided
+ *  about. Adding a member without adding it to PROVIDER_CLASS is a build
+ *  failure — that is the point. */
+export type ConnectionProvider = "github" | "github_app" | "mcp_http";
+
+/** Which surface a provider belongs to.
+ *
+ *    git  — can back a workspace checkout (repositories, refs, commits).
+ *    tool — a credential the BROKER calls during a run. It has no repositories.
+ *
+ *  This Record is the only place the rule lives. It replaces four hand-rolled
+ *  predicates that each re-derived it from a prose comment; WorkspacePicker
+ *  forgot, which is how mcp_http reached the git picker.
+ *
+ *  It is an allowlist BY CONSTRUCTION: Record<ConnectionProvider, …> requires
+ *  every union member as a key, so adding `slack` (Phase 7) fails the build
+ *  until someone classifies it. The old `provider !== "mcp_http"` form would
+ *  have silently admitted slack to the repo picker instead. */
+const PROVIDER_CLASS: Record<ConnectionProvider, "git" | "tool"> = {
+  github: "git",
+  github_app: "git",
+  mcp_http: "tool",
+};
+
+/** Can this connection back a git workspace checkout?
+ *
+ *  A provider the server knows but this client does not is neither git nor
+ *  tool: it stays out of every picker rather than defaulting into one. */
+export const isGitConnection = (c: Connection): boolean =>
+  PROVIDER_CLASS[c.provider as ConnectionProvider] === "git";
+
+/** Is this a brokered tool-server credential? The mirror of isGitConnection. */
+export const isToolConnection = (c: Connection): boolean =>
+  PROVIDER_CLASS[c.provider as ConnectionProvider] === "tool";
 
 /** One connector-catalog entry (untrusted reference data; tool_hints are
  *  policy-default seeds — the permission gate stays the judge). */

--- a/apps/web/app/lib/github-flows.test.ts
+++ b/apps/web/app/lib/github-flows.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { Connection, GithubAppRegistration } from "./api";
+import { nextGithubAction, pickNewConnection } from "./github-flows";
+
+const reg = (id: string, status: string): GithubAppRegistration =>
+  ({ id, status }) as GithubAppRegistration;
+
+const conn = (
+  id: string,
+  provider: string,
+  status: string,
+  registration_id: string | null = null
+): Connection => ({ id, provider, status, registration_id }) as Connection;
+
+describe("nextGithubAction", () => {
+  it("offers to create an App when no registration is active", () => {
+    expect(nextGithubAction([], [])).toEqual({ kind: "create" });
+    // A pending registration is not usable custody yet.
+    expect(nextGithubAction([reg("r1", "pending")], [])).toEqual({ kind: "create" });
+    expect(nextGithubAction([reg("r1", "revoked")], [])).toEqual({ kind: "create" });
+  });
+
+  it("offers to install when the App exists but is not installed", () => {
+    expect(nextGithubAction([reg("r1", "active")], [])).toEqual({ kind: "install", regId: "r1" });
+  });
+
+  it("offers more repositories once an installation is live", () => {
+    const conns = [conn("c1", "github_app", "active", "r1")];
+    expect(nextGithubAction([reg("r1", "active")], conns)).toEqual({
+      kind: "add_repos",
+      regId: "r1",
+    });
+  });
+
+  it("ignores a revoked connection when deciding install vs add_repos", () => {
+    const conns = [conn("c1", "github_app", "revoked", "r1")];
+    expect(nextGithubAction([reg("r1", "active")], conns)).toEqual({ kind: "install", regId: "r1" });
+  });
+
+  it("never attributes a LEGACY connection to a registration", () => {
+    // registration_id === null means custody lives on the connection itself.
+    // There is no registration to install into; never synthesise one.
+    const legacy = [conn("c1", "github_app", "active", null)];
+    expect(nextGithubAction([reg("r1", "active")], legacy)).toEqual({
+      kind: "install",
+      regId: "r1",
+    });
+  });
+});
+
+describe("pickNewConnection", () => {
+  it("selects the single git connection that appeared", () => {
+    const after = [conn("c1", "github_app", "active"), conn("c2", "github_app", "active")];
+    expect(pickNewConnection(["c1"], after)).toBe("c2");
+  });
+
+  it("selects nothing when several appeared", () => {
+    // Guessing would silently bind the wrong repo host to a run whose task
+    // text is already typed. Make the user choose.
+    const after = [conn("c1", "github_app", "active"), conn("c2", "github_app", "active")];
+    expect(pickNewConnection([], after)).toBeNull();
+  });
+
+  it("selects nothing when nothing appeared", () => {
+    expect(pickNewConnection(["c1"], [conn("c1", "github_app", "active")])).toBeNull();
+  });
+
+  it("ignores a new NON-git connection", () => {
+    // Connecting an MCP server mid-flow must not hijack the repo picker.
+    const after = [conn("c1", "github_app", "active"), conn("c2", "mcp_http", "active")];
+    expect(pickNewConnection(["c1"], after)).toBeNull();
+  });
+
+  it("ignores a new git connection that is not yet active", () => {
+    const after = [conn("c1", "github_app", "active"), conn("c2", "github_app", "pending")];
+    expect(pickNewConnection(["c1"], after)).toBeNull();
+  });
+});

--- a/apps/web/app/lib/github-flows.ts
+++ b/apps/web/app/lib/github-flows.ts
@@ -1,0 +1,70 @@
+// The GitHub App acquisition dances, as data. Pure functions live here rather
+// than inside WorkspacePicker so they are testable without component-test
+// infrastructure — the dashboard has none.
+
+import { Connection, GithubAppRegistration, isGitConnection } from "./api";
+
+export type GithubAction =
+  | { kind: "create" }
+  | { kind: "install"; regId: string }
+  | { kind: "add_repos"; regId: string };
+
+/** What the git picker's "+ new" means right now.
+ *
+ *  Three states wearing one button:
+ *    no active registration       → create an App (the manifest dance)
+ *    registration, no install     → install it
+ *    registration + installation  → install on more repositories
+ *
+ *  Legacy connections (registration_id === null) custody their own credential
+ *  and have NO registration to install into, so they never satisfy the
+ *  add_repos branch. Never synthesise a registration id: custody resolution
+ *  fails closed by design. */
+export function nextGithubAction(
+  registrations: GithubAppRegistration[],
+  connections: Connection[]
+): GithubAction {
+  const active = registrations.find((r) => r.status === "active");
+  if (!active) return { kind: "create" };
+  const installed = connections.some(
+    (c) => c.registration_id === active.id && c.status === "active"
+  );
+  return installed ? { kind: "add_repos", regId: active.id } : { kind: "install", regId: active.id };
+}
+
+export const GITHUB_ACTION_LABEL: Record<GithubAction["kind"], string> = {
+  create: "New GitHub App",
+  install: "Install GitHub App",
+  add_repos: "Add repositories",
+};
+
+/** After a GitHub round-trip: which connection should we auto-select?
+ *
+ *  Exactly one new active git connection → select it. Several → select none
+ *  and let the user choose: guessing would silently bind the wrong repo host
+ *  to a run whose task text is already typed. */
+export function pickNewConnection(before: string[], after: Connection[]): string | null {
+  const seen = new Set(before);
+  const fresh = after.filter((c) => isGitConnection(c) && c.status === "active" && !seen.has(c.id));
+  return fresh.length === 1 ? fresh[0].id : null;
+}
+
+/** Open a tab for a URL the API has not returned yet.
+ *
+ *  The tab MUST open synchronously inside the click handler: awaiting first
+ *  voids the user gesture and popup blockers eat the late window.open. Lifted
+ *  from integrations/page.tsx so both callers share one implementation.
+ *  Rejects on failure — callers wrap this in their own error handling. */
+export function openVia(getUrl: () => Promise<string>): Promise<void> {
+  const tab = window.open("", "_blank");
+  return getUrl().then(
+    (url) => {
+      if (tab) tab.location.href = url;
+      else window.location.href = url;
+    },
+    (e) => {
+      tab?.close();
+      throw e;
+    }
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "lucide-react": "^1.24.0",
@@ -22,6 +23,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
     "tailwindcss": "^4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.43)(vite@8.1.4(@types/node@20.19.43)(jiti@2.7.0))
 
 packages:
 
@@ -122,14 +125,23 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -438,8 +450,112 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -538,6 +654,12 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -738,6 +860,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -793,6 +944,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -859,6 +1014,10 @@ packages:
 
   caniuse-lite@1.0.30001803:
     resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -971,6 +1130,9 @@ packages:
   es-iterator-helpers@1.3.3:
     resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1112,9 +1274,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1163,6 +1332,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1641,6 +1815,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1671,6 +1849,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1745,6 +1926,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1812,12 +1998,21 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1882,9 +2077,20 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1953,6 +2159,90 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1972,6 +2262,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2104,7 +2399,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2115,6 +2421,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2304,6 +2615,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.2.10': {}
 
   '@next/eslint-plugin-next@16.2.10':
@@ -2348,7 +2666,62 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2427,6 +2800,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -2607,6 +2987,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@20.19.43)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@20.19.43)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -2695,6 +3116,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -2754,6 +3177,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001803: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2929,6 +3354,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3161,7 +3588,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3208,6 +3641,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3669,6 +4105,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.3: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3701,6 +4139,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3777,6 +4217,27 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   run-parallel@1.2.0:
     dependencies:
@@ -3895,9 +4356,15 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -3976,10 +4443,16 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4094,6 +4567,45 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite@8.1.4(@types/node@20.19.43)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.43
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.10(@types/node@20.19.43)(vite@8.1.4(@types/node@20.19.43)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@20.19.43)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@20.19.43)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.43
+    transitivePeerDependencies:
+      - msw
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4138,6 +4650,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Pure-logic tests only. The dashboard has no component-test infrastructure
+// (no @testing-library), which is why picker logic lives in lib/ as pure
+// functions rather than inline in components.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["app/**/*.test.ts"],
+  },
+});

--- a/docs/plans/2026-07-15-run-composer-pickers-design.md
+++ b/docs/plans/2026-07-15-run-composer-pickers-design.md
@@ -1,6 +1,7 @@
 # Run-composer pickers: unleak the connection lists, one row vocabulary, `+ new` in place
 
-Status: design approved 2026-07-15. Not yet planned or built.
+Status: SHIPPED 2026-07-15 (branch claude/run-composer-pickers, PR #42).
+Verified end-to-end in a live browser; see the implementation plan's Task 10 Step 4.
 Scope: `apps/web` only. No Rust changes, no migrations, no API changes.
 
 ## 1. The problem
@@ -48,17 +49,43 @@ already on the roadmap.
 `lib/api.ts` already hosts connection predicates (`needsManualIngress`, `:289`).
 Add the provider rule there and delete the hand-rolled copies:
 
-```ts
-/** Providers that can back a git workspace checkout. mcp_http is a tool
- *  credential the broker calls — it has no repos, and neither will slack
- *  (Phase 7). Allowlist, not an mcp_http denylist: a new provider stays out
- *  of git pickers until someone deliberately adds it here. */
-export const isGitConnection = (c: Connection) =>
-  c.provider === "github" || c.provider === "github_app";
+**As shipped**, this went further than a pair of predicates. Keying a `Record`
+by the provider union makes the rule *unforgettable* rather than merely
+centralised:
 
-/** Tool-server credentials — brokered MCP. The mirror of isGitConnection. */
-export const isToolConnection = (c: Connection) => c.provider === "mcp_http";
+```ts
+export type ConnectionProvider = "github" | "github_app" | "mcp_http";
+
+/** Allowlist BY CONSTRUCTION: Record<ConnectionProvider, …> requires every
+ *  union member as a key, so adding `slack` (Phase 7) fails the BUILD until
+ *  someone classifies it git-or-tool. */
+const PROVIDER_CLASS: Record<ConnectionProvider, "git" | "tool"> = {
+  github: "git",
+  github_app: "git",
+  mcp_http: "tool",
+};
+
+/** Unknown wire values (server ahead of this client) are neither: they stay
+ *  out of every picker rather than defaulting into one. */
+export const isGitConnection = (c: Connection): boolean =>
+  PROVIDER_CLASS[c.provider as ConnectionProvider] === "git";
+export const isToolConnection = (c: Connection): boolean =>
+  PROVIDER_CLASS[c.provider as ConnectionProvider] === "tool";
 ```
+
+**Verified, not assumed.** Adding `"slack"` to the union and running `tsc`:
+
+```
+error TS2741: Property 'slack' is missing in type
+'{ github: "git"; github_app: "git"; mcp_http: "tool"; }'
+but required in type 'Record<ConnectionProvider, "git" | "tool">'.
+```
+
+This is strictly stronger than the unit test the spec originally called for: a
+test asserting `isGitConnection(slack) === false` can be skipped, deleted, or
+simply never written for the *next* provider. A compile error cannot. Both
+exist — the test documents intent, the Record enforces it — and `pnpm build`
+already runs inside `just check`.
 
 Call sites converted: `WorkspacePicker.tsx:81` (the fix), plus
 `integrations/page.tsx:111` and `capabilities/page.tsx:105` (removing the

--- a/docs/plans/2026-07-15-run-composer-pickers-design.md
+++ b/docs/plans/2026-07-15-run-composer-pickers-design.md
@@ -1,0 +1,238 @@
+# Run-composer pickers: unleak the connection lists, one row vocabulary, `+ new` in place
+
+Status: design approved 2026-07-15. Not yet planned or built.
+Scope: `apps/web` only. No Rust changes, no migrations, no API changes.
+
+## 1. The problem
+
+The Configure Run modal's **Workspace & tools** step offers `mcp_http · Cloudflare`
+as a source for a git checkout. Cloudflare is a *tool* credential the broker calls
+on the control plane's behalf; it has no repositories. Picking it is nonsense.
+
+Two things are wrong, and only one of them is the one you see:
+
+1. **The leak.** `WorkspacePicker` lists every active connection regardless of
+   provider.
+2. **The vocabulary split.** The same step renders raw native `<select>`
+   (Connection, Repository) immediately beside designed `.cap-row` cards
+   (capability bundles). The native macOS dropdown is what renders the
+   checkmark list in the bug report — it is not our design system at all.
+
+## 2. Root cause
+
+fluidbox keeps one `connections` table across three providers (`github` PAT,
+`github_app`, `mcp_http`). The integrations/capabilities split is real and
+intentional — but it is enforced by **hand-rolled predicates copy-pasted at
+each call site**, described in prose comments rather than expressed in code:
+
+| Site | Predicate | Correct? |
+|---|---|---|
+| `capabilities/page.tsx:105` | `provider === "mcp_http"` | yes |
+| `integrations/page.tsx:111` | `provider !== "mcp_http"` | yes, by luck |
+| `ResourceOverview.tsx:81,84` | both directions | yes |
+| `RunComposer.tsx:176` | `provider === "github_app"` | yes |
+| `WorkspacePicker.tsx:81` | `status` only — **no provider filter** | **no** |
+
+Four sites duplicate the rule; one forgot. That is not bad luck, it is the
+design guaranteeing a leak.
+
+**The exclusion form is a scheduled recurrence.** `provider !== "mcp_http"`
+admits anything that is not MCP. Phase 7 is Slack. A `slack` connection would
+sail through that predicate and land in the git-repo picker — the same bug,
+already on the roadmap.
+
+## 3. Design
+
+### 3.1 One predicate, allowlist form (the load-bearing change)
+
+`lib/api.ts` already hosts connection predicates (`needsManualIngress`, `:289`).
+Add the provider rule there and delete the hand-rolled copies:
+
+```ts
+/** Providers that can back a git workspace checkout. mcp_http is a tool
+ *  credential the broker calls — it has no repos, and neither will slack
+ *  (Phase 7). Allowlist, not an mcp_http denylist: a new provider stays out
+ *  of git pickers until someone deliberately adds it here. */
+export const isGitConnection = (c: Connection) =>
+  c.provider === "github" || c.provider === "github_app";
+
+/** Tool-server credentials — brokered MCP. The mirror of isGitConnection. */
+export const isToolConnection = (c: Connection) => c.provider === "mcp_http";
+```
+
+Call sites converted: `WorkspacePicker.tsx:81` (the fix), plus
+`integrations/page.tsx:111` and `capabilities/page.tsx:105` (removing the
+latent Slack bug). `ResourceOverview.tsx` and `RunComposer.tsx:176` adopt them
+where they express the same intent — `RunComposer:176` stays `github_app`-only
+(event triggers need App identity to publish checks; that is narrower than
+"git", and deliberately so).
+
+This is the only change that prevents recurrence. Everything below is the
+design-system pass.
+
+### 3.2 The vocabulary is already there: selection semantics pick the card,
+### cardinality picks the container
+
+`.opt` (`globals.css:2593`) and `.cap-row` (`:2589`) are not two design
+languages. They are one — identical `border-strong`, `radius: 8px`, and
+`.on → accent-dim + accent-tint`. They differ by **selection semantics**:
+
+- `.cap-row` — **multi**-select (checkbox), compact: name + meta.
+- `.opt` — **single**-select (button), rich: `.t` title / `.id` / `.d`
+  description, plus an `.off` disabled state.
+
+Connection, Repository, and Agent are all *single*-select, so they take `.opt` —
+the same card the model picker already uses (`RunComposer:513`) two sections
+above them in this very modal. Bundles are multi-select and correctly keep
+`.cap-row`.
+
+The **container** then follows cardinality:
+
+| List | Size | Select | Card | Container |
+|---|---|---|---|---|
+| Connection | 0–5 | single | `.opt` | `.opt-grid` |
+| Agent | 0–20 | single | `.opt` | `.opt-grid` |
+| Repository | 0–100 (`per_page=100`) | single | `.opt` | `.opt-list` + filter |
+| Bundles | 0–50 | multi | `.cap-row` | `.opt-list` |
+
+`.opt-grid` is `repeat(auto-fit, minmax(150px, 1fr))` — right for 4 models, a
+wall for 100 repos. `.opt-list` is the scrolling single-column container that
+**already exists** at `BundlePicker.tsx:79`, inlined as an anonymous style prop:
+
+```jsx
+<div style={{ display: "grid", gap: 6, maxHeight: 340, overflowY: "auto", paddingRight: 2 }}>
+```
+
+Promote it to a named class in `globals.css` and both the repo list and the
+bundle list use it. This is the design's only new CSS, and it is a cleanup of
+an existing inline style rather than new surface area.
+
+A popover combobox was rejected: `ModalShell` already installs a focus trap
+(`bits.tsx:89`), and nesting a second one inside it risks real keyboard-nav
+bugs for a cosmetic gain.
+
+### 3.3 "Public repository" stops masquerading as a connection
+
+Today the Connection `<select>` carries `value=""` labelled *"public URL (no
+credential)"* — a **mode** rendered as if it were an identity. That is the same
+category error as the `mcp_http` leak, just quieter. As an explicit `.opt` card
+it states what it is:
+
+```
+Connection                                        + New GitHub App
+┌───────────────────────────────┐ ┌───────────────────────────────┐
+│ Public repository             │ │ fluidbox-test-1      Selected │  ← .opt.on
+│ (no credential)               │ │ github_app                    │
+│ Clone by URL. Public repos    │ │ → hrishikeshdkakkad           │
+│ only.                         │ │                               │
+└───────────────────────────────┘ └───────────────────────────────┘
+   .opt .t / .d                      .opt .t / .id / .d
+
+   (mcp_http · Cloudflare — gone: isGitConnection)
+
+Repository                                      + Add repositories
+┌──────────────────────────────────────────────────────────────┐
+│ 🔍 filter…                                                   │
+├──────────────────────────────────────────────────────────────┤
+│ hrishikeshdkakkad/fluidbox                  private · main   │  ← .opt.on
+│ hrishikeshdkakkad/infra                     private · main   │
+└──────────────────────────────────────────────────────────────┘
+   .opt-list (scrolls)
+```
+
+Selecting *Public repository* reveals the Clone URL input, exactly as
+`connectionId === ""` does today. The `WorkspaceDraft` shape is unchanged —
+`connectionId: ""` still means public. This is presentation only.
+
+### 3.4 `+ new` is a state machine, not a button
+
+"Repo should have a github app, or create and install new" is three states, not
+one action. The picker reads `/github/app` (registrations) alongside
+`/connections`:
+
+| Registration state | Label | Action |
+|---|---|---|
+| No active registration | `+ New GitHub App` | manifest dance → `POST /github/app/manifest/start` |
+| Active registration, no connection | `+ Install GitHub App` | `POST /github/app/{regId}/install/start` |
+| Registration + connections | `+ Add repositories` | `POST /github/app/{regId}/install/start` |
+
+The manifest panel carries the same optional **organization** field the
+integrations page has (`:79`). It cannot be dropped: private apps install only
+on the account that owns them, so a silent personal-only default would strand
+every org user.
+
+**Legacy connections fail closed.** `registration_id === null` means custody
+lives on the connection, not a registration — there is no registration to
+install into. Those rows show no `+ Add repositories` affordance; the empty
+repo state links to `/integrations` instead. Never synthesise a registration id.
+
+### 3.5 Surviving the GitHub round-trip
+
+The manifest and install dances round-trip through github.com in a new tab. The
+modal holds its draft and reconciles on return — the pattern
+`integrations/page.tsx:40` already uses:
+
+1. Open the tab **synchronously** on click, then point it at the URL the API
+   returns. Awaiting first voids the click gesture and popup blockers eat the
+   tab — `integrations/page.tsx:61-73` documents this; reuse that `openVia`
+   helper rather than re-deriving it.
+2. `window.addEventListener("focus", …)` re-fetches `/connections` + `/github/app`.
+3. Diff against the previously-seen connection ids. If exactly one new git
+   connection appeared, select it. If several did, select none and let the user
+   choose — guessing would silently bind the wrong repo host to the run.
+4. Task text, agent choice, and pins are React state in `RunComposer` and are
+   never unmounted, so they survive with no extra machinery.
+
+`openVia` moves from `integrations/page.tsx` into a shared module so both
+callers use one implementation.
+
+### 3.6 Un-attachable bundles
+
+`pmt-bundle-*` rows with `0 tools` are **test residue, not a UI bug**:
+`fluidbox-db/src/lib.rs:4414` mints `pmt-bundle-{uuid}`, and per CLAUDE.md the
+`fluidbox-db` tests run against **real Neon**. The dev database accumulates them.
+The cleanup is `just db-clean`.
+
+Independently, `BundlePicker` hides `tool_count === 0` bundles behind a
+`Show N empty bundles` disclosure. A zero-tool bundle contributes nothing to a
+run; attaching one is always a mistake. This is a guard, not the fix — the fix
+is not polluting the database.
+
+## 4. Non-goals
+
+- Page-level lists (`/agents`, `/capabilities`, `/integrations`, `/automations`,
+  `/governance`). They already carry New/Add actions and are out of scope.
+- Any Rust, API, migration, or `RunSpec` change. The frozen-spec, custody, and
+  gate invariants are untouched — this is presentation only, per the
+  dashboard-is-presentation-only constraint.
+- Changing `WorkspaceDraft` / `draftToInput`. The emitted workspace JSON is
+  byte-for-byte what it is today.
+- Repo search server-side. Filtering is client-side over the ≤100 already fetched.
+
+## 5. Testing
+
+- `just check` — fmt, clippy, test, web build.
+- **Unit**: `isGitConnection` / `isToolConnection` over all four providers,
+  including a `slack` row that must be excluded from both git and tool lists.
+  This is the regression test for the Phase 7 recurrence.
+- **Manual** (the reported bug): open Configure Run → Workspace & tools → Git
+  repository. `mcp_http · Cloudflare` must not appear. `+ New GitHub App` must
+  open a tab; returning must refresh and preserve the task text.
+- Legacy `github_app` connection (`registration_id === null`) shows no
+  `+ Add repositories`.
+- No e2e change. `scripts/governance-e2e.sh` covers the permission gate, which
+  this does not touch.
+
+## 6. Files
+
+| File | Change |
+|---|---|
+| `apps/web/app/lib/api.ts` | add `isGitConnection`, `isToolConnection` |
+| `apps/web/app/lib/github-flows.ts` | **new** — `openVia` + manifest/install starters |
+| `apps/web/app/globals.css` | name `.opt-list` (promoted from `BundlePicker:79`'s inline style) |
+| `apps/web/app/components/WorkspacePicker.tsx` | provider fix; connection/repo → `.opt`; `+ new` state machine |
+| `apps/web/app/components/BundlePicker.tsx` | zero-tool disclosure; inline style → `.opt-list` |
+| `apps/web/app/components/RunComposer.tsx` | agent `<select>` → `.opt` (matches its own model picker) |
+| `apps/web/app/integrations/page.tsx` | adopt predicate + shared `openVia` |
+| `apps/web/app/capabilities/page.tsx` | adopt predicate |
+| `apps/web/app/components/ResourceOverview.tsx` | adopt predicate |

--- a/docs/plans/2026-07-15-run-composer-pickers-implementation.md
+++ b/docs/plans/2026-07-15-run-composer-pickers-implementation.md
@@ -1201,27 +1201,98 @@ git commit -m "feat(web): agent picker as .opt cards, matching its own model pic
 **Files:**
 - Modify: `docs/plans/2026-07-15-run-composer-pickers-design.md` (status line)
 
-- [ ] **Step 1: Clear the test residue**
+- [ ] **Step 1: ~~Clear the test residue~~ — DO NOT RUN `just db-clean`**
 
-Run: `just db-clean`
-Expected: the `pmt-bundle-…` rows are gone from the dev database (they are `fluidbox-db` test residue against real Neon, not a UI defect — Task 6's guard is a safety net, not the cure).
+**Corrected during execution.** `just db-clean` is not a surgical residue
+cleanup — its dry-run shows it deletes **all 13 capability_bundles** (including
+the live `cloudflare` bundle), **55 sessions**, **7 subscriptions**, 6
+trigger_deliveries, and every agent except `claude-fixer`/`repo-reporter`. It is
+a full dev-data reset.
 
-- [ ] **Step 2: Run the full bar**
+Task 6's guard already hides zero-tool bundles at the picker, which is the
+user-visible fix. Leave the `pmt-bundle-*` rows in place: they are harmless, and
+their presence is what lets Step 4 below *verify* the guard actually works.
+
+If someone later wants them physically gone, target them precisely rather than
+resetting the database:
+
+```sql
+DELETE FROM capability_bundles WHERE name LIKE 'pmt-bundle-%';
+```
+
+- [x] **Step 2: Run the full bar**
 
 Run: `just check`
-Expected: PASS — fmt, clippy, cargo test, `pnpm test` (13 passed), `pnpm build`.
 
-- [ ] **Step 3: Run the acceptance suite**
+Result (2026-07-15): `fmt` ✓, `clippy -D warnings` ✓, `pnpm test` ✓ (13 passed),
+`pnpm build` ✓. **`cargo test -p fluidbox-db` is FLAKY in this environment and
+fails ~1 test per run — a different one each time**, always
+`PoolTimedOut` / "pool timed out while waiting for an open connection":
 
-Run: `just e2e` (stop `just dev` first — it owns the stack)
-Expected: PASS. Nothing here touches the permission gate, so a failure means something outside this plan's scope broke.
+| run | failed |
+|---|---|
+| 1 | intent_registry_digest_binding, invocation_claims_idempotent, policy_agents_using_counts, upsert_preserves_managed_overrides |
+| 2 | + revision_default_workspace_roundtrips, session_token_revoke_is_terminal (5 total) |
+| 3 (server stopped) | session_token_revoke_is_terminal (1) |
+| 4 (`--test-threads=1`) | 4 failed, 140s — serializing made it **worse** |
+| 5 | revision_default_workspace_roundtrips (1) |
 
-- [ ] **Step 4: Confirm no denylist crept back in**
+**Not caused by this work.** `git diff origin/main -- crates/ images/ scripts/`
+is empty: zero Rust changed, so `cargo test -p fluidbox-db` reads byte-identical
+sources to `origin/main`. Neon itself is healthy — a raw `select 1` returns in
+0.9s and `pg_stat_activity` shows 12 of 112 connections used. Stopping `just dev`
+helps a lot (it holds pool connections — matches the "no running server" note),
+but does not fully fix it. Each test builds its own pool; the evidence points at
+pools not being released promptly rather than a Neon-side limit.
+
+Pre-existing repo issue, out of scope here. Worth its own issue.
+
+- [x] **Step 3: ~~Run the acceptance suite~~ — deliberately skipped**
+
+`just e2e` drives the control plane over real HTTP and includes a **live agent
+demo that spends real Anthropic credit**. This change is TypeScript in
+`apps/web` only — the e2e never renders the dashboard, and zero Rust changed, so
+it cannot produce signal about this diff. Skipped rather than burn credit for
+no information.
+
+The feature was instead verified where it actually lives: **driven end-to-end in
+a real browser** (Step 4 below).
+
+- [x] **Step 4: Browser verification (Chrome, live stack) — ALL PASSED**
+
+| # | Check | Result |
+|---|---|---|
+| 1 | `mcp_http · Cloudflare` absent from Connection | ✓ gone; still listed under Capability bundles where it belongs |
+| 2 | Connection renders `.opt` cards, not a native select | ✓ |
+| 3 | "Public repository" is an explicit card | ✓ `no credential` / "Clone by URL. Public repositories only." |
+| 4 | `+ new` label matches registration state | ✓ `+ Add repositories` (active reg + live install) |
+| 5 | Tab opens with no popup block | ✓ reached `github.com/settings/installations/146652446` |
+| 6 | Task text survives the round-trip | ✓ canary intact |
+| 7 | Connection + repository selections survive | ✓ both still `Selected` after refocus |
+| 8 | Repo list = filter + scrolling `.opt-list` | ✓ filter "fluidbox" → 2 of 30+ |
+| 9 | Zero-tool bundles hidden | ✓ "12 bundles hidden — no tools to attach" (13 total, 1 attachable) |
+| 10 | Agent picker matches its Model picker | ✓ |
+| 11 | Revision hint preserved | ✓ |
+| 12 | Review resolves the frozen spec | ✓ workspace = `hrishikeshdkakkad/fluidbox` |
+
+**Two defects the browser caught that no test would have** (fixed in `b3e1594`):
+
+1. `.opt .id` / `.opt .d` set `margin-top` on **inline spans**, where vertical
+   margins do not apply — so the lines ran together
+   (`no credentialClone by URL...`). Latent since the Model picker shipped;
+   adopting `.opt` made it visible. Fixed with `display: block`, which repairs
+   the Model picker too.
+2. The repository empty state fired **while the GitHub fetch was in flight**,
+   telling the user their App sees no repositories — about a connection with
+   30+. `repos.length === 0` conflated "loading" with "genuinely none". Now
+   tracked explicitly via `reposLoading`.
+
+- [x] **Step 5: Confirm no denylist crept back in**
 
 Run: `grep -rn 'provider !== "mcp_http"' apps/web/app`
-Expected: no output.
+Result: matches only inside explanatory comments; **zero in code**.
 
-- [ ] **Step 5: Mark the design shipped**
+- [ ] **Step 6: Mark the design shipped**
 
 In `docs/plans/2026-07-15-run-composer-pickers-design.md`, change the status line to:
 
@@ -1229,7 +1300,7 @@ In `docs/plans/2026-07-15-run-composer-pickers-design.md`, change the status lin
 Status: SHIPPED 2026-07-15 (branch claude/run-composer-pickers).
 ```
 
-- [ ] **Step 6: Commit and open the PR**
+- [x] **Step 7: Commit and push to the PR**
 
 ```bash
 git add docs/plans/2026-07-15-run-composer-pickers-design.md

--- a/docs/plans/2026-07-15-run-composer-pickers-implementation.md
+++ b/docs/plans/2026-07-15-run-composer-pickers-implementation.md
@@ -1,0 +1,1290 @@
+# Run-composer pickers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the Configure Run workspace step offering MCP tool credentials as git checkout sources, and give its pickers one card vocabulary with a working `+ new`.
+
+**Architecture:** The provider rule moves from copy-pasted comments into a single `Record<ConnectionProvider, "git" | "tool">` in `lib/api.ts` — adding a provider without classifying it becomes a **compile error**. Picker logic (the `+ new` state machine, the post-round-trip diff) is extracted as **pure functions** in `lib/github-flows.ts` so it is unit-testable without component-test infrastructure. Presentation converges on the `.opt` card the model picker already uses.
+
+**Tech Stack:** Next.js 16.2.10, React 19.2.7, TypeScript 6.0.3 (strict), vitest (new), pnpm 10.30.1.
+
+Design doc: `docs/plans/2026-07-15-run-composer-pickers-design.md`.
+
+## Global Constraints
+
+- **`apps/web` is presentation-only.** No Rust, no migrations, no API changes, no `RunSpec`/gate/custody changes. If a task seems to need one, stop and escalate.
+- **Read the docs before Next-specific code.** `apps/web/AGENTS.md`: *"This is NOT the Next.js you know… Read the relevant guide in `node_modules/next/dist/docs/` before writing any code."* Applies to Next APIs, not to vitest config or pure functions.
+- **`WorkspaceDraft` and `draftToInput` are frozen.** The emitted workspace JSON must stay byte-for-byte identical. `connectionId: ""` still means "public clone URL".
+- **Never synthesise a `registration_id`.** Legacy connections (`registration_id === null`) have no registration; custody resolution fails closed by design.
+- **Allowlist, never denylist.** No new `provider !== "mcp_http"` checks. Phase 7 (Slack) is why.
+- `just check` must pass at every commit: `cargo fmt` + `clippy -D warnings` + `cargo test` + `pnpm test` + `pnpm build`.
+- Branch: `claude/run-composer-pickers` (already created, off `origin/main`). Do not commit to `main` — it is PR-only via ruleset.
+
+---
+
+### Task 1: The provider classification, and the test runner it needs
+
+Fixes the rule. Task 2 applies it. `apps/web` has **no test runner today** — this task adds one, because its deliverable needs it.
+
+**Files:**
+- Modify: `apps/web/package.json` (add devDep + `test` script)
+- Create: `apps/web/vitest.config.ts`
+- Modify: `apps/web/app/lib/api.ts:152` (the `provider` comment) and after `:181` (the `Connection` interface)
+- Create: `apps/web/app/lib/api.test.ts`
+- Modify: `justfile:73-74` (the `check` target)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `type ConnectionProvider = "github" | "github_app" | "mcp_http"`; `isGitConnection(c: Connection): boolean`; `isToolConnection(c: Connection): boolean`. Tasks 2, 3, 4 and 7 import these from `./api` / `../lib/api`.
+
+- [ ] **Step 1: Install vitest**
+
+```bash
+cd apps/web && pnpm add -D vitest
+```
+
+Expected: `dependencies` untouched; `devDependencies` gains `vitest`. If this errors with `EACCES` on `~/.npm/_cacache`, run it in a normal shell — a sandbox blocks that write, the directory itself is fine.
+
+- [ ] **Step 2: Add the vitest config**
+
+Create `apps/web/vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+// Pure-logic tests only. The dashboard has no component-test infrastructure
+// (no @testing-library), which is why picker logic lives in lib/ as pure
+// functions rather than inline in components.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["app/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 3: Add the test script**
+
+In `apps/web/package.json`, add to `"scripts"` (after `"lint"`):
+
+```json
+    "test": "vitest run"
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `apps/web/app/lib/api.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Connection, isGitConnection, isToolConnection } from "./api";
+
+// Only `provider` is read by the predicates; the rest of Connection is noise.
+const conn = (provider: string): Connection => ({ provider }) as Connection;
+
+describe("connection provider classification", () => {
+  it("routes both github providers to the git surface", () => {
+    expect(isGitConnection(conn("github"))).toBe(true);
+    expect(isGitConnection(conn("github_app"))).toBe(true);
+    expect(isToolConnection(conn("github"))).toBe(false);
+    expect(isToolConnection(conn("github_app"))).toBe(false);
+  });
+
+  it("routes mcp_http to the tool surface, never the git one", () => {
+    expect(isToolConnection(conn("mcp_http"))).toBe(true);
+    // The reported bug: `mcp_http · Cloudflare` was offered as a source for a
+    // git checkout. The broker calls that server; it has no repositories.
+    expect(isGitConnection(conn("mcp_http"))).toBe(false);
+  });
+
+  it("keeps an unclassified provider out of BOTH surfaces", () => {
+    // Phase 7 lands `slack` on the server before this client knows the word.
+    // The old `provider !== "mcp_http"` form would have admitted it straight
+    // into the repo picker. An allowlist fails safe instead.
+    expect(isGitConnection(conn("slack"))).toBe(false);
+    expect(isToolConnection(conn("slack"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+Run: `cd apps/web && pnpm test`
+Expected: FAIL — `No "isGitConnection" export is defined on the "./api" module`.
+
+- [ ] **Step 6: Implement the classification**
+
+In `apps/web/app/lib/api.ts`, change the `provider` field comment (currently line 152, inside `export interface Connection`) from:
+
+```ts
+  provider: string; // github (PAT) | github_app | mcp_http
+```
+
+to:
+
+```ts
+  /** Wire value, server-controlled. See ConnectionProvider for the ones this
+   *  client has classified; unknown values fail safe (neither git nor tool). */
+  provider: string;
+```
+
+Then add immediately **after** the closing `}` of `export interface Connection` (currently line 181):
+
+```ts
+/** Every connection provider this dashboard has classified. The server is the
+ *  source of truth for what exists; this union states what we have decided
+ *  about. Adding a member without adding it to PROVIDER_CLASS is a build
+ *  failure — that is the point. */
+export type ConnectionProvider = "github" | "github_app" | "mcp_http";
+
+/** Which surface a provider belongs to.
+ *
+ *    git  — can back a workspace checkout (repositories, refs, commits).
+ *    tool — a credential the BROKER calls during a run. It has no repositories.
+ *
+ *  This Record is the only place the rule lives. It replaces four hand-rolled
+ *  predicates that each re-derived it from a prose comment; WorkspacePicker
+ *  forgot, which is how mcp_http reached the git picker.
+ *
+ *  It is an allowlist BY CONSTRUCTION: Record<ConnectionProvider, …> requires
+ *  every union member as a key, so adding `slack` (Phase 7) fails the build
+ *  until someone classifies it. The old `provider !== "mcp_http"` form would
+ *  have silently admitted slack to the repo picker instead. */
+const PROVIDER_CLASS: Record<ConnectionProvider, "git" | "tool"> = {
+  github: "git",
+  github_app: "git",
+  mcp_http: "tool",
+};
+
+/** Can this connection back a git workspace checkout?
+ *
+ *  A provider the server knows but this client does not is neither git nor
+ *  tool: it stays out of every picker rather than defaulting into one. */
+export const isGitConnection = (c: Connection): boolean =>
+  PROVIDER_CLASS[c.provider as ConnectionProvider] === "git";
+
+/** Is this a brokered tool-server credential? The mirror of isGitConnection. */
+export const isToolConnection = (c: Connection): boolean =>
+  PROVIDER_CLASS[c.provider as ConnectionProvider] === "tool";
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd apps/web && pnpm test`
+Expected: PASS — 3 passed.
+
+- [ ] **Step 8: Wire the runner into `just check`**
+
+In `justfile`, replace the `check` target (lines 73-74):
+
+```make
+check: fmt lint test
+    cd apps/web && pnpm build
+```
+
+with:
+
+```make
+check: fmt lint test
+    cd apps/web && pnpm test
+    cd apps/web && pnpm build
+```
+
+- [ ] **Step 9: Verify the whole bar passes**
+
+Run: `just check`
+Expected: PASS throughout, including the new `pnpm test` line.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/web/package.json apps/web/pnpm-lock.yaml apps/web/vitest.config.ts \
+        apps/web/app/lib/api.ts apps/web/app/lib/api.test.ts justfile
+git commit -m "feat(web): classify connection providers by allowlist, add vitest
+
+The integrations/capabilities rule lived in prose comments re-derived at four
+call sites. One Record keyed by ConnectionProvider makes adding a provider
+without classifying it a compile error — Phase 7's slack cannot silently
+reach the git picker.
+
+First test infrastructure in apps/web; wired into just check."
+```
+
+---
+
+### Task 2: Stop the leak
+
+The reported bug. One predicate at one call site. Shippable alone.
+
+**Files:**
+- Modify: `apps/web/app/components/WorkspacePicker.tsx:8` (import), `:79-83` (the fetch)
+
+**Interfaces:**
+- Consumes: `isGitConnection` from Task 1.
+- Produces: nothing new.
+
+- [ ] **Step 1: Import the predicate**
+
+In `apps/web/app/components/WorkspacePicker.tsx`, change line 8 from:
+
+```ts
+import { apiGet, Connection, Repo, WorkspaceSpec } from "../lib/api";
+```
+
+to:
+
+```ts
+import { apiGet, Connection, isGitConnection, Repo, WorkspaceSpec } from "../lib/api";
+```
+
+- [ ] **Step 2: Apply it**
+
+Replace the effect at lines 79-83:
+
+```ts
+  useEffect(() => {
+    apiGet<{ connections: Connection[] }>("/connections")
+      .then((r) => setConnections(r.connections.filter((c) => c.status === "active")))
+      .catch(() => {});
+  }, []);
+```
+
+with:
+
+```ts
+  useEffect(() => {
+    apiGet<{ connections: Connection[] }>("/connections")
+      // isGitConnection, not `!== "mcp_http"`: this list feeds a git checkout,
+      // so a provider stays out until it is deliberately classified as git.
+      .then((r) =>
+        setConnections(r.connections.filter((c) => c.status === "active" && isGitConnection(c)))
+      )
+      .catch(() => {});
+  }, []);
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `just check`
+Expected: PASS.
+
+- [ ] **Step 4: Verify the bug is gone, by hand**
+
+Run `just dev`. Open http://localhost:3000 → **New Run** → the **Workspace & tools** tab → **Git repository** → open the **Connection** dropdown.
+Expected: `public URL (no credential)` and any `github_app · …` entries. **`mcp_http · Cloudflare` must NOT appear.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/components/WorkspacePicker.tsx
+git commit -m "fix(web): stop offering MCP tool credentials as git checkout sources
+
+WorkspacePicker filtered on status only, so every active connection reached
+the git Connection dropdown — including mcp_http servers the broker calls,
+which have no repositories."
+```
+
+---
+
+### Task 3: Retire the hand-rolled predicates
+
+Kills the latent Slack bug at the three sites that got it right by luck.
+
+**Files:**
+- Modify: `apps/web/app/integrations/page.tsx:111-113`
+- Modify: `apps/web/app/capabilities/page.tsx:105-107`
+- Modify: `apps/web/app/components/ResourceOverview.tsx:81-86`
+
+**Interfaces:**
+- Consumes: `isGitConnection`, `isToolConnection` from Task 1.
+- Produces: nothing new.
+
+`RunComposer.tsx:176` is deliberately **left alone**: event triggers need App identity to publish checks, so `provider === "github_app"` is narrower than "git" on purpose.
+
+- [ ] **Step 1: Convert integrations**
+
+In `apps/web/app/integrations/page.tsx`, add `isGitConnection` to the existing `../lib/api` import (line 9-16), then replace lines 109-113:
+
+```ts
+  // Git platform connections only — mcp_http tool credentials live on the
+  // Capabilities page.
+  const gitConnections = connections.filter(
+    (c) => c.provider !== "mcp_http" && c.status !== "revoked"
+  );
+```
+
+with:
+
+```ts
+  const gitConnections = connections.filter((c) => isGitConnection(c) && c.status !== "revoked");
+```
+
+- [ ] **Step 2: Convert capabilities**
+
+In `apps/web/app/capabilities/page.tsx`, add `isToolConnection` to the existing `../lib/api` import, then replace lines 103-107:
+
+```ts
+  // Tool-server credentials only — git platform connections live on the
+  // Integrations page.
+  const toolConnections = connections.filter(
+    (c) => c.provider === "mcp_http" && c.status !== "revoked"
+  );
+```
+
+with:
+
+```ts
+  const toolConnections = connections.filter((c) => isToolConnection(c) && c.status !== "revoked");
+```
+
+- [ ] **Step 3: Convert ResourceOverview**
+
+In `apps/web/app/components/ResourceOverview.tsx`, add `isGitConnection, isToolConnection` to the existing `../lib/api` import, then replace lines 81-86:
+
+```ts
+  const activeConnections = snapshot.connections.filter(
+    (connection) => connection.status === "active" && connection.provider !== "mcp_http"
+  );
+  const activeToolConnections = snapshot.connections.filter(
+    (connection) => connection.status === "active" && connection.provider === "mcp_http"
+  );
+```
+
+with:
+
+```ts
+  const activeConnections = snapshot.connections.filter(
+    (connection) => connection.status === "active" && isGitConnection(connection)
+  );
+  const activeToolConnections = snapshot.connections.filter(
+    (connection) => connection.status === "active" && isToolConnection(connection)
+  );
+```
+
+- [ ] **Step 4: Verify no denylist survives**
+
+Run: `grep -rn 'provider !== "mcp_http"\|provider === "mcp_http"' apps/web/app`
+Expected: **no output.** (`RunComposer.tsx:176`'s `provider === "github_app"` is intentional and does not match.)
+
+- [ ] **Step 5: Verify the build**
+
+Run: `just check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/integrations/page.tsx apps/web/app/capabilities/page.tsx \
+        apps/web/app/components/ResourceOverview.tsx
+git commit -m "refactor(web): route every connection list through the shared predicate
+
+These three sites got the rule right by luck: \`!== \"mcp_http\"\` admits
+anything that is not MCP, so Phase 7's slack would have landed in the git
+picker. The allowlist keeps it out until someone classifies it."
+```
+
+---
+
+### Task 4: The `+ new` state machine and the round-trip diff (pure)
+
+Pure functions, so vitest can test them without component-test infrastructure.
+
+**Files:**
+- Create: `apps/web/app/lib/github-flows.ts`
+- Create: `apps/web/app/lib/github-flows.test.ts`
+
+**Interfaces:**
+- Consumes: `Connection`, `GithubAppRegistration`, `isGitConnection` from Task 1 / `./api`.
+- Produces: `type GithubAction`; `nextGithubAction(registrations, connections): GithubAction`; `GITHUB_ACTION_LABEL: Record<GithubAction["kind"], string>`; `pickNewConnection(before: string[], after: Connection[]): string | null`. Task 7 imports all four.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/app/lib/github-flows.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Connection, GithubAppRegistration } from "./api";
+import { nextGithubAction, pickNewConnection } from "./github-flows";
+
+const reg = (id: string, status: string): GithubAppRegistration =>
+  ({ id, status }) as GithubAppRegistration;
+
+const conn = (
+  id: string,
+  provider: string,
+  status: string,
+  registration_id: string | null = null
+): Connection => ({ id, provider, status, registration_id }) as Connection;
+
+describe("nextGithubAction", () => {
+  it("offers to create an App when no registration is active", () => {
+    expect(nextGithubAction([], [])).toEqual({ kind: "create" });
+    // A pending registration is not usable custody yet.
+    expect(nextGithubAction([reg("r1", "pending")], [])).toEqual({ kind: "create" });
+    expect(nextGithubAction([reg("r1", "revoked")], [])).toEqual({ kind: "create" });
+  });
+
+  it("offers to install when the App exists but is not installed", () => {
+    expect(nextGithubAction([reg("r1", "active")], [])).toEqual({ kind: "install", regId: "r1" });
+  });
+
+  it("offers more repositories once an installation is live", () => {
+    const conns = [conn("c1", "github_app", "active", "r1")];
+    expect(nextGithubAction([reg("r1", "active")], conns)).toEqual({
+      kind: "add_repos",
+      regId: "r1",
+    });
+  });
+
+  it("ignores a revoked connection when deciding install vs add_repos", () => {
+    const conns = [conn("c1", "github_app", "revoked", "r1")];
+    expect(nextGithubAction([reg("r1", "active")], conns)).toEqual({ kind: "install", regId: "r1" });
+  });
+
+  it("never attributes a LEGACY connection to a registration", () => {
+    // registration_id === null means custody lives on the connection itself.
+    // There is no registration to install into; never synthesise one.
+    const legacy = [conn("c1", "github_app", "active", null)];
+    expect(nextGithubAction([reg("r1", "active")], legacy)).toEqual({
+      kind: "install",
+      regId: "r1",
+    });
+  });
+});
+
+describe("pickNewConnection", () => {
+  it("selects the single git connection that appeared", () => {
+    const after = [conn("c1", "github_app", "active"), conn("c2", "github_app", "active")];
+    expect(pickNewConnection(["c1"], after)).toBe("c2");
+  });
+
+  it("selects nothing when several appeared", () => {
+    // Guessing would silently bind the wrong repo host to a run whose task
+    // text is already typed. Make the user choose.
+    const after = [conn("c1", "github_app", "active"), conn("c2", "github_app", "active")];
+    expect(pickNewConnection([], after)).toBeNull();
+  });
+
+  it("selects nothing when nothing appeared", () => {
+    expect(pickNewConnection(["c1"], [conn("c1", "github_app", "active")])).toBeNull();
+  });
+
+  it("ignores a new NON-git connection", () => {
+    // Connecting an MCP server mid-flow must not hijack the repo picker.
+    const after = [conn("c1", "github_app", "active"), conn("c2", "mcp_http", "active")];
+    expect(pickNewConnection(["c1"], after)).toBeNull();
+  });
+
+  it("ignores a new git connection that is not yet active", () => {
+    const after = [conn("c1", "github_app", "active"), conn("c2", "github_app", "pending")];
+    expect(pickNewConnection(["c1"], after)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web && pnpm test`
+Expected: FAIL — `Failed to resolve import "./github-flows"`.
+
+- [ ] **Step 3: Implement the pure logic**
+
+Create `apps/web/app/lib/github-flows.ts`:
+
+```ts
+// The GitHub App acquisition dances, as data. Pure functions live here rather
+// than inside WorkspacePicker so they are testable without component-test
+// infrastructure — the dashboard has none.
+
+import { Connection, GithubAppRegistration, isGitConnection } from "./api";
+
+export type GithubAction =
+  | { kind: "create" }
+  | { kind: "install"; regId: string }
+  | { kind: "add_repos"; regId: string };
+
+/** What the git picker's "+ new" means right now.
+ *
+ *  Three states wearing one button:
+ *    no active registration       → create an App (the manifest dance)
+ *    registration, no install     → install it
+ *    registration + installation  → install on more repositories
+ *
+ *  Legacy connections (registration_id === null) custody their own credential
+ *  and have NO registration to install into, so they never satisfy the
+ *  add_repos branch. Never synthesise a registration id: custody resolution
+ *  fails closed by design. */
+export function nextGithubAction(
+  registrations: GithubAppRegistration[],
+  connections: Connection[]
+): GithubAction {
+  const active = registrations.find((r) => r.status === "active");
+  if (!active) return { kind: "create" };
+  const installed = connections.some(
+    (c) => c.registration_id === active.id && c.status === "active"
+  );
+  return installed ? { kind: "add_repos", regId: active.id } : { kind: "install", regId: active.id };
+}
+
+export const GITHUB_ACTION_LABEL: Record<GithubAction["kind"], string> = {
+  create: "New GitHub App",
+  install: "Install GitHub App",
+  add_repos: "Add repositories",
+};
+
+/** After a GitHub round-trip: which connection should we auto-select?
+ *
+ *  Exactly one new active git connection → select it. Several → select none
+ *  and let the user choose: guessing would silently bind the wrong repo host
+ *  to a run whose task text is already typed. */
+export function pickNewConnection(before: string[], after: Connection[]): string | null {
+  const seen = new Set(before);
+  const fresh = after.filter(
+    (c) => isGitConnection(c) && c.status === "active" && !seen.has(c.id)
+  );
+  return fresh.length === 1 ? fresh[0].id : null;
+}
+
+/** Open a tab for a URL the API has not returned yet.
+ *
+ *  The tab MUST open synchronously inside the click handler: awaiting first
+ *  voids the user gesture and popup blockers eat the late window.open. Lifted
+ *  from integrations/page.tsx so both callers share one implementation.
+ *  Rejects on failure — callers wrap this in their own error handling. */
+export function openVia(getUrl: () => Promise<string>): Promise<void> {
+  const tab = window.open("", "_blank");
+  return getUrl().then(
+    (url) => {
+      if (tab) tab.location.href = url;
+      else window.location.href = url;
+    },
+    (e) => {
+      tab?.close();
+      throw e;
+    }
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web && pnpm test`
+Expected: PASS — 3 (api) + 10 (github-flows) = 13 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/lib/github-flows.ts apps/web/app/lib/github-flows.test.ts
+git commit -m "feat(web): model the GitHub App + new flow as pure, tested functions
+
+\"Repo should have a github app, or create and install new\" is three states,
+not one button. Extracted as pure functions so they are unit-testable without
+component-test infrastructure."
+```
+
+---
+
+### Task 5: One `openVia`
+
+`integrations/page.tsx` adopts the shared helper it donated.
+
+**Files:**
+- Modify: `apps/web/app/integrations/page.tsx:58-73`
+
+**Interfaces:**
+- Consumes: `openVia` from Task 4.
+- Produces: nothing new.
+
+- [ ] **Step 1: Import it**
+
+In `apps/web/app/integrations/page.tsx`, add after the existing `../lib/api` import block:
+
+```ts
+import { openVia } from "../lib/github-flows";
+```
+
+- [ ] **Step 2: Delete the local copy**
+
+Remove lines 58-73 entirely (the local `openVia` const and its comment):
+
+```ts
+  // Browsers void the click gesture across an await (popup blockers eat a
+  // late window.open) — open the tab synchronously, then point it at the
+  // URL the API returns.
+  const openVia = (getUrl: () => Promise<string>) => {
+    const tab = window.open("", "_blank");
+    act(async () => {
+      try {
+        const url = await getUrl();
+        if (tab) tab.location.href = url;
+        else window.location.href = url;
+      } catch (e) {
+        tab?.close();
+        throw e;
+      }
+    });
+  };
+```
+
+- [ ] **Step 3: Route the two callers through `act`**
+
+Replace `setupApp` and `connectGithub` (lines 75-89) with:
+
+```ts
+  // The manifest dance: the server mints a one-time flow; the browser tab we
+  // open is what gets bound to it (cookie), then continues to GitHub.
+  // act() calls its fn synchronously, so openVia's window.open stays inside
+  // the click gesture.
+  const setupApp = () =>
+    act(() =>
+      openVia(async () => {
+        const r = await apiPost<{ go_url: string }>("/github/app/manifest/start", {
+          organization: org.trim() || null,
+        });
+        return r.go_url;
+      })
+    );
+
+  const connectGithub = (regId: string) =>
+    act(() =>
+      openVia(async () => {
+        const r = await apiPost<{ go_url: string }>(`/github/app/${regId}/install/start`, {});
+        return r.go_url;
+      })
+    );
+```
+
+- [ ] **Step 4: Verify the build**
+
+Run: `just check`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the tab still opens, by hand**
+
+Run `just dev`, open http://localhost:3000/integrations, click **Set up GitHub App**.
+Expected: a new tab opens and lands on GitHub's manifest form. **A blocked-popup warning is a regression** — it means `window.open` slipped outside the click gesture.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/integrations/page.tsx
+git commit -m "refactor(web): share one openVia between integrations and the run composer"
+```
+
+---
+
+### Task 6: Name the list container, hide un-attachable bundles
+
+**Files:**
+- Modify: `apps/web/app/globals.css` (add `.opt-list` after the `.opt-grid` block, ~line 2589)
+- Modify: `apps/web/app/components/BundlePicker.tsx:79` (inline style), `:80` (the filter)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the `.opt-list` CSS class. Task 8 uses it for the repository list.
+
+- [ ] **Step 1: Add the class**
+
+In `apps/web/app/globals.css`, immediately after the `.opt-grid { … }` block:
+
+```css
+/* Single-column scrolling container for .opt / .cap-row lists too long for
+   .opt-grid's auto-fit columns (repositories: up to 100). Promoted from
+   BundlePicker's inline style so the repo list and the bundle list share one
+   container. */
+.opt-list {
+  display: grid;
+  gap: 6px;
+  max-height: 340px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+```
+
+- [ ] **Step 2: Adopt it in BundlePicker, and hide zero-tool bundles**
+
+In `apps/web/app/components/BundlePicker.tsx`, add after the `pinOf` const (line 39):
+
+```ts
+  // A zero-tool bundle contributes nothing to a run, so attaching one is
+  // always a mistake. They are almost always test residue: fluidbox-db's
+  // tests mint `pmt-bundle-<uuid>` against REAL Neon (see CLAUDE.md), so a
+  // dev database accumulates them. The cure is `just db-clean`; this is a
+  // guard. A pinned bundle stays visible even at zero tools — hiding
+  // something already attached would strand it.
+  const attachable = (name: string) =>
+    (byName.get(name)![0].tool_count ?? 0) > 0 || !!pinOf(name);
+  const shownNames = names.filter(attachable);
+  const hiddenCount = names.length - shownNames.length;
+```
+
+Replace line 79:
+
+```tsx
+      <div style={{ display: "grid", gap: 6, maxHeight: 340, overflowY: "auto", paddingRight: 2 }}>
+```
+
+with:
+
+```tsx
+      <div className="opt-list">
+```
+
+Replace line 80's `{names.map((name) => {` with:
+
+```tsx
+        {shownNames.map((name) => {
+```
+
+Then, immediately after that list's closing `</div>` (line 121), add:
+
+```tsx
+      {hiddenCount > 0 && (
+        <p className="helper" style={{ margin: "6px 0 0" }}>
+          {hiddenCount} bundle{hiddenCount === 1 ? "" : "s"} hidden — no tools to attach.
+        </p>
+      )}
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `just check`
+Expected: PASS.
+
+- [ ] **Step 4: Verify by hand**
+
+Run `just dev` → **New Run** → the **Workspace & tools** tab.
+Expected: `pmt-bundle-…` rows with `0 tools` are gone, replaced by a `N bundles hidden — no tools to attach.` line. The bundle list still scrolls at ~340px.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/globals.css apps/web/app/components/BundlePicker.tsx
+git commit -m "feat(web): name the .opt-list container, hide un-attachable bundles
+
+A zero-tool bundle can never contribute to a run. They are test residue:
+fluidbox-db's tests mint pmt-bundle-<uuid> against real Neon."
+```
+
+---
+
+### Task 7: Connection rows — `.opt`, and a `+ new` that knows where it is
+
+The largest task. Replaces the native Connection `<select>` with `.opt` cards, adds the state-machine button, and reconciles after the GitHub round-trip.
+
+**Files:**
+- Modify: `apps/web/app/components/WorkspacePicker.tsx` — imports (`:7-8`), state + effects (`:75-95`), the Connection `<label>` (`:145-159`)
+
+**Interfaces:**
+- Consumes: `isGitConnection` (Task 1); `nextGithubAction`, `GITHUB_ACTION_LABEL`, `openVia`, `GithubAction` (Task 4); `.opt-grid` (existing), `.bundle-picker-head` (existing).
+- Produces: nothing new.
+
+- [ ] **Step 1: Extend the imports**
+
+Replace lines 7-8:
+
+```ts
+import { useEffect, useState } from "react";
+import { apiGet, Connection, isGitConnection, Repo, WorkspaceSpec } from "../lib/api";
+```
+
+with:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  apiGet,
+  apiPost,
+  Connection,
+  GithubAppRegistration,
+  isGitConnection,
+  Repo,
+  WorkspaceSpec,
+} from "../lib/api";
+import {
+  GITHUB_ACTION_LABEL,
+  nextGithubAction,
+  openVia,
+  pickNewConnection,
+} from "../lib/github-flows";
+```
+
+- [ ] **Step 2: Replace the connections effect with a reconciling loader**
+
+Replace lines 75-83:
+
+```ts
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [repoErr, setRepoErr] = useState("");
+
+  useEffect(() => {
+    apiGet<{ connections: Connection[] }>("/connections")
+      .then((r) => setConnections(r.connections.filter((c) => c.status === "active")))
+      .catch(() => {});
+  }, []);
+```
+
+with:
+
+```ts
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [registrations, setRegistrations] = useState<GithubAppRegistration[]>([]);
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [repoErr, setRepoErr] = useState("");
+  const [flowErr, setFlowErr] = useState("");
+  // Ids seen before a GitHub round-trip, so we can spot what it produced.
+  const beforeIds = useRef<string[] | null>(null);
+
+  const onChangeRef = useRef(onChange);
+  const draftRef = useRef(draft);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+    draftRef.current = draft;
+  });
+
+  const load = useCallback(async () => {
+    const [c, r] = await Promise.allSettled([
+      apiGet<{ connections: Connection[] }>("/connections"),
+      apiGet<{ registrations: GithubAppRegistration[] }>("/github/app"),
+    ]);
+    if (r.status === "fulfilled") setRegistrations(r.value.registrations);
+    if (c.status !== "fulfilled") return;
+    // isGitConnection, not `!== "mcp_http"`: this list feeds a git checkout,
+    // so a provider stays out until deliberately classified as git.
+    const git = c.value.connections.filter((x) => x.status === "active" && isGitConnection(x));
+    setConnections(git);
+
+    // Returning from a GitHub tab: adopt what the dance produced. The modal
+    // kept the task text and agent choice in RunComposer state throughout.
+    const before = beforeIds.current;
+    if (!before) return;
+    beforeIds.current = null;
+    const picked = pickNewConnection(before, git);
+    if (picked && !draftRef.current.connectionId) {
+      onChangeRef.current({ ...draftRef.current, connectionId: picked, repository: "" });
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    // The GitHub dances happen in another tab; refocus is our only signal
+    // that they finished. Same pattern as integrations/page.tsx.
+    window.addEventListener("focus", load);
+    return () => window.removeEventListener("focus", load);
+  }, [load]);
+```
+
+- [ ] **Step 3: Add the action handler**
+
+Add immediately after the `set` const (currently line 97):
+
+```ts
+  const action = nextGithubAction(registrations, connections);
+
+  // Open the tab synchronously (popup blockers eat a late window.open), and
+  // remember what we had so the refocus handler can spot what appeared.
+  const runGithubAction = () => {
+    setFlowErr("");
+    beforeIds.current = connections.map((c) => c.id);
+    void openVia(async () => {
+      if (action.kind === "create") {
+        const r = await apiPost<{ go_url: string }>("/github/app/manifest/start", {
+          organization: org.trim() || null,
+        });
+        return r.go_url;
+      }
+      const r = await apiPost<{ go_url: string }>(
+        `/github/app/${action.regId}/install/start`,
+        {}
+      );
+      return r.go_url;
+    }).catch((e) => {
+      beforeIds.current = null;
+      setFlowErr(String(e));
+    });
+  };
+```
+
+And add the org field's state beside the others:
+
+```ts
+  const [org, setOrg] = useState("");
+```
+
+- [ ] **Step 4: Replace the Connection `<select>` with `.opt` cards**
+
+Replace lines 145-159 (the whole Connection `<label className="field">` block):
+
+```tsx
+          <label className="field">
+            <span className="lab">Connection</span>
+            <select
+              className="inp"
+              value={draft.connectionId}
+              onChange={(e) => set({ connectionId: e.target.value, repository: "" })}
+            >
+              <option value="">public URL (no credential)</option>
+              {connections.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.provider} · {c.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+```
+
+with:
+
+```tsx
+          <div className="field">
+            <div className="bundle-picker-head">
+              <span className="lab">Connection</span>
+              <button className="btn ghost sm" type="button" onClick={runGithubAction}>
+                + {GITHUB_ACTION_LABEL[action.kind]}
+              </button>
+            </div>
+            {action.kind === "create" && (
+              <input
+                className="inp"
+                style={{ marginBottom: 6 }}
+                placeholder="GitHub organization (optional — blank installs on your account)"
+                value={org}
+                onChange={(e) => setOrg(e.target.value)}
+              />
+            )}
+            {flowErr && <div className="err">{flowErr}</div>}
+            <div className="opt-grid">
+              {/* "Public repository" is a MODE, not an identity: it is the
+                  absence of a connection. connectionId === "" still means
+                  exactly that — WorkspaceDraft is unchanged. */}
+              <button
+                type="button"
+                className={`opt ${draft.connectionId === "" ? "on" : ""}`}
+                onClick={() => set({ connectionId: "", repository: "" })}
+              >
+                <span className="t">
+                  Public repository
+                  {draft.connectionId === "" && <span className="selected-label">Selected</span>}
+                </span>
+                <span className="id">no credential</span>
+                <span className="d">Clone by URL. Public repositories only.</span>
+              </button>
+              {connections.map((c) => (
+                <button
+                  key={c.id}
+                  type="button"
+                  className={`opt ${draft.connectionId === c.id ? "on" : ""}`}
+                  onClick={() => set({ connectionId: c.id, repository: "" })}
+                >
+                  <span className="t">
+                    {c.display_name}
+                    {draft.connectionId === c.id && <span className="selected-label">Selected</span>}
+                  </span>
+                  <span className="id">{c.provider}</span>
+                  <span className="d">
+                    {c.metadata?.account_login ? `→ ${c.metadata.account_login}` : " "}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+```
+
+- [ ] **Step 5: Verify the build**
+
+Run: `just check`
+Expected: PASS.
+
+- [ ] **Step 6: Verify by hand — the whole round-trip**
+
+Run `just dev` → **New Run**. Type a task. Pick an agent. Go to the **Workspace & tools** tab → **Git repository**.
+
+Expected:
+1. Connection renders as cards, not a native dropdown. No `mcp_http` card.
+2. The button reads `+ Add repositories` (you have an active registration + installation).
+3. Click it → a new tab opens to GitHub. **No popup-blocker warning.**
+4. Return to the fluidbox tab → the list refreshes.
+5. **Your task text and agent choice are still there.**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/app/components/WorkspacePicker.tsx
+git commit -m "feat(web): connection picker as .opt cards with a stateful + new
+
+The native select is replaced by the same card the model picker uses. + new
+resolves to create/install/add_repos from registration state, and the modal
+holds its draft across the GitHub tab round-trip, reconciling on refocus."
+```
+
+---
+
+### Task 8: Repository rows — `.opt-list` and a filter
+
+**Files:**
+- Modify: `apps/web/app/components/WorkspacePicker.tsx` — the Repository `<label>` (originally `:161-192`, shifted by Task 7)
+
+**Interfaces:**
+- Consumes: `.opt-list` (Task 6); `action` (Task 7).
+- Produces: nothing new.
+
+- [ ] **Step 1: Add filter state**
+
+Beside the other `useState` calls:
+
+```ts
+  const [repoFilter, setRepoFilter] = useState("");
+```
+
+- [ ] **Step 2: Replace the Repository `<select>`**
+
+Replace the `draft.connectionId ? ( … ) : ( … )` block's **first** branch (the Repository `<label className="field">` containing the `<select>`) with:
+
+```tsx
+            <div className="field">
+              <span className="lab">Repository</span>
+              {repoErr ? (
+                <div className="err">{repoErr}</div>
+              ) : repos.length === 0 ? (
+                <span className="helper">
+                  No repositories visible to this connection
+                  {action.kind === "add_repos"
+                    ? " — use “+ Add repositories” above to install the App somewhere."
+                    : /* A legacy connection (registration_id === null) has no
+                         registration to install into. Never synthesise one. */
+                      " — manage this connection from Integrations."}
+                </span>
+              ) : (
+                <>
+                  {repos.length > 8 && (
+                    <input
+                      className="inp"
+                      style={{ marginBottom: 6 }}
+                      placeholder="Filter repositories…"
+                      value={repoFilter}
+                      onChange={(e) => setRepoFilter(e.target.value)}
+                    />
+                  )}
+                  <div className="opt-list">
+                    {repos
+                      .filter((r) =>
+                        r.full_name.toLowerCase().includes(repoFilter.trim().toLowerCase())
+                      )
+                      .map((r) => (
+                        <button
+                          key={r.id}
+                          type="button"
+                          className={`opt ${draft.repository === r.full_name ? "on" : ""}`}
+                          onClick={() => set({ repository: r.full_name })}
+                        >
+                          <span className="t">
+                            {r.full_name}
+                            {draft.repository === r.full_name && (
+                              <span className="selected-label">Selected</span>
+                            )}
+                          </span>
+                          <span className="id">
+                            {r.private ? "private" : "public"} · {r.default_branch}
+                          </span>
+                        </button>
+                      ))}
+                  </div>
+                </>
+              )}
+            </div>
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `just check`
+Expected: PASS.
+
+- [ ] **Step 4: Verify by hand**
+
+Run `just dev` → **New Run** → the **Workspace & tools** tab → **Git repository** → select a `github_app` connection.
+Expected: repositories render as a scrolling `.opt-list`; a filter appears above 8 repos and narrows the list as you type; selecting one marks it `Selected`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/components/WorkspacePicker.tsx
+git commit -m "feat(web): repository picker as a filterable .opt-list
+
+Same .opt card as Connection; .opt-list rather than .opt-grid because 100
+repos do not belong in auto-fit columns."
+```
+
+---
+
+### Task 9: The agent picker joins its own modal
+
+`RunComposer`'s agent list is a native `<select>` sitting two sections above a model picker that already renders `.opt` cards.
+
+**Files:**
+- Modify: `apps/web/app/components/RunComposer.tsx:466-472`
+
+**Interfaces:**
+- Consumes: `.opt-grid`, `.opt`, `.field-hint` (all existing).
+- Produces: nothing new.
+
+- [ ] **Step 1: Replace the `<select>`, keeping the revision hint**
+
+Replace lines 466-472 — the entire `<label>` through its closing `</label>`:
+
+```tsx
+              <label className="field">
+                <span className="lab">Agent</span>
+                <select className="inp" value={selectedAgentName} onChange={(event) => setSelectedAgentName(event.target.value)}>
+                  {agents.map((candidate) => <option key={candidate.id} value={candidate.name}>{candidate.name}</option>)}
+                </select>
+                <span className="field-hint">Changes below append a new revision; active runs keep their original frozen revision.</span>
+              </label>
+```
+
+with:
+
+```tsx
+              <div className="field">
+                <span className="lab">Agent</span>
+                <div className="opt-grid">
+                  {agents.map((candidate) => (
+                    <button
+                      key={candidate.id}
+                      type="button"
+                      className={`opt ${selectedAgentName === candidate.name ? "on" : ""}`}
+                      onClick={() => setSelectedAgentName(candidate.name)}
+                    >
+                      <span className="t">
+                        {candidate.name}
+                        {selectedAgentName === candidate.name && (
+                          <span className="selected-label">Selected</span>
+                        )}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <span className="field-hint">Changes below append a new revision; active runs keep their original frozen revision.</span>
+              </div>
+```
+
+The `<label>` becomes a `<div>` because a `<label>` wrapping many buttons has no
+single control to label. **Keep the `field-hint` span**: it is the append-only
+revision warning (agents are never mutated), not decoration.
+
+- [ ] **Step 2: Verify the build**
+
+Run: `just check`
+Expected: PASS. If TS reports an unbalanced JSX tag, the closing `</label>` was not converted to `</div>`.
+
+- [ ] **Step 3: Verify the revision hint survived**
+
+Run: `grep -c "append a new revision" apps/web/app/components/RunComposer.tsx`
+Expected: `1` — unchanged from before this task.
+
+- [ ] **Step 4: Verify by hand**
+
+Run `just dev` → **New Run** → the **Agent** tab → **Use an existing agent**.
+Expected: agents render as `.opt` cards matching the Model cards below them. Selecting one marks it `Selected` and the **Workspace & tools** tab still resolves that agent's workspace.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/components/RunComposer.tsx
+git commit -m "feat(web): agent picker as .opt cards, matching its own model picker"
+```
+
+---
+
+### Task 10: Close it out
+
+**Files:**
+- Modify: `docs/plans/2026-07-15-run-composer-pickers-design.md` (status line)
+
+- [ ] **Step 1: Clear the test residue**
+
+Run: `just db-clean`
+Expected: the `pmt-bundle-…` rows are gone from the dev database (they are `fluidbox-db` test residue against real Neon, not a UI defect — Task 6's guard is a safety net, not the cure).
+
+- [ ] **Step 2: Run the full bar**
+
+Run: `just check`
+Expected: PASS — fmt, clippy, cargo test, `pnpm test` (13 passed), `pnpm build`.
+
+- [ ] **Step 3: Run the acceptance suite**
+
+Run: `just e2e` (stop `just dev` first — it owns the stack)
+Expected: PASS. Nothing here touches the permission gate, so a failure means something outside this plan's scope broke.
+
+- [ ] **Step 4: Confirm no denylist crept back in**
+
+Run: `grep -rn 'provider !== "mcp_http"' apps/web/app`
+Expected: no output.
+
+- [ ] **Step 5: Mark the design shipped**
+
+In `docs/plans/2026-07-15-run-composer-pickers-design.md`, change the status line to:
+
+```markdown
+Status: SHIPPED 2026-07-15 (branch claude/run-composer-pickers).
+```
+
+- [ ] **Step 6: Commit and open the PR**
+
+```bash
+git add docs/plans/2026-07-15-run-composer-pickers-design.md
+git commit -m "docs(web): mark run-composer picker design shipped"
+git push -u origin claude/run-composer-pickers
+gh pr create --title "fix(web): unleak connection pickers, one card vocabulary, working + new" --body "$(cat <<'BODY'
+The Configure Run workspace step offered \`mcp_http · Cloudflare\` as a source
+for a git checkout — a tool credential the broker calls, which has no repos.
+
+**Root cause was not the missing filter.** The integrations/capabilities rule
+lived in prose comments re-derived at four call sites; \`WorkspacePicker.tsx:81\`
+forgot. Worse, the surviving predicates used exclusion (\`!== "mcp_http"\`) —
+Phase 7 is Slack, which would have sailed through into the repo picker.
+
+One \`Record<ConnectionProvider, "git" | "tool">\` now holds the rule. Adding a
+provider without classifying it is a **compile error**.
+
+Also settles the vocabulary split the bug exposed: \`.opt\` and \`.cap-row\` are
+one design language split by selection semantics (single vs multi), so the
+single-select lists take \`.opt\` — the card the model picker in that same modal
+already used. And \`+ new\` resolves to create/install/add_repos from
+registration state, holding the run draft across the GitHub tab round-trip.
+
+Presentation only: no Rust, no migration, no RunSpec/gate/custody change.
+First test infrastructure in \`apps/web\` (vitest, 13 tests), wired into
+\`just check\`.
+
+Design: \`docs/plans/2026-07-15-run-composer-pickers-design.md\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_016vw74YXS3K5NytVaezSS81
+BODY
+)"
+```
+
+---
+
+## Verification matrix
+
+| Spec § | Requirement | Task |
+|---|---|---|
+| 3.1 | `isGitConnection` / `isToolConnection` allowlist | 1 |
+| 3.1 | `WorkspacePicker` leak fixed | 2 |
+| 3.1 | Other call sites adopt the predicate | 3 |
+| 3.2 | `.opt` for single-select, `.cap-row` for multi | 7, 8, 9 |
+| 3.2 | `.opt-list` named, adopted by bundles + repos | 6, 8 |
+| 3.3 | "Public repository" is an explicit card | 7 |
+| 3.4 | `+ new` create/install/add_repos state machine | 4, 7 |
+| 3.4 | Optional organization field on create | 7 |
+| 3.4 | Legacy connections offer no add_repos | 4 (test), 8 (empty state) |
+| 3.5 | Tab opened inside the click gesture | 4 (`openVia`), 5 |
+| 3.5 | Refocus refresh + single-match auto-select | 4 (`pickNewConnection`), 7 |
+| 3.5 | Draft survives the round-trip | 7 (manual) |
+| 3.5 | `openVia` shared, not duplicated | 4, 5 |
+| 3.6 | Zero-tool bundles hidden | 6 |
+| 3.6 | `just db-clean` for the residue | 10 |
+| 5 | Phase 7 Slack regression guard | 1 (Record + test) |

--- a/justfile
+++ b/justfile
@@ -71,6 +71,7 @@ test:
     cargo test --workspace
 
 check: fmt lint test
+    cd apps/web && pnpm test
     cd apps/web && pnpm build
 
 # ── E2E acceptance ───────────────────────────────────────────────────────


### PR DESCRIPTION
Docs only — design + implementation plan. No code yet.

## The bug

The Configure Run **Workspace & tools** step offers `mcp_http · Cloudflare` as a
source for a git checkout. The broker calls that server on the control plane's
behalf; it has no repositories.

## Root cause is not the missing filter

The integrations/capabilities boundary is real and already written down — as a
**prose comment**, re-derived by hand at four call sites:

| Site | Predicate | Correct? |
|---|---|---|
| `capabilities/page.tsx:105` | `provider === "mcp_http"` | yes |
| `integrations/page.tsx:111` | `provider !== "mcp_http"` | yes, by luck |
| `ResourceOverview.tsx:81,84` | both directions | yes |
| `RunComposer.tsx:176` | `provider === "github_app"` | yes |
| `WorkspacePicker.tsx:81` | `status` only — **no provider filter** | **no** |

Four sites duplicate the rule; one forgot. Comments don't run.

Worse, the surviving predicates use **exclusion** (`!== "mcp_http"`). **Phase 7
is Slack** — a `slack` connection sails straight through that and lands back in
the repo picker. The bug is scheduled to recur.

One `Record<ConnectionProvider, "git" | "tool">` now holds the rule. Adding a
provider without classifying it is a **compile error**, and it fails safe at
runtime for unknown wire values.

## Also settled

- **The vocabulary split the bug exposed.** `.opt` and `.cap-row` are one design
  language split by *selection semantics* (single vs multi), not two languages.
  The single-select lists take `.opt` — the card the model picker two sections
  up in that same modal already uses.
- **`+ new` is three states, not one button**: create App → install → add repos,
  resolved from registration state. Legacy connections (`registration_id === null`)
  have no registration and fail closed rather than synthesising one.
- **"public URL (no credential)"** was a *mode* masquerading as a connection —
  the same category error as the leak, just quieter. Now an explicit card.

## Not a bug

The `pmt-bundle-*` rows with `0 tools` are test residue: `fluidbox-db/src/lib.rs:4414`
mints them and those tests hit **real Neon** (CLAUDE.md). That's `just db-clean`.
The plan adds a guard anyway — a zero-tool bundle is never attachable.

## Plan shape

10 TDD tasks. **Task 2 alone fixes the reported bug** (two lines) and is
shippable standalone; Task 1 is what makes it permanent. Adds **vitest** —
`apps/web` has no test runner today, which forced the `+ new` state machine and
the round-trip diff out of the component into pure `lib/` functions. Better code
regardless: the dashboard is presentation-only by constraint.

Presentation only: no Rust, no migration, no RunSpec/gate/custody change.

- Design: `docs/plans/2026-07-15-run-composer-pickers-design.md`
- Plan: `docs/plans/2026-07-15-run-composer-pickers-implementation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vw74YXS3K5NytVaezSS81