### PR TITLE
feat(scripts): db-clean-tests — a scalpel for test residue, not a reset

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,11 +53,20 @@ neon-setup:
 db:
     psql "$DATABASE_URL"
 
-# Remove e2e/test cruft from the DB (sessions, test agents, subscriptions,
-# schedules, bundles). Preserves the tenant, policies, connections, and the
-# seed agents. DRY-RUN by default; pass `apply` to commit. See scripts/db-clean.sh.
+# RESET the DB to seed state — drops ALL sessions, ALL capability bundles
+# (including real ones like `cloudflare`) and every agent outside the keep-list.
+# Preserves the tenant, policies, connections, and registrations. This is a big
+# hammer: for removing only test residue, use `db-clean-tests` instead.
+# DRY-RUN by default; pass `apply` to commit. See scripts/db-clean.sh.
 db-clean *ARGS:
     bash scripts/db-clean.sh {{ARGS}}
+
+# Remove ONLY test-suite residue (fixture agents + their sessions, pmt-bundle-*)
+# by EXACT name — safe to run against a DB with real work in it. Run this after
+# any sanctioned `just check` / `just e2e`, which write fixtures into the real
+# tenant. DRY-RUN by default; pass `apply` to commit. See scripts/db-clean-tests.sh.
+db-clean-tests *ARGS:
+    bash scripts/db-clean-tests.sh {{ARGS}}
 
 # ── Quality ──────────────────────────────────────────────────────────────
 

--- a/scripts/db-clean-tests.sh
+++ b/scripts/db-clean-tests.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# fluidbox db-clean-tests — remove ONLY test-suite residue. A scalpel.
+#
+# Not to be confused with `just db-clean`, which is a RESET: that one drops ALL
+# sessions, ALL capability_bundles (including real ones like `cloudflare`) and
+# every agent outside a keep-list. This script deletes only rows the test suite
+# itself creates, and is safe to run against a database with real work in it.
+#
+# WHY THIS EXISTS: `fluidbox-db` tests call ensure_default_tenant(), so they
+# write fixtures into the SAME tenant as real data (see
+# docs/plans/2026-07-15-test-data-isolation-design.md). Until tests get their
+# own tenant, fixtures can only be identified by exact name.
+#
+# EXACT NAMES, NEVER PATTERNS. `%test%` would delete the real agents
+# `clouflare-test` and `clouflare-mcp-test-resource`. The list below is
+# drift-guarded against the test source: add a fixture agent without listing it
+# here and this script FAILS rather than silently leaving residue behind.
+#
+#   just db-clean-tests           # dry-run — show what WOULD be deleted
+#   just db-clean-tests apply     # actually delete
+set -euo pipefail
+source "$(dirname "$0")/e2e-lib.sh"
+load_env
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APPLY="${1:-}"
+
+# Fixture agents created by crates/fluidbox-db/src/lib.rs tests.
+FIXTURE_AGENTS="'test-seq-agent','test-token-agent','test-intent-agent','test-cap-agent','test-ws-agent','test-del-agent','test-idem-agent','test-sched-agent','test-stale-agent','test-trig-agent','pau-agent','pmt-agent-a','pmt-agent-b'"
+
+# ── Drift guard ────────────────────────────────────────────────────────────
+# Every agent the db tests create must appear above. A new fixture that nobody
+# adds here would otherwise accumulate silently — the exact failure this script
+# exists to stop. Fail loudly instead.
+missing=""
+while read -r n; do
+  [ -z "$n" ] && continue
+  case "$FIXTURE_AGENTS" in *"'$n'"*) ;; *) missing="$missing $n" ;; esac
+done < <(grep -oE 'create_agent\(&pool, tenant, "[^"]+"' "$ROOT/crates/fluidbox-db/src/lib.rs" 2>/dev/null |
+  sed -E 's/.*"([^"]+)"$/\1/' | sort -u)
+if [ -n "$missing" ]; then
+  echo "✗ DRIFT: these agents are created by fluidbox-db tests but are not in FIXTURE_AGENTS:"
+  echo "   $missing"
+  echo "  Add them to scripts/db-clean-tests.sh, then re-run."
+  exit 1
+fi
+
+if [ "$APPLY" = "apply" ]; then
+  END="commit;"; MODE="APPLY (committing)"
+else
+  END="rollback;"; MODE="DRY-RUN (rolling back — pass 'apply' to commit)"
+fi
+echo "fluidbox db-clean-tests — $MODE"
+echo "fixture agents: $FIXTURE_AGENTS"
+echo "fixture bundles: pmt-bundle-%"
+echo
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -P pager=off <<SQL
+\echo '── WILL DELETE ────────────────────────'
+select 'fixture agents' t, count(*) n from agents where name in ($FIXTURE_AGENTS)
+union all select 'their sessions', count(*) from sessions s
+  where s.agent_id in (select id from agents where name in ($FIXTURE_AGENTS))
+union all select 'pmt-bundle-* bundles', count(*) from capability_bundles where name like 'pmt-bundle-%'
+order by 1;
+
+\echo ''
+\echo '── WILL KEEP (everything else) ────────'
+select name, (select count(*) from sessions s where s.agent_id = a.id) as sessions
+from agents a where a.name not in ($FIXTURE_AGENTS) order by name;
+
+begin;
+-- sessions BEFORE agents: sessions.agent_id is NO ACTION, not CASCADE.
+-- Session children (events, approvals, artifacts, usage_entries, api_tokens,
+-- result_deliveries, trigger_invocations) cascade from here.
+delete from sessions
+ where agent_id in (select id from agents where name in ($FIXTURE_AGENTS));
+
+-- Subscriptions also reference agents with NO ACTION.
+delete from trigger_subscriptions
+ where agent_id in (select id from agents where name in ($FIXTURE_AGENTS));
+
+-- agent_revisions cascade from agents.
+delete from agents where name in ($FIXTURE_AGENTS);
+
+-- crates/fluidbox-db/src/lib.rs:4414 mints these as pmt-bundle-{uuid}.
+delete from capability_bundles where name like 'pmt-bundle-%';
+
+\echo ''
+\echo '── AFTER (in-transaction) ─────────────'
+select 'fixture agents' t, count(*) n from agents where name in ($FIXTURE_AGENTS)
+union all select 'pmt-bundle-* bundles', count(*) from capability_bundles where name like 'pmt-bundle-%'
+union all select 'agents remaining', count(*) from agents
+union all select 'sessions remaining', count(*) from sessions
+order by 1;
+$END
+SQL
+
+echo
+if [ "$APPLY" = "apply" ]; then
+  echo "✓ committed — test residue removed."
+else
+  echo "(dry-run only — nothing changed. Re-run: just db-clean-tests apply)"
+fi


### PR DESCRIPTION
fluidbox-db tests call ensure_default_tenant(), so they write fixtures into the SAME tenant as real data and never tear down. Running `cargo test -p fluidbox-db` five times while chasing a flake minted 15 orphan sessions that surfaced on the dashboard as "13 sandboxes running" — they were fixtures with sandbox_handle NULL that the boot-time orphan reaper later marked "stalled before launch".

`just db-clean` cannot be the answer: it is a RESET — it drops ALL sessions, ALL capability_bundles (including the live `cloudflare` bundle) and every agent outside a keep-list. Its docstring in the justfile now says so.

db-clean-tests deletes ONLY fixture rows, by EXACT name. Never patterns: `%test%` would eat the real agents `clouflare-test` and `clouflare-mcp-test-resource` (15 sessions between them).

Drift-guarded: every `create_agent(&pool, tenant, "…")` in the db test suite must appear in FIXTURE_AGENTS or the script FAILS. A hand-kept list that can silently miss a new fixture is the same failure mode as the copy-pasted provider predicate this repo just retired.

Dry-run on the live DB: 32 sessions + 11 fixture agents + 13 pmt-bundle-* + 4 subscriptions removed; all 6 real agents and their 26 sessions untouched; `cloudflare` verified not matched by the predicate.


Claude-Session: https://claude.ai/code/session_016vw74YXS3K5NytVaezSS81

<!-- Thanks for contributing! Small, focused PRs review fastest. -->

## What & why

<!-- What does this change, and what problem does it solve? Link the issue: Fixes #123 -->

## How was this tested?

<!-- e.g. new unit tests in fluidbox-core, `just check`, `just e2e`, manual run via CLI/dashboard -->

## Checklist

- [ ] `just check` passes (fmt, clippy `-D warnings`, tests, web build)
- [ ] Touched the permission/approval/trigger path → ran `just e2e`
- [ ] Behavior change → tests added/updated
- [ ] User-visible change → `CHANGELOG.md` (Unreleased) and docs updated
- [ ] Architectural change → preserves the convergence invariants (`PLAN.md` §2)
- [ ] No secrets in code, tests, fixtures, or logs
