### PR TITLE
K8s Phase 0 — provider seam + collection hardening (Docker-only) (#49)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "bollard",
  "chrono",
  "fluidbox-core",
+ "fluidbox-workspace",
  "futures",
  "serde",
  "serde_json",
@@ -981,6 +982,7 @@ dependencies = [
  "fluidbox-core",
  "fluidbox-db",
  "fluidbox-provider",
+ "fluidbox-workspace",
  "futures",
  "getrandom 0.3.4",
  "hex",
@@ -998,6 +1000,17 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "fluidbox-workspace"
+version = "0.1.0"
+dependencies = [
+ "fluidbox-core",
+ "hex",
+ "sha2 0.11.0",
+ "thiserror",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/fluidbox-core",
     "crates/fluidbox-db",
+    "crates/fluidbox-workspace",
     "crates/fluidbox-provider",
     "crates/fluidbox-server",
     "crates/fluidbox-cli",
@@ -18,6 +19,7 @@ repository = "https://github.com/hrishikeshdkakkad/fluidbox"
 [workspace.dependencies]
 fluidbox-core = { path = "crates/fluidbox-core" }
 fluidbox-db = { path = "crates/fluidbox-db" }
+fluidbox-workspace = { path = "crates/fluidbox-workspace" }
 fluidbox-provider = { path = "crates/fluidbox-provider" }
 
 anyhow = "1"

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1734,6 +1734,24 @@ a.row:hover,
 .pill.awaiting_approval .dot {
   background: var(--amber);
 }
+/* Wind-down states: the run is finishing (collecting its diff) or cancelling.
+   Amber like awaiting_approval, with the running dot's pulse to read as
+   in-progress rather than terminal. */
+.pill.cancelling,
+.pill.finalizing {
+  color: var(--amber);
+}
+.pill.cancelling .dot,
+.pill.finalizing .dot {
+  background: var(--amber);
+  animation: blink 1.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pill.cancelling .dot,
+  .pill.finalizing .dot {
+    animation: none;
+  }
+}
 .pill.completed {
   color: var(--green);
 }

--- a/apps/web/app/sessions/[id]/page.tsx
+++ b/apps/web/app/sessions/[id]/page.tsx
@@ -451,6 +451,34 @@ function TimelineItem({ ev }: { ev: EventRow }) {
       );
       break;
     }
+    case "run.quiesce_requested":
+      tag = "cancel";
+      body = (
+        <span className="mut">
+          quiesce requested — waiting {s("deadline_secs")}s for the runner to stop
+        </span>
+      );
+      break;
+    case "artifact.collected":
+      tag = "artifact";
+      body = (
+        <>
+          collected <span className="em">{s("name")}</span>{" "}
+          <span className="mut">
+            ({s("bytes")} bytes{d.truncated ? ", truncated" : ""})
+          </span>
+        </>
+      );
+      break;
+    case "artifact.missing":
+      cls = "danger";
+      tag = "artifact";
+      body = (
+        <>
+          {s("kind")} not collected <span className="mut">· {s("reason")}</span>
+        </>
+      );
+      break;
   }
 
   return (

--- a/crates/fluidbox-core/src/event.rs
+++ b/crates/fluidbox-core/src/event.rs
@@ -113,6 +113,24 @@ pub enum EventBody {
     /// is the authoritative copy). `bundles` are "name@version" strings.
     #[serde(rename = "capability.frozen")]
     CapabilitiesFrozen { bundles: Vec<String>, tools: u64 },
+    /// Terminal artifact collection metadata — size/digest/truncation only,
+    /// never payloads (the artifact row holds the content).
+    #[serde(rename = "artifact.collected")]
+    ArtifactCollected {
+        kind: String,
+        name: String,
+        bytes: u64,
+        sha256: String,
+        truncated: bool,
+    },
+    /// EXPLICIT not-collected marker (design 2026-07-15): a diff that could
+    /// not be collected is never silently reported as "(no changes)".
+    #[serde(rename = "artifact.missing")]
+    ArtifactMissing { kind: String, reason: String },
+    /// Cancellation quiesce signal requested; delivered to the runner via
+    /// the heartbeat response ({"action":"quiesce"}).
+    #[serde(rename = "run.quiesce_requested")]
+    QuiesceRequested { deadline_secs: u64 },
     /// One brokered tool execution: the control plane turned the sealed
     /// credential server-side. Identity, status, latency, result digest —
     /// never inputs, outputs, or secrets.

--- a/crates/fluidbox-core/src/state.rs
+++ b/crates/fluidbox-core/src/state.rs
@@ -3,6 +3,14 @@ use serde::{Deserialize, Serialize};
 /// Session lifecycle. `initializing` is the post-startup init phase: the
 /// sandbox is up but the agent has not started — the orchestrator
 /// materializes the workspace there, so init failures cost zero model spend.
+///
+/// `cancelling` and `finalizing` are the wind-down states (design
+/// 2026-07-15, Phase 0): real, persisted, visible in the audit trail.
+/// `cancelling` = waiting for the runner to quiesce (heartbeat-response
+/// signal, 30 s deadline); `finalizing` = terminal artifact collection in
+/// progress. EVERY terminal path rides them — the transition matrix has no
+/// direct active→terminal edge, which is what makes "collect before
+/// terminal" structural rather than disciplinary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStatus {
@@ -11,6 +19,8 @@ pub enum SessionStatus {
     Initializing,
     Running,
     AwaitingApproval,
+    Cancelling,
+    Finalizing,
     Completed,
     Failed,
     Cancelled,
@@ -25,6 +35,8 @@ impl SessionStatus {
             Self::Initializing => "initializing",
             Self::Running => "running",
             Self::AwaitingApproval => "awaiting_approval",
+            Self::Cancelling => "cancelling",
+            Self::Finalizing => "finalizing",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
@@ -39,6 +51,8 @@ impl SessionStatus {
             "initializing" => Self::Initializing,
             "running" => Self::Running,
             "awaiting_approval" => Self::AwaitingApproval,
+            "cancelling" => Self::Cancelling,
+            "finalizing" => Self::Finalizing,
             "completed" => Self::Completed,
             "failed" => Self::Failed,
             "cancelled" => Self::Cancelled,
@@ -54,6 +68,19 @@ impl SessionStatus {
         )
     }
 
+    /// On the way out: the durable finalizer owns the session. The facade,
+    /// permission gate, broker, and token renew all refuse new work here —
+    /// same as terminal, but the terminal transition (and its delivery
+    /// enqueue) hasn't happened yet because collection hasn't finished.
+    pub fn is_winding_down(&self) -> bool {
+        matches!(self, Self::Cancelling | Self::Finalizing)
+    }
+
+    /// Accepting new agent work (facade calls, tool decisions, renewals).
+    pub fn accepts_work(&self) -> bool {
+        !self.is_terminal() && !self.is_winding_down()
+    }
+
     /// The server is the single status writer; every write goes through this.
     pub fn can_transition_to(&self, next: SessionStatus) -> bool {
         use SessionStatus::*;
@@ -63,30 +90,43 @@ impl SessionStatus {
         matches!(
             (self, next),
             (Created, Provisioning)
-                | (Created, Failed)
-                | (Created, Cancelled)
                 | (Provisioning, Initializing)
-                | (Provisioning, Failed)
-                | (Provisioning, Cancelled)
                 | (Initializing, Running)
-                | (Initializing, Failed)
-                | (Initializing, Cancelled)
                 | (Running, AwaitingApproval)
-                | (Running, Completed)
-                | (Running, Failed)
-                | (Running, Cancelled)
-                | (Running, BudgetExceeded)
                 | (AwaitingApproval, Running)
-                | (AwaitingApproval, Failed)
-                | (AwaitingApproval, Cancelled)
-                | (AwaitingApproval, BudgetExceeded)
+                // Wind-down entry: any active state can begin cancelling or
+                // finalizing (crash recovery must be able to finalize a
+                // session wherever the control plane left it).
+                | (
+                    Created | Provisioning | Initializing | Running | AwaitingApproval,
+                    Cancelling | Finalizing,
+                )
+                // Quiesce resolved (runner stopped or deadline passed) →
+                // collection phase.
+                | (Cancelling, Finalizing)
+                // Escape hatch: a finalizer that exhausts its retries can
+                // terminalize from either wind-down state.
+                | (Cancelling, Failed)
+                // Collection done (or explicitly recorded missing) → the ONLY
+                // door to terminal states. Delivery enqueue rides terminal
+                // entry, so it structurally cannot race the artifact.
+                | (Finalizing, Completed | Failed | Cancelled | BudgetExceeded)
         )
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SessionStatus::*;
+    use super::SessionStatus::{self, *};
+
+    const ACTIVE: [SessionStatus; 5] = [
+        Created,
+        Provisioning,
+        Initializing,
+        Running,
+        AwaitingApproval,
+    ];
+    const TERMINAL: [SessionStatus; 4] = [Completed, Failed, Cancelled, BudgetExceeded];
 
     #[test]
     fn happy_path_transitions() {
@@ -95,29 +135,71 @@ mod tests {
         assert!(Initializing.can_transition_to(Running));
         assert!(Running.can_transition_to(AwaitingApproval));
         assert!(AwaitingApproval.can_transition_to(Running));
-        assert!(Running.can_transition_to(Completed));
+        assert!(Running.can_transition_to(Finalizing));
+        assert!(Finalizing.can_transition_to(Completed));
     }
 
     #[test]
     fn terminal_states_are_sticky() {
-        for s in [Completed, Failed, Cancelled, BudgetExceeded] {
+        for s in TERMINAL {
             assert!(!s.can_transition_to(Running));
             assert!(!s.can_transition_to(Failed));
+            assert!(!s.can_transition_to(Finalizing));
         }
     }
 
     #[test]
-    fn any_nonterminal_state_can_fail() {
-        // A crashed control plane must be able to fail a session wherever
-        // it was left — Created included (the stalled-launch sweep).
-        for s in [
-            Created,
-            Provisioning,
-            Initializing,
-            Running,
-            AwaitingApproval,
-        ] {
-            assert!(s.can_transition_to(Failed), "{s:?} must be able to fail");
+    fn no_direct_terminal_entry() {
+        // Collect-before-terminal is STRUCTURAL: the only way into a
+        // terminal state is through `finalizing` (or `cancelling → failed`
+        // for the give-up path). A code path that forgets collection cannot
+        // reach terminal.
+        for s in ACTIVE {
+            for t in TERMINAL {
+                assert!(
+                    !s.can_transition_to(t),
+                    "{s:?} must not reach {t:?} without finalizing"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_nonterminal_can_reach_failed() {
+        // A crashed control plane must be able to fail a session wherever it
+        // was left — via the wind-down path (≤2 hops).
+        for s in ACTIVE {
+            assert!(s.can_transition_to(Finalizing), "{s:?} must wind down");
+        }
+        assert!(Cancelling.can_transition_to(Failed));
+        assert!(Cancelling.can_transition_to(Finalizing));
+        assert!(Finalizing.can_transition_to(Failed));
+    }
+
+    #[test]
+    fn cancel_rides_cancelling() {
+        for s in ACTIVE {
+            assert!(s.can_transition_to(Cancelling), "{s:?} must be cancellable");
+        }
+        // …but the terminal `cancelled` only lands after collection.
+        assert!(!Cancelling.can_transition_to(Cancelled));
+        assert!(Finalizing.can_transition_to(Cancelled));
+    }
+
+    #[test]
+    fn winding_down_refuses_new_work() {
+        for s in [Cancelling, Finalizing] {
+            assert!(s.is_winding_down());
+            assert!(!s.accepts_work());
+            assert!(!s.is_terminal());
+            assert!(!s.can_transition_to(Running));
+            assert!(!s.can_transition_to(AwaitingApproval));
+        }
+        for s in ACTIVE {
+            assert!(s.accepts_work());
+        }
+        for s in TERMINAL {
+            assert!(!s.accepts_work());
         }
     }
 
@@ -135,6 +217,8 @@ mod tests {
             Initializing,
             Running,
             AwaitingApproval,
+            Cancelling,
+            Finalizing,
             Completed,
             Failed,
             Cancelled,

--- a/crates/fluidbox-core/src/traits.rs
+++ b/crates/fluidbox-core/src/traits.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 
 /// Serializable descriptor of a live sandbox. Persisted as jsonb — never a
 /// live client — so the control plane can reattach after a restart, and so
-/// the same shape fits Docker (`container_id`) and Lambda MicroVMs
-/// (`microvm_id` + endpoint + lease).
+/// the same shape fits Docker (`container_id`) and Kubernetes
+/// (`pod name` + namespace + uid).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxHandle {
     pub runtime: String,
@@ -24,7 +24,8 @@ pub struct SandboxSpec {
     pub image: String,
     pub env: Vec<(String, String)>,
     /// Host workspace directory to mount at /workspace (provider-internal
-    /// optimization; MicroVM providers push an archive instead).
+    /// optimization; archive-based providers pull an immutable archive
+    /// instead).
     pub workspace_host_dir: Option<String>,
     pub network: NetworkMode,
 }
@@ -41,22 +42,108 @@ pub enum NetworkMode {
     Hardened,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SandboxState {
-    Running,
-    Exited(i64),
-    Gone,
+impl NetworkMode {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "host-dev" => Some(Self::HostDev),
+            "hardened" => Some(Self::Hardened),
+            _ => None,
+        }
+    }
 }
 
-/// Where sandboxes physically run. Docker in M1; Lambda MicroVMs in M2.
+/// Structured sandbox state (trait v2). The `reason` strings are provider
+/// vocabulary (ImagePullBackOff, OOMKilled, "no such container"…) — they let
+/// the orchestrator ledger a *specific* death instead of a generic one, and
+/// are informational, never parsed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxStatus {
+    /// Created but not yet running (scheduling, image pull, secret wait…).
+    Pending {
+        reason: Option<String>,
+    },
+    Running,
+    /// Ran and exited; exit code when the runtime still knows it.
+    Terminated {
+        exit_code: Option<i64>,
+        reason: Option<String>,
+    },
+    /// The sandbox object no longer exists or its state cannot be
+    /// determined (removed container, deleted pod, lost node).
+    Unknown {
+        reason: Option<String>,
+    },
+}
+
+impl SandboxStatus {
+    /// Still occupying (or about to occupy) compute. A live sandbox's
+    /// worktree may be racing — collection must wait for !is_live().
+    pub fn is_live(&self) -> bool {
+        matches!(self, Self::Pending { .. } | Self::Running)
+    }
+
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Pending { reason } | Self::Unknown { reason } => reason.as_deref(),
+            Self::Terminated { reason, .. } => reason.as_deref(),
+            Self::Running => None,
+        }
+    }
+}
+
+/// What a provider needs, beyond the handle, to collect a session's
+/// terminal artifacts.
+#[derive(Debug, Clone)]
+pub struct CollectContext {
+    pub session_id: Uuid,
+    pub base_commit: Option<String>,
+}
+
+/// One bounded, collected artifact payload. `sha256`/`bytes` describe the
+/// stored content (post-truncation when `truncated`).
+#[derive(Debug, Clone)]
+pub struct CollectedArtifact {
+    pub kind: String,
+    pub name: String,
+    pub content: String,
+    pub content_type: String,
+    pub truncated: bool,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+/// Outcome of `collect_artifacts`. `Missing` is EXPLICIT by design: a diff
+/// that could not be collected is never silently reported as "(no changes)".
+/// `Collected(vec![])` means collection ran and the worktree was clean.
+#[derive(Debug)]
+pub enum CollectedArtifacts {
+    Collected(Vec<CollectedArtifact>),
+    Missing { reason: String },
+}
+
+/// Where sandboxes physically run. Docker today; Kubernetes lands beside it
+/// (dual-provider permanence — Docker is never replaced).
 #[async_trait]
 pub trait ExecutionProvider: Send + Sync {
     async fn provision(&self, spec: &SandboxSpec) -> Result<SandboxHandle, ProviderError>;
-    async fn state(&self, handle: &SandboxHandle) -> Result<SandboxState, ProviderError>;
+    async fn state(&self, handle: &SandboxHandle) -> Result<SandboxStatus, ProviderError>;
+    /// Collect terminal artifacts (the diff) for a session — bounded in time
+    /// and size, NEVER executing git against agent-controlled `.git` state.
+    /// `handle` is None when the session never got a sandbox; providers with
+    /// control-plane-side transports (Docker's host dir) may still collect.
+    async fn collect_artifacts(
+        &self,
+        handle: Option<&SandboxHandle>,
+        ctx: &CollectContext,
+    ) -> Result<CollectedArtifacts, ProviderError>;
+    /// Idempotent, precondition-guarded teardown.
     async fn terminate(&self, handle: &SandboxHandle) -> Result<(), ProviderError>;
-    /// Reap every sandbox this provider ever made for fluidbox (boot-time
-    /// orphan sweep); returns the session ids found.
-    async fn list_orphans(&self) -> Result<Vec<(Uuid, SandboxHandle)>, ProviderError>;
+    /// Every sandbox this provider manages for fluidbox (boot-time sweep +
+    /// reconciliation); returns the session ids found.
+    async fn list_managed(&self) -> Result<Vec<(Uuid, SandboxHandle)>, ProviderError>;
+    /// Non-fatal readiness probe: is the runtime reachable? Feeds boot
+    /// logging and /health/ready — never gates startup.
+    async fn healthcheck(&self) -> Result<(), ProviderError>;
     fn runtime_name(&self) -> &'static str;
 }
 

--- a/crates/fluidbox-db/src/lib.rs
+++ b/crates/fluidbox-db/src/lib.rs
@@ -1762,6 +1762,168 @@ pub async fn heartbeat(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
     Ok(())
 }
 
+// ─── Durable finalization intent (K8s design 2026-07-15, migration 0011) ──
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct FinalizationRow {
+    pub session_id: Uuid,
+    pub outcome: String,
+    pub summary: Option<String>,
+    pub reason: Option<String>,
+    pub needs_quiesce: bool,
+    pub quiesce_deadline: Option<DateTime<Utc>>,
+    pub claimed_at: Option<DateTime<Utc>>,
+    pub attempts: i32,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Persist the intent to finalize a session (idempotent). Returns true iff
+/// THIS call created the row — the first writer wins the outcome; a racing
+/// second caller (e.g. /result and the wall-clock sweeper firing together)
+/// gets false and defers to the recorded intent.
+#[allow(clippy::too_many_arguments)]
+pub async fn begin_finalization(
+    pool: &PgPool,
+    session: Uuid,
+    outcome: &str,
+    summary: Option<&str>,
+    reason: Option<&str>,
+    needs_quiesce: bool,
+    quiesce_deadline: Option<DateTime<Utc>>,
+) -> sqlx::Result<bool> {
+    let r = sqlx::query(
+        "insert into session_finalizations
+           (session_id, outcome, summary, reason, needs_quiesce, quiesce_deadline)
+         values ($1,$2,$3,$4,$5,$6)
+         on conflict (session_id) do nothing",
+    )
+    .bind(session)
+    .bind(outcome)
+    .bind(summary)
+    .bind(reason)
+    .bind(needs_quiesce)
+    .bind(quiesce_deadline)
+    .execute(pool)
+    .await?;
+    Ok(r.rows_affected() == 1)
+}
+
+pub async fn get_finalization(
+    pool: &PgPool,
+    session: Uuid,
+) -> sqlx::Result<Option<FinalizationRow>> {
+    sqlx::query_as("select * from session_finalizations where session_id = $1")
+        .bind(session)
+        .fetch_optional(pool)
+        .await
+}
+
+/// Claim a finalization for driving: succeeds when the row is unclaimed OR its
+/// claim went stale (the previous driver crashed). Bumps `attempts` and stamps
+/// `claimed_at`. A concurrent driver that loses the CAS gets None and backs
+/// off — the finalizing→terminal transition is the ultimate single-winner
+/// gate regardless, so a double-claim can never double-finalize.
+pub async fn claim_finalization(
+    pool: &PgPool,
+    session: Uuid,
+    stale_secs: i64,
+) -> sqlx::Result<Option<FinalizationRow>> {
+    sqlx::query_as(
+        "update session_finalizations
+            set claimed_at = now(), attempts = attempts + 1
+          where session_id = $1
+            and (claimed_at is null or claimed_at < now() - make_interval(secs => $2))
+          returning *",
+    )
+    .bind(session)
+    .bind(stale_secs as f64)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Sessions with a persisted finalization intent whose session is still
+/// winding down (cancelling/finalizing) — the restart-recovery + orphan sweep
+/// worklist. Ordered oldest-first so a backlog drains fairly.
+pub async fn pending_finalizations(pool: &PgPool) -> sqlx::Result<Vec<Uuid>> {
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "select f.session_id from session_finalizations f
+           join sessions s on s.id = f.session_id
+          where s.status in ('cancelling','finalizing')
+          order by f.created_at asc",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
+pub async fn delete_finalization(pool: &PgPool, session: Uuid) -> sqlx::Result<()> {
+    sqlx::query("delete from session_finalizations where session_id = $1")
+        .bind(session)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+// ─── Cross-replica OAuth refresh serialization (K8s design 2026-07-15) ─────
+
+/// Stable 64-bit advisory-lock key from a connection id. Postgres advisory
+/// locks are keyed on `bigint`; we fold the uuid's leading 8 bytes.
+pub fn oauth_lock_key(connection_id: Uuid) -> i64 {
+    let b = connection_id.as_bytes();
+    i64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
+}
+
+/// Take a transaction-scoped Postgres advisory lock keyed on a connection id,
+/// on `tx`. Serializes OAuth refresh-token rotation ACROSS control-plane
+/// replicas (a second replica can no longer double-rotate a refresh token
+/// into `invalid_grant`) — replacing reliance on the in-process mutex. The
+/// lock releases automatically when `tx` is committed or dropped, so the
+/// caller holds `tx` across the refresh HTTP round-trip and the rotation
+/// write, then commits.
+pub async fn acquire_oauth_lock(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    connection_id: Uuid,
+) -> sqlx::Result<()> {
+    sqlx::query("select pg_advisory_xact_lock($1)")
+        .bind(oauth_lock_key(connection_id))
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Idempotent artifact write: a crash-retry during finalization must not
+/// accumulate duplicate diff rows. Replaces any existing (session, kind, name).
+pub async fn upsert_artifact(
+    pool: &PgPool,
+    session: Uuid,
+    kind: &str,
+    name: &str,
+    content: &str,
+    content_type: &str,
+) -> sqlx::Result<ArtifactRow> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("delete from artifacts where session_id = $1 and kind = $2 and name = $3")
+        .bind(session)
+        .bind(kind)
+        .bind(name)
+        .execute(&mut *tx)
+        .await?;
+    let row: ArtifactRow = sqlx::query_as(
+        "insert into artifacts (id, session_id, kind, name, content, content_type)
+         values ($1,$2,$3,$4,$5,$6) returning *",
+    )
+    .bind(Uuid::now_v7())
+    .bind(session)
+    .bind(kind)
+    .bind(name)
+    .bind(content)
+    .bind(content_type)
+    .fetch_one(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(row)
+}
+
 // ─── Events (append-only; Redacted enforced at the type level) ────────────
 
 pub async fn append_event(pool: &PgPool, event: Redacted<EventEnvelope>) -> sqlx::Result<i64> {

--- a/crates/fluidbox-provider/Cargo.toml
+++ b/crates/fluidbox-provider/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 fluidbox-core.workspace = true
+fluidbox-workspace.workspace = true
 bollard.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/fluidbox-provider/src/lib.rs
+++ b/crates/fluidbox-provider/src/lib.rs
@@ -1,11 +1,13 @@
-//! fluidbox-provider — the Docker ExecutionProvider (M1).
+//! fluidbox-provider — the Docker ExecutionProvider (M1), the reference
+//! trait-v2 implementation and permanently-supported default backend.
 //!
 //! Sandboxes are plain containers, labelled so a boot-time sweep can reap
 //! orphans. The `SandboxHandle` persisted to the DB carries only the
 //! container id + network name, so the control plane can reattach after a
 //! restart. Workspace materialization is done control-plane-side (see
-//! `workspace`); the container only ever sees a copy bind-mounted at
-//! /workspace.
+//! `fluidbox_workspace`); the container only ever sees a copy bind-mounted at
+//! /workspace. Diff collection runs against the PRISTINE baseline via the
+//! shared `fluidbox-workspace` engine — never against the agent's `.git`.
 
 use async_trait::async_trait;
 use bollard::models::{ContainerCreateBody, HostConfig, NetworkCreateRequest};
@@ -15,24 +17,33 @@ use bollard::query_parameters::{
 };
 use bollard::Docker;
 use fluidbox_core::traits::{
-    ExecutionProvider, NetworkMode, ProviderError, SandboxHandle, SandboxSpec, SandboxState,
+    CollectContext, CollectedArtifact, CollectedArtifacts, ExecutionProvider, NetworkMode,
+    ProviderError, SandboxHandle, SandboxSpec, SandboxStatus,
 };
+use fluidbox_workspace::collect::{collect_diff, CollectionOutcome, DiffCaps};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use uuid::Uuid;
 
-pub mod workspace;
+/// Re-export so existing call sites (`fluidbox_provider::workspace::…`) keep
+/// working; the implementation now lives in the shared crate.
+pub use fluidbox_workspace as workspace;
 
 const SESSION_LABEL: &str = "fluidbox.session";
 const MANAGED_LABEL: &str = "fluidbox.managed";
 
 pub struct DockerProvider {
     docker: Docker,
+    /// `<data_dir>/workspaces` root, so `collect_artifacts` can find each
+    /// session's pristine baseline + worktree (Docker's collection transport
+    /// is the host dir, not `pods/exec`).
+    data_dir: PathBuf,
 }
 
 impl DockerProvider {
-    pub fn connect() -> anyhow::Result<Self> {
+    pub fn connect(data_dir: PathBuf) -> anyhow::Result<Self> {
         let docker = Docker::connect_with_local_defaults()?;
-        Ok(Self { docker })
+        Ok(Self { docker, data_dir })
     }
 
     pub async fn ping(&self) -> anyhow::Result<()> {
@@ -132,7 +143,7 @@ impl ExecutionProvider for DockerProvider {
         })
     }
 
-    async fn state(&self, handle: &SandboxHandle) -> Result<SandboxState, ProviderError> {
+    async fn state(&self, handle: &SandboxHandle) -> Result<SandboxStatus, ProviderError> {
         match self
             .docker
             .inspect_container(&handle.external_id, None::<InspectContainerOptions>)
@@ -141,14 +152,49 @@ impl ExecutionProvider for DockerProvider {
             Ok(info) => {
                 let st = info.state.unwrap_or_default();
                 if st.running.unwrap_or(false) {
-                    Ok(SandboxState::Running)
+                    Ok(SandboxStatus::Running)
                 } else {
-                    Ok(SandboxState::Exited(st.exit_code.unwrap_or(0)))
+                    Ok(SandboxStatus::Terminated {
+                        exit_code: st.exit_code,
+                        reason: st.error.filter(|e| !e.is_empty()),
+                    })
                 }
             }
-            Err(e) if e.to_string().contains("No such container") => Ok(SandboxState::Gone),
+            Err(e) if e.to_string().contains("No such container") => Ok(SandboxStatus::Unknown {
+                reason: Some("no such container".into()),
+            }),
             Err(e) => Err(map_err(e)),
         }
+    }
+
+    async fn collect_artifacts(
+        &self,
+        _handle: Option<&SandboxHandle>,
+        ctx: &CollectContext,
+    ) -> Result<CollectedArtifacts, ProviderError> {
+        // Docker's transport is the host workspace dir; the collection engine
+        // (pristine baseline + scrubbed git) is shared with every provider.
+        // Runs in a blocking pool: git subprocess + fs I/O.
+        let root = fluidbox_workspace::session_workspace_root(&self.data_dir, ctx.session_id);
+        let base = ctx.base_commit.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            collect_diff(&root, base.as_deref(), &DiffCaps::default())
+        })
+        .await
+        .map_err(|e| ProviderError::Other(format!("collection task panicked: {e}")))?;
+
+        Ok(match outcome {
+            CollectionOutcome::Diff(d) => CollectedArtifacts::Collected(vec![CollectedArtifact {
+                kind: "diff".into(),
+                name: "changes.patch".into(),
+                content: d.patch,
+                content_type: "text/x-diff".into(),
+                truncated: d.truncated,
+                sha256: d.sha256,
+                bytes: d.bytes,
+            }]),
+            CollectionOutcome::Missing { reason } => CollectedArtifacts::Missing { reason },
+        })
     }
 
     async fn terminate(&self, handle: &SandboxHandle) -> Result<(), ProviderError> {
@@ -171,7 +217,7 @@ impl ExecutionProvider for DockerProvider {
         Ok(())
     }
 
-    async fn list_orphans(&self) -> Result<Vec<(Uuid, SandboxHandle)>, ProviderError> {
+    async fn list_managed(&self) -> Result<Vec<(Uuid, SandboxHandle)>, ProviderError> {
         let mut filters: HashMap<String, Vec<String>> = HashMap::new();
         filters.insert("label".to_string(), vec![format!("{MANAGED_LABEL}=1")]);
         let opts = ListContainersOptionsBuilder::new()
@@ -207,6 +253,10 @@ impl ExecutionProvider for DockerProvider {
             ));
         }
         Ok(out)
+    }
+
+    async fn healthcheck(&self) -> Result<(), ProviderError> {
+        self.docker.ping().await.map(|_| ()).map_err(map_err)
     }
 
     fn runtime_name(&self) -> &'static str {

--- a/crates/fluidbox-server/Cargo.toml
+++ b/crates/fluidbox-server/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 fluidbox-core.workspace = true
 fluidbox-db.workspace = true
+fluidbox-workspace.workspace = true
 fluidbox-provider.workspace = true
 axum.workspace = true
 tower-http.workspace = true

--- a/crates/fluidbox-server/src/api.rs
+++ b/crates/fluidbox-server/src/api.rs
@@ -271,10 +271,13 @@ pub async fn health() -> Json<Value> {
 
 pub async fn health_ready(State(state): State<AppState>) -> ApiResult<Json<Value>> {
     sqlx::query("select 1").execute(&state.pool).await?;
-    let docker_ok = state.provider.ping().await.is_ok();
-    Ok(Json(
-        json!({ "status": "ready", "db": true, "docker": docker_ok }),
-    ))
+    let provider_ok = state.provider.healthcheck().await.is_ok();
+    Ok(Json(json!({
+        "status": "ready",
+        "db": true,
+        "provider": state.provider.runtime_name(),
+        "provider_ok": provider_ok,
+    })))
 }
 
 // ─── Agents & revisions ───────────────────────────────────────────────────

--- a/crates/fluidbox-server/src/config.rs
+++ b/crates/fluidbox-server/src/config.rs
@@ -52,7 +52,21 @@ pub struct Config {
     /// Feeds the OAuth redirect_uri and the CIMD client_id document — both
     /// are fetched by parties that can't use host.docker.internal.
     pub public_url: String,
+    /// Execution backend: `docker` (default) or `kubernetes`. Selects which
+    /// `ExecutionProvider` `AppState.provider` holds. Dual-provider permanence
+    /// (settled Q17): Docker is never replaced.
+    pub provider: String,
+    /// Sandbox network mode, config-derived instead of hardcoded
+    /// (`host-dev` default; `hardened` = zero external egress). Was pinned to
+    /// HostDev at `orchestrator.rs:150`.
+    pub network_mode: fluidbox_core::traits::NetworkMode,
 }
+
+/// Serialized runner-env ceiling: env injection is the v1 config channel
+/// (authenticated fetch is the designated v1.1 follow-up), and Kubernetes
+/// caps a Secret/env at ~1 MiB. 512 KiB leaves headroom and fails a bloated
+/// run closed at zero model spend rather than at an opaque kubelet error.
+pub const MAX_RUNNER_ENV_BYTES: usize = 512 * 1024;
 
 impl Config {
     pub fn from_env() -> anyhow::Result<Self> {
@@ -104,6 +118,13 @@ impl Config {
                 .unwrap_or_else(|_| "http://127.0.0.1:8787".into())
                 .trim_end_matches('/')
                 .to_string(),
+            provider: get("FLUIDBOX_PROVIDER")
+                .unwrap_or_else(|_| "docker".into())
+                .to_lowercase(),
+            network_mode: get("FLUIDBOX_NETWORK_MODE")
+                .ok()
+                .and_then(|s| fluidbox_core::traits::NetworkMode::parse(&s.to_lowercase()))
+                .unwrap_or_default(),
         })
     }
 }

--- a/crates/fluidbox-server/src/facade.rs
+++ b/crates/fluidbox-server/src/facade.rs
@@ -243,7 +243,9 @@ pub async fn messages(
     let session = fluidbox_db::get_session(&state.pool, session_id)
         .await?
         .ok_or(ApiError::NotFound)?;
-    if session.status_enum().is_terminal() {
+    // No model spend for a terminal OR winding-down run — the budget stop and
+    // the finalizer both rely on the facade refusing once a run is over.
+    if !session.status_enum().accepts_work() {
         return Ok(dialect_error(
             shape_hint(&rest),
             StatusCode::BAD_REQUEST,

--- a/crates/fluidbox-server/src/harness.rs
+++ b/crates/fluidbox-server/src/harness.rs
@@ -169,6 +169,8 @@ mod tests {
             github_clone_base: String::new(),
             keep_workspaces: false,
             public_url: String::new(),
+            provider: "docker".into(),
+            network_mode: fluidbox_core::traits::NetworkMode::HostDev,
         }
     }
 

--- a/crates/fluidbox-server/src/internal.rs
+++ b/crates/fluidbox-server/src/internal.rs
@@ -490,9 +490,10 @@ pub async fn permission(
     let session = fluidbox_db::get_session(&state.pool, auth.session_id)
         .await?
         .ok_or(ApiError::NotFound)?;
-    // A terminal session never gets a fresh decision — the primary guard,
-    // independent of token revocation (which is best-effort defense in depth).
-    if session.status_enum().is_terminal() {
+    // A terminal OR winding-down session never gets a fresh decision — the
+    // primary guard, independent of token revocation (which is best-effort
+    // defense in depth). A run being finalized/cancelled admits no new tools.
+    if !session.status_enum().accepts_work() {
         return Ok(Json(json!({
             "decision": "deny",
             "message": "session is not active",
@@ -542,7 +543,7 @@ pub async fn tool_call(
     let session = fluidbox_db::get_session(&state.pool, auth.session_id)
         .await?
         .ok_or(ApiError::NotFound)?;
-    if session.status_enum().is_terminal() {
+    if !session.status_enum().accepts_work() {
         return Err(ApiError::BadRequest("session is not active".into()));
     }
     let run_spec: RunSpec = serde_json::from_value(session.run_spec.clone())
@@ -755,7 +756,16 @@ pub async fn events(
 
 pub async fn heartbeat(auth: SessionAuth, State(state): State<AppState>) -> ApiResult<Json<Value>> {
     fluidbox_db::heartbeat(&state.pool, auth.session_id).await?;
-    Ok(Json(json!({ "ok": true })))
+    // Quiesce channel (the ONLY runner-contract change in the K8s design):
+    // once a session enters `cancelling`, its heartbeat response carries
+    // {"action":"quiesce"} — the runner stops the agent and exits WITHOUT
+    // posting /result, so the cancel finalizer collects a settled worktree.
+    // Level-triggered: every heartbeat repeats it until the runner exits.
+    let action = match fluidbox_db::get_session(&state.pool, auth.session_id).await? {
+        Some(s) if s.status_enum() == SessionStatus::Cancelling => Some("quiesce"),
+        _ => None,
+    };
+    Ok(Json(json!({ "ok": true, "action": action })))
 }
 
 #[derive(Deserialize)]
@@ -786,8 +796,15 @@ pub async fn result(
     let session = fluidbox_db::get_session(&state.pool, session_id)
         .await?
         .ok_or(ApiError::NotFound)?;
-    if session.status_enum().is_terminal() {
+    let st = session.status_enum();
+    if st.is_terminal() {
         return Ok(Json(json!({ "ok": true, "note": "already terminal" })));
+    }
+    // Already winding down: a cancel (or a prior /result) owns finalization —
+    // ACK idempotently and let it complete. A quiesced runner shouldn't even
+    // reach here, but a racing /result must never override the cancel outcome.
+    if st.is_winding_down() {
+        return Ok(Json(json!({ "ok": true, "note": "finalizing" })));
     }
     // Non-terminal: the token must still be live to drive a finalize (revoke
     // only happens on terminal, so this is the ordinary first-post path).
@@ -797,10 +814,10 @@ pub async fn result(
     {
         return Err(ApiError::Unauthorized);
     }
-    let state2 = state.clone();
-    tokio::spawn(async move {
-        orchestrator::finalize(&state2, &session, &res.outcome, res.summary.as_deref()).await;
-    });
+    // Persist the finalization intent and enter `finalizing` BEFORE ACKing
+    // (fixes the lossy ACK-then-`tokio::spawn`): a crash after this point is
+    // recovered by the finalize worker. `finalize` spawns the driver itself.
+    orchestrator::finalize(&state, &session, &res.outcome, res.summary.as_deref()).await;
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -829,9 +846,9 @@ pub async fn token_renew(
     let session = fluidbox_db::get_session(&state.pool, auth.session_id)
         .await?
         .ok_or(ApiError::NotFound)?;
-    if session.status_enum().is_terminal() {
+    if !session.status_enum().accepts_work() {
         return Err(ApiError::BadRequest(
-            "session is terminal — token cannot be renewed".into(),
+            "session is not active — token cannot be renewed".into(),
         ));
     }
     let ttl = req.ttl_secs.clamp(1, MAX_RENEW_TTL_SECS);

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -27,10 +27,25 @@ mod workers;
 
 use axum::routing::{get, post, put};
 use axum::Router;
+use fluidbox_core::traits::ExecutionProvider;
 use state::{AppStateInner, ApprovalRegistry};
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
+
+/// Select the execution backend from `FLUIDBOX_PROVIDER` (default `docker`).
+/// Dual-provider permanence (settled Q17): Docker is always available; the
+/// Kubernetes provider is added beside it in Phase 1.
+fn build_provider(cfg: &config::Config) -> anyhow::Result<Arc<dyn ExecutionProvider>> {
+    match cfg.provider.as_str() {
+        "docker" => Ok(Arc::new(fluidbox_provider::DockerProvider::connect(
+            cfg.data_dir.clone(),
+        )?)),
+        other => anyhow::bail!(
+            "FLUIDBOX_PROVIDER='{other}' is not available in this build (known: docker)"
+        ),
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -62,9 +77,14 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    let provider = fluidbox_provider::DockerProvider::connect()?;
-    if let Err(e) = provider.ping().await {
-        tracing::warn!("docker ping failed ({e}); sandboxes will not launch until docker is up");
+    let provider = build_provider(&cfg)?;
+    if let Err(e) = provider.healthcheck().await {
+        tracing::warn!(
+            "provider '{}' health probe failed ({e}); sandboxes will not launch until it is reachable",
+            provider.runtime_name()
+        );
+    } else {
+        tracing::info!("execution provider: {}", provider.runtime_name());
     }
 
     let events_tx = fluidbox_db::spawn_listener(cfg.database_url.clone());
@@ -82,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
     let state: state::AppState = Arc::new(AppStateInner {
         tenant_id: seed.tenant_id,
         redactor: fluidbox_core::event::Redactor::default(),
-        provider: Arc::new(provider),
+        provider,
         approvals: ApprovalRegistry::default(),
         events_tx,
         http: reqwest::Client::builder()

--- a/crates/fluidbox-server/src/oauth.rs
+++ b/crates/fluidbox-server/src/oauth.rs
@@ -771,18 +771,36 @@ pub async fn ensure_access_token(
             return Ok(tok.clone());
         }
     }
+    // Two-level serialization of the refresh-token rotation:
+    //  1. an in-process mutex avoids self-racing within ONE control plane, and
+    //  2. a transaction-scoped Postgres advisory lock (keyed on the connection
+    //     id) serializes ACROSS replicas — a second control plane can no longer
+    //     double-rotate the refresh token into invalid_grant. The lock is held
+    //     for the whole refresh (HTTP + rotation write) and released on commit.
     let lock = {
         let mut locks = state.oauth_locks.lock().await;
         locks.entry(conn.id).or_default().clone()
     };
     let _guard = lock.lock().await;
-    // Double-check: another caller may have refreshed while we waited.
+    let mut tx = state
+        .pool
+        .begin()
+        .await
+        .map_err(|e| format!("oauth lock txn failed: {e}"))?;
+    fluidbox_db::acquire_oauth_lock(&mut tx, conn.id)
+        .await
+        .map_err(|e| format!("oauth advisory lock failed: {e}"))?;
+    // Double-check under both locks: another caller (here or on another
+    // replica) may have refreshed while we waited.
     if let Some((tok, exp)) = state.connector_tokens.lock().await.get(&conn.id) {
         if *exp - margin > Utc::now() {
             return Ok(tok.clone());
         }
     }
-    refresh_access_token(state, conn).await
+    let result = refresh_access_token(state, conn).await;
+    // Commit releases the advisory lock (a dropped/rolled-back tx would too).
+    tx.commit().await.ok();
+    result
 }
 
 /// One refresh-grant round trip. Rotation: a new refresh token atomically

--- a/crates/fluidbox-server/src/orchestrator.rs
+++ b/crates/fluidbox-server/src/orchestrator.rs
@@ -1,18 +1,43 @@
 //! Session lifecycle driver. The server is the single status writer; the
 //! runner only reports events/heartbeats/result. This module owns the
-//! transitions, the sandbox, workspace init, budget enforcement, and reaping.
+//! transitions, the sandbox, workspace init, budget enforcement, and the
+//! durable terminal finalizer.
+//!
+//! **Durable finalizer (K8s design 2026-07-15, Phase 0).** Every terminal
+//! path — result, cancel, fail, watchdog, budget — funnels through
+//! `begin_finalize` → a persisted `session_finalizations` intent + a
+//! `cancelling`/`finalizing` state → `drive_finalization`, which collects the
+//! diff artifact BEFORE the terminal transition. Because delivery enqueue
+//! rides terminal entry (in `transition`), collection can never race the
+//! artifact. The intent is persisted before `/result` ACKs, and a
+//! restart-recoverable worker re-drives any interrupted finalization, so a
+//! crash mid-finalize strands nothing.
 
 use crate::ledger;
 use crate::state::AppState;
 use fluidbox_core::event::{Actor, EventBody};
 use fluidbox_core::spec::{RunSpec, WorkspaceSpec};
 use fluidbox_core::state::SessionStatus;
-use fluidbox_core::traits::{ExecutionProvider, NetworkMode, SandboxHandle, SandboxSpec};
+use fluidbox_core::traits::{CollectContext, CollectedArtifacts, SandboxHandle, SandboxSpec};
 use fluidbox_db::SessionRow;
 use std::path::PathBuf;
+use std::time::Duration;
 use uuid::Uuid;
 
 const SESSION_TOKEN_TTL_SECS: i64 = 3 * 3600;
+
+/// Cancellation quiesce deadline: three 10 s heartbeat opportunities + jitter
+/// (settled Q5; 20 s rejected as only two opportunities). Past it, a racing
+/// worktree is never collected — the diff is recorded `artifact_missing`.
+const QUIESCE_DEADLINE_SECS: i64 = 30;
+
+/// A finalization claim older than this is re-drivable (the previous driver
+/// crashed). Comfortably above the collection + quiesce budget below.
+const FINALIZE_CLAIM_STALE_SECS: i64 = 180;
+
+/// Terminal artifact collection is bounded: a hostile or huge worktree can
+/// waste the cap, never wedge `finalizing`.
+const COLLECT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Spawn the full run of a freshly-created session in the background.
 pub fn spawn_run(state: AppState, session_id: Uuid) {
@@ -42,19 +67,15 @@ async fn transition(state: &AppState, id: Uuid, next: SessionStatus, reason: Opt
                 // Defense-in-depth: kill the session's tokens the moment it
                 // goes terminal so a still-running or leaked token can't reach
                 // the facade/gateway. The PRIMARY guard is each endpoint's own
-                // terminal-session check (facade, permission, tool_call,
-                // result, token_renew all refuse a terminal session), so a
-                // best-effort revoke that fails still leaves the run governed —
-                // hence warn-and-continue, not fail. (Full transactional
-                // terminal + delivery idempotency is a pre-existing follow-up,
-                // HANDOVER §4.)
+                // terminal/wind-down check.
                 if let Err(e) = fluidbox_db::revoke_session_tokens(&state.pool, id).await {
                     tracing::warn!("revoke_session_tokens {id} failed: {e}");
                 }
                 // Publication is decoupled: enqueue rows; the delivery worker
                 // owns retries. This is the ONLY enqueue point — every exit
-                // path (finalize/fail/cancel/sweeps) funnels through here,
-                // and the state machine makes terminal entry exactly-once.
+                // path funnels through here — and it fires on terminal entry,
+                // which is now reachable ONLY from `finalizing`, so the diff
+                // artifact is already stored when delivery is enqueued.
                 crate::deliveries::enqueue_for_session(state, id).await;
             }
             true
@@ -67,6 +88,22 @@ async fn transition(state: &AppState, id: Uuid, next: SessionStatus, reason: Opt
     }
 }
 
+/// Terminal completion (runner `/result`, wall-clock budget, tool-call
+/// budget). Collects the diff before terminalizing; no quiesce (the runner
+/// already stopped, or is being stopped without needing a clean worktree
+/// beyond what it left).
+pub async fn finalize(
+    state: &AppState,
+    session: &SessionRow,
+    outcome: &str,
+    summary: Option<&str>,
+) {
+    begin_finalize(state, session.id, outcome, summary, summary, false).await;
+}
+
+/// Terminal failure. Same durable path — a failed run now STILL collects
+/// whatever the agent produced (fixes live defect #1: `fail()` used to reap
+/// with no diff).
 pub async fn fail(state: &AppState, id: Uuid, reason: &str) {
     ledger::record(
         state,
@@ -77,8 +114,327 @@ pub async fn fail(state: &AppState, id: Uuid, reason: &str) {
         },
     )
     .await;
-    transition(state, id, SessionStatus::Failed, Some(reason)).await;
+    begin_finalize(state, id, "failed", None, Some(reason), false).await;
+}
+
+/// Cancel a session (admin action, or a `replace` concurrency policy). Rides
+/// the durable finalizer WITH quiesce: the runner is asked (via its heartbeat
+/// response) to stop and NOT post `/result`, we wait up to 30 s for a clean
+/// worktree, then collect. Returns true if cancellation was initiated (the
+/// terminal `cancelled` lands asynchronously after collection).
+pub async fn cancel(state: &AppState, id: Uuid, reason: &str) -> bool {
+    let Ok(Some(session)) = fluidbox_db::get_session(&state.pool, id).await else {
+        return false;
+    };
+    let st = session.status_enum();
+    if st.is_terminal() || st.is_winding_down() {
+        return false;
+    }
+    begin_finalize(state, id, "cancelled", None, Some(reason), true).await
+}
+
+/// Persist the terminal intent, enter the matching wind-down state, and kick
+/// the driver. Idempotent: a racing second caller (e.g. `/result` and the
+/// wall-clock sweeper) sees the intent already recorded and defers.
+async fn begin_finalize(
+    state: &AppState,
+    id: Uuid,
+    outcome: &str,
+    summary: Option<&str>,
+    reason: Option<&str>,
+    want_quiesce: bool,
+) -> bool {
+    let Ok(Some(session)) = fluidbox_db::get_session(&state.pool, id).await else {
+        return false;
+    };
+    let st = session.status_enum();
+    if st.is_terminal() {
+        return false;
+    }
+
+    // Quiesce only makes sense while a runner is actually live to receive the
+    // heartbeat signal; otherwise go straight to collection.
+    let quiesce = want_quiesce
+        && matches!(st, SessionStatus::Running | SessionStatus::AwaitingApproval)
+        && session.sandbox_handle.is_some();
+    let (winddown, deadline) = if quiesce {
+        (
+            SessionStatus::Cancelling,
+            Some(chrono::Utc::now() + chrono::Duration::seconds(QUIESCE_DEADLINE_SECS)),
+        )
+    } else {
+        (SessionStatus::Finalizing, None)
+    };
+
+    // Persist intent BEFORE any ACK / state change (the /result-lossiness fix).
+    // A DB error here must NOT leave the session winding down without a durable
+    // intent — the recovery worker joins on `session_finalizations`, so an
+    // intent-less `finalizing` session would strand forever. Fail closed:
+    // don't transition; the caller/watchdog can retry.
+    let created = match fluidbox_db::begin_finalization(
+        &state.pool,
+        id,
+        outcome,
+        summary,
+        reason,
+        quiesce,
+        deadline,
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("begin_finalization {id} failed, not winding down: {e}");
+            return false;
+        }
+    };
+
+    // If the session is already winding down (a retry, or the other of a
+    // /result+cancel race), don't re-transition — just make sure a driver runs.
+    if !st.is_winding_down() {
+        transition(state, id, winddown, reason).await;
+    }
+
+    if quiesce && created {
+        ledger::record(
+            state,
+            id,
+            Actor::System,
+            EventBody::QuiesceRequested {
+                deadline_secs: QUIESCE_DEADLINE_SECS as u64,
+            },
+        )
+        .await;
+    }
+
+    let state2 = state.clone();
+    tokio::spawn(async move {
+        drive_finalization(&state2, id).await;
+    });
+    true
+}
+
+/// Drive one session's finalization to a terminal state. Claim-guarded (so
+/// only one driver acts at a time) and idempotent (the `finalizing→terminal`
+/// transition is the single-winner gate). Safe to call repeatedly — the
+/// recovery worker calls it for any interrupted finalization.
+pub async fn drive_finalization(state: &AppState, id: Uuid) {
+    let claimed = fluidbox_db::claim_finalization(&state.pool, id, FINALIZE_CLAIM_STALE_SECS).await;
+    let intent = match claimed {
+        Ok(Some(i)) => i,
+        Ok(None) => return, // another driver owns it, or no intent — nothing to do
+        Err(e) => {
+            tracing::warn!("claim_finalization {id} failed: {e}");
+            return;
+        }
+    };
+
+    let Ok(Some(session)) = fluidbox_db::get_session(&state.pool, id).await else {
+        fluidbox_db::delete_finalization(&state.pool, id).await.ok();
+        return;
+    };
+    if session.status_enum().is_terminal() {
+        fluidbox_db::delete_finalization(&state.pool, id).await.ok();
+        return;
+    }
+
+    // Cancelling → wait for the runner to quiesce (or the deadline), then
+    // enter the collection phase.
+    let mut skip_collection = false;
+    if session.status_enum() == SessionStatus::Cancelling {
+        let timed_out = await_quiesce(state, &session, intent.quiesce_deadline).await;
+        if timed_out {
+            skip_collection = true; // never collect a racing worktree
+        }
+        transition(
+            state,
+            id,
+            SessionStatus::Finalizing,
+            intent.reason.as_deref(),
+        )
+        .await;
+    }
+
+    collect_and_terminalize(state, id, &intent, skip_collection).await;
+}
+
+/// Block until the runner's sandbox is no longer live (clean quiesce) or the
+/// deadline passes. Returns true on timeout.
+async fn await_quiesce(
+    state: &AppState,
+    session: &SessionRow,
+    deadline: Option<chrono::DateTime<chrono::Utc>>,
+) -> bool {
+    let deadline = deadline.unwrap_or_else(chrono::Utc::now);
+    let handle: Option<SandboxHandle> = session
+        .sandbox_handle
+        .clone()
+        .and_then(|j| serde_json::from_value(j).ok());
+    let Some(handle) = handle else {
+        return false; // no sandbox to wait on
+    };
+    loop {
+        if chrono::Utc::now() >= deadline {
+            return true;
+        }
+        match state.provider.state(&handle).await {
+            Ok(st) if !st.is_live() => return false, // runner exited
+            _ => {}
+        }
+        tokio::time::sleep(Duration::from_millis(750)).await;
+    }
+}
+
+/// Collect the diff (unless skipped), store the artifact or an explicit
+/// `artifact_missing`, then make the single terminal transition, reap, and
+/// clear the intent.
+async fn collect_and_terminalize(
+    state: &AppState,
+    id: Uuid,
+    intent: &fluidbox_db::FinalizationRow,
+    skip_collection: bool,
+) {
+    let Ok(Some(session)) = fluidbox_db::get_session(&state.pool, id).await else {
+        return;
+    };
+
+    // A diff is only "expected" once the session had a workspace/sandbox — a
+    // pre-launch failure records no artifact_missing noise.
+    let expected_diff = session.started_at.is_some()
+        || session.base_commit.is_some()
+        || session.sandbox_handle.is_some();
+
+    if skip_collection {
+        record_missing(state, id, "quiesce_timeout").await;
+    } else {
+        let handle: Option<SandboxHandle> = session
+            .sandbox_handle
+            .clone()
+            .and_then(|j| serde_json::from_value(j).ok());
+        let ctx = CollectContext {
+            session_id: id,
+            base_commit: session.base_commit.clone(),
+        };
+        let collected = tokio::time::timeout(
+            COLLECT_TIMEOUT,
+            state.provider.collect_artifacts(handle.as_ref(), &ctx),
+        )
+        .await;
+        match collected {
+            Ok(Ok(CollectedArtifacts::Collected(arts))) => {
+                store_collected(state, id, arts).await;
+            }
+            Ok(Ok(CollectedArtifacts::Missing { reason })) => {
+                if expected_diff {
+                    record_missing(state, id, &reason).await;
+                }
+            }
+            Ok(Err(e)) => {
+                if expected_diff {
+                    record_missing(state, id, &format!("collector error: {e}")).await;
+                }
+            }
+            Err(_) => {
+                if expected_diff {
+                    record_missing(state, id, "collection_timeout").await;
+                }
+            }
+        }
+    }
+
+    // Summary artifact (unchanged shape).
+    if let Some(s) = intent.summary.as_deref() {
+        fluidbox_db::set_result_summary(&state.pool, id, s)
+            .await
+            .ok();
+        fluidbox_db::upsert_artifact(&state.pool, id, "summary", "summary.md", s, "text/markdown")
+            .await
+            .ok();
+    }
+
+    ledger::record(
+        state,
+        id,
+        Actor::Harness,
+        EventBody::RunResult {
+            outcome: intent.outcome.clone(),
+            summary: intent.summary.clone(),
+        },
+    )
+    .await;
+
+    let terminal = match intent.outcome.as_str() {
+        "completed" => SessionStatus::Completed,
+        "cancelled" => SessionStatus::Cancelled,
+        "budget_exceeded" => SessionStatus::BudgetExceeded,
+        _ => SessionStatus::Failed,
+    };
+    // The single-winner gate: delivery enqueue rides this transition.
+    transition(state, id, terminal, intent.reason.as_deref()).await;
+
     reap(state, id).await;
+    if !state.cfg.keep_workspaces {
+        if let Err(e) = fluidbox_workspace::cleanup_workspace(&state.cfg.data_dir, id) {
+            tracing::warn!("workspace cleanup failed for {id}: {e}");
+        }
+    }
+    fluidbox_db::delete_finalization(&state.pool, id).await.ok();
+}
+
+async fn store_collected(
+    state: &AppState,
+    id: Uuid,
+    arts: Vec<fluidbox_core::traits::CollectedArtifact>,
+) {
+    for a in arts {
+        // A clean worktree is a real (empty) result, not a missing diff — the
+        // artifact contract keeps a diff row on every collected run.
+        let (content, content_type): (String, String) =
+            if a.kind == "diff" && a.content.trim().is_empty() {
+                ("(no changes)".into(), "text/plain".into())
+            } else {
+                (a.content.clone(), a.content_type.clone())
+            };
+        fluidbox_db::upsert_artifact(&state.pool, id, &a.kind, &a.name, &content, &content_type)
+            .await
+            .ok();
+        ledger::record(
+            state,
+            id,
+            Actor::System,
+            EventBody::ArtifactCollected {
+                kind: a.kind,
+                name: a.name,
+                bytes: a.bytes,
+                sha256: a.sha256,
+                truncated: a.truncated,
+            },
+        )
+        .await;
+    }
+}
+
+async fn record_missing(state: &AppState, id: Uuid, reason: &str) {
+    fluidbox_db::upsert_artifact(
+        &state.pool,
+        id,
+        "diff",
+        "changes.patch",
+        &format!("(diff unavailable: {reason})"),
+        "text/plain",
+    )
+    .await
+    .ok();
+    ledger::record(
+        state,
+        id,
+        Actor::System,
+        EventBody::ArtifactMissing {
+            kind: "diff".into(),
+            reason: reason.into(),
+        },
+    )
+    .await;
 }
 
 async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
@@ -108,38 +464,18 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
     transition(&state, session_id, SessionStatus::Initializing, None).await;
     let workspace_dir = materialize_workspace(&state, session_id, &run_spec).await?;
 
-    // Launch the sandbox. The generic FLUIDBOX_* block is the harness-neutral
-    // runner contract; everything harness-specific rides runner_env().
     let control_url = state.cfg.public_control_url.clone();
-    let mut env = vec![
-        ("FLUIDBOX_CONTROL_URL".into(), control_url.clone()),
-        ("FLUIDBOX_SESSION_ID".into(), session_id.to_string()),
-        ("FLUIDBOX_SESSION_TOKEN".into(), session_token.clone()),
-        ("FLUIDBOX_TASK".into(), run_spec.task.clone()),
-        (
-            "FLUIDBOX_AUTONOMY".into(),
-            run_spec.autonomy.as_str().into(),
-        ),
-        ("FLUIDBOX_MODEL".into(), run_spec.model.clone()),
-        ("FLUIDBOX_WORKSPACE".into(), "/workspace".into()),
-    ];
-    // Per-harness extras: claude gets the Anthropic trio (facade URL + fake
-    // key = session token); codex gets nothing extra — its supervisor wires
-    // the facade from the generic block.
-    env.extend(crate::harness::runner_env(
-        &run_spec.harness,
-        &control_url,
-        &session_token,
-        &run_spec.model,
-    ));
-    if let Some(sp) = &run_spec.system_prompt {
-        env.push(("FLUIDBOX_SYSTEM_PROMPT".into(), sp.clone()));
-    }
-    if !run_spec.capabilities.is_empty() {
-        env.push((
-            "FLUIDBOX_CAPABILITIES".into(),
-            runner_capability_manifest(&run_spec.capabilities).to_string(),
-        ));
+    let env = build_runner_env(&run_spec, &control_url, session_id, &session_token);
+
+    // 512 KiB serialized runner-env ceiling (env injection is the v1 config
+    // channel; a Kubernetes Secret caps ~1 MiB). Fail closed at zero spend.
+    let env_bytes = serialized_env_len(&env);
+    if env_bytes > crate::config::MAX_RUNNER_ENV_BYTES {
+        anyhow::bail!(
+            "runner env is {env_bytes} bytes, over the {} byte ceiling ({})",
+            crate::config::MAX_RUNNER_ENV_BYTES,
+            env_size_breakdown(&env)
+        );
     }
 
     let sandbox_spec = SandboxSpec {
@@ -147,7 +483,7 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
         image: run_spec.runner_image.clone(),
         env,
         workspace_host_dir: workspace_dir.as_ref().map(|p| p.display().to_string()),
-        network: NetworkMode::HostDev,
+        network: state.cfg.network_mode,
     };
 
     let handle = state.provider.provision(&sandbox_spec).await?;
@@ -158,9 +494,6 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
     transition(&state, session_id, SessionStatus::Running, None).await;
     fluidbox_db::heartbeat(&state.pool, session_id).await.ok();
 
-    // The run now proceeds via the internal gateway (permission/events/
-    // heartbeat/result). The watchdog + budget sweeper + result handler drive
-    // it to a terminal state. We just record the launch.
     ledger::record(
         &state,
         session_id,
@@ -178,11 +511,67 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Assemble the runner env. The generic FLUIDBOX_* block is the harness-neutral
+/// runner contract; per-harness extras ride `harness::runner_env`.
+pub fn build_runner_env(
+    run_spec: &RunSpec,
+    control_url: &str,
+    session_id: Uuid,
+    session_token: &str,
+) -> Vec<(String, String)> {
+    let mut env = vec![
+        ("FLUIDBOX_CONTROL_URL".into(), control_url.to_string()),
+        ("FLUIDBOX_SESSION_ID".into(), session_id.to_string()),
+        ("FLUIDBOX_SESSION_TOKEN".into(), session_token.to_string()),
+        ("FLUIDBOX_TASK".into(), run_spec.task.clone()),
+        (
+            "FLUIDBOX_AUTONOMY".into(),
+            run_spec.autonomy.as_str().into(),
+        ),
+        ("FLUIDBOX_MODEL".into(), run_spec.model.clone()),
+        ("FLUIDBOX_WORKSPACE".into(), "/workspace".into()),
+    ];
+    env.extend(crate::harness::runner_env(
+        &run_spec.harness,
+        control_url,
+        session_token,
+        &run_spec.model,
+    ));
+    if let Some(sp) = &run_spec.system_prompt {
+        env.push(("FLUIDBOX_SYSTEM_PROMPT".into(), sp.clone()));
+    }
+    if !run_spec.capabilities.is_empty() {
+        env.push((
+            "FLUIDBOX_CAPABILITIES".into(),
+            runner_capability_manifest(&run_spec.capabilities).to_string(),
+        ));
+    }
+    env
+}
+
+/// Serialized size the provider must transport (env-var form: `K=V\0`).
+pub fn serialized_env_len(env: &[(String, String)]) -> usize {
+    env.iter().map(|(k, v)| k.len() + v.len() + 2).sum()
+}
+
+pub fn env_size_breakdown(env: &[(String, String)]) -> String {
+    let mut parts: Vec<(usize, &str)> = env
+        .iter()
+        .map(|(k, v)| (k.len() + v.len(), k.as_str()))
+        .collect();
+    parts.sort_by_key(|&(n, _)| std::cmp::Reverse(n)); // largest first
+    parts
+        .iter()
+        .take(4)
+        .map(|(n, k)| format!("{k}={n}B"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// The sandbox-facing slice of the frozen capability set. The runner needs:
 /// sandbox servers' launch specs (command/args), and brokered servers'
 /// frozen tool snapshots (to advertise them via the broker shim). Broker
-/// internals — URLs, connection ids — stay out of the sandbox: it holds an
-/// intent channel, not a map of the control plane's upstreams.
+/// internals — URLs, connection ids — stay out of the sandbox.
 fn runner_capability_manifest(
     capabilities: &[fluidbox_core::capability::FrozenBundle],
 ) -> serde_json::Value {
@@ -222,7 +611,7 @@ async fn materialize_workspace(
         WorkspaceSpec::LocalCopy { path } => {
             let src = PathBuf::from(path);
             let ws = tokio::task::spawn_blocking(move || {
-                fluidbox_provider::workspace::materialize_local(&data_dir, session_id, &src)
+                fluidbox_workspace::materialize_local(&data_dir, session_id, &src)
             })
             .await??;
             (ws, None, None)
@@ -243,7 +632,7 @@ async fn materialize_workspace(
             };
             let (url, rf, sha) = (clone_url.clone(), r#ref.clone(), commit_sha.clone());
             let ws = tokio::task::spawn_blocking(move || {
-                fluidbox_provider::workspace::materialize_git(
+                fluidbox_workspace::materialize_git(
                     &data_dir,
                     session_id,
                     &url,
@@ -263,7 +652,7 @@ async fn materialize_workspace(
                 .join("repo");
             std::fs::create_dir_all(&dir)?;
             let ws = tokio::task::spawn_blocking(move || {
-                fluidbox_provider::workspace::materialize_local(&data_dir, session_id, &dir)
+                fluidbox_workspace::materialize_local(&data_dir, session_id, &dir)
             })
             .await??;
             (ws, None, None)
@@ -301,97 +690,6 @@ async fn connection_auth_header(state: &AppState, connection_id: Uuid) -> anyhow
     crate::connectors::fetch_auth_header(state, &conn).await
 }
 
-/// Capture the diff artifact from the materialized workspace, then remove
-/// the per-session workspace dir (idempotent; kept when the capture failed
-/// or FLUIDBOX_KEEP_WORKSPACES is set, so there's something to debug).
-async fn capture_diff_and_cleanup(state: &AppState, session: &SessionRow) {
-    let id = session.id;
-    let ws_dir = state
-        .cfg
-        .data_dir
-        .join("workspaces")
-        .join(id.to_string())
-        .join("repo");
-    let mut captured = true;
-    if ws_dir.exists() {
-        match fluidbox_provider::workspace::capture_diff(&ws_dir, session.base_commit.as_deref()) {
-            Ok(diff) if !diff.trim().is_empty() => {
-                fluidbox_db::add_artifact(
-                    &state.pool,
-                    id,
-                    "diff",
-                    "changes.patch",
-                    &diff,
-                    "text/x-diff",
-                )
-                .await
-                .ok();
-            }
-            Ok(_) => {
-                fluidbox_db::add_artifact(
-                    &state.pool,
-                    id,
-                    "diff",
-                    "changes.patch",
-                    "(no changes)",
-                    "text/plain",
-                )
-                .await
-                .ok();
-            }
-            Err(e) => {
-                captured = false;
-                tracing::warn!("diff capture failed for {id}: {e}");
-            }
-        }
-    }
-    if captured && !state.cfg.keep_workspaces {
-        if let Err(e) = fluidbox_provider::workspace::cleanup_workspace(&state.cfg.data_dir, id) {
-            tracing::warn!("workspace cleanup failed for {id}: {e}");
-        }
-    }
-}
-
-/// Called by the internal /result handler: finalize a run, capture the diff,
-/// then reap the sandbox.
-pub async fn finalize(
-    state: &AppState,
-    session: &SessionRow,
-    outcome: &str,
-    summary: Option<&str>,
-) {
-    let id = session.id;
-    capture_diff_and_cleanup(state, session).await;
-
-    if let Some(s) = summary {
-        fluidbox_db::set_result_summary(&state.pool, id, s)
-            .await
-            .ok();
-        fluidbox_db::add_artifact(&state.pool, id, "summary", "summary.md", s, "text/markdown")
-            .await
-            .ok();
-    }
-
-    let terminal = match outcome {
-        "completed" => SessionStatus::Completed,
-        "cancelled" => SessionStatus::Cancelled,
-        "budget_exceeded" => SessionStatus::BudgetExceeded,
-        _ => SessionStatus::Failed,
-    };
-    ledger::record(
-        state,
-        id,
-        Actor::Harness,
-        EventBody::RunResult {
-            outcome: outcome.into(),
-            summary: summary.map(|s| s.to_string()),
-        },
-    )
-    .await;
-    transition(state, id, terminal, summary).await;
-    reap(state, id).await;
-}
-
 /// Tear down the sandbox for a session (idempotent).
 pub async fn reap(state: &AppState, id: Uuid) {
     if let Ok(Some(session)) = fluidbox_db::get_session(&state.pool, id).await {
@@ -403,24 +701,6 @@ pub async fn reap(state: &AppState, id: Uuid) {
             }
         }
     }
-}
-
-/// Cancel a session (admin action, or a `replace` concurrency policy).
-/// Captures whatever the agent produced so far as the diff artifact, then
-/// tears everything down.
-pub async fn cancel(state: &AppState, id: Uuid, reason: &str) -> bool {
-    let Ok(Some(session)) = fluidbox_db::get_session(&state.pool, id).await else {
-        return false;
-    };
-    if session.status_enum().is_terminal() {
-        return false;
-    }
-    let ok = transition(state, id, SessionStatus::Cancelled, Some(reason)).await;
-    if ok {
-        reap(state, id).await;
-        capture_diff_and_cleanup(state, &session).await;
-    }
-    ok
 }
 
 fn uuid_token() -> String {

--- a/crates/fluidbox-server/src/run_service.rs
+++ b/crates/fluidbox-server/src/run_service.rs
@@ -234,6 +234,27 @@ pub async fn create_run(state: &AppState, req: CreateRun) -> ApiResult<RunCreati
         capabilities,
     };
 
+    // 512 KiB serialized runner-env ceiling (design 2026-07-15): env injection
+    // is the v1 config channel and a Kubernetes Secret caps ~1 MiB. Reject a
+    // bloated run at creation with a clear 422 + per-component diagnostics,
+    // rather than an opaque kubelet/daemon failure at launch. The estimate
+    // uses placeholder identity (tiny, bounded); `run()` re-checks for real.
+    let est_env = orchestrator::build_runner_env(
+        &run_spec,
+        &state.cfg.public_control_url,
+        Uuid::nil(),
+        "fbx_sess_00000000000000000000000000000000",
+    );
+    let env_bytes = orchestrator::serialized_env_len(&est_env);
+    if env_bytes > crate::config::MAX_RUNNER_ENV_BYTES {
+        return Err(ApiError::UnprocessableEntity(format!(
+            "runner environment is {env_bytes} bytes, over the {} byte ceiling — \
+             shorten the task/system prompt or narrow capabilities ({})",
+            crate::config::MAX_RUNNER_ENV_BYTES,
+            orchestrator::env_size_breakdown(&est_env),
+        )));
+    }
+
     let session = fluidbox_db::create_session(
         &state.pool,
         state.tenant_id,

--- a/crates/fluidbox-server/src/state.rs
+++ b/crates/fluidbox-server/src/state.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use chrono::{DateTime, Utc};
 use fluidbox_core::event::Redactor;
-use fluidbox_provider::DockerProvider;
+use fluidbox_core::traits::ExecutionProvider;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -41,7 +41,10 @@ pub struct AppStateInner {
     pub pool: PgPool,
     pub tenant_id: Uuid,
     pub redactor: Redactor,
-    pub provider: Arc<DockerProvider>,
+    /// The active execution backend (Docker default, Kubernetes optional) —
+    /// a trait object so `FLUIDBOX_PROVIDER` selects at boot without any call
+    /// site knowing which backend it drives.
+    pub provider: Arc<dyn ExecutionProvider>,
     pub approvals: ApprovalRegistry,
     /// LISTEN/NOTIFY wakeups (session_id, seq) for SSE fanout.
     pub events_tx: broadcast::Sender<(Uuid, i64)>,

--- a/crates/fluidbox-server/src/workers.rs
+++ b/crates/fluidbox-server/src/workers.rs
@@ -1,18 +1,24 @@
 //! Background workers: heartbeat watchdog, budget sweeper (wall-clock),
-//! approval expiry, and boot-time orphan reaping.
+//! approval expiry, the restart-recoverable finalize driver, and boot-time
+//! orphan reaping.
 
 use crate::orchestrator;
 use crate::state::AppState;
 use fluidbox_core::spec::RunSpec;
-use fluidbox_core::traits::{ExecutionProvider, SandboxHandle, SandboxState};
+use fluidbox_core::traits::SandboxHandle;
 use std::time::Duration;
 
-/// Reap any sandboxes labelled ours that have no matching live session (or
-/// whose session is already terminal). Runs once at boot.
+/// Reap any sandboxes the provider manages that have no matching live session
+/// (or whose session is already terminal), and resume any finalization the
+/// control plane was driving when it went down. Runs once at boot.
 pub async fn boot_orphan_sweep(state: AppState) {
-    match state.provider.list_orphans().await {
-        Ok(orphans) => {
-            for (session_id, handle) in orphans {
+    // Resume interrupted finalizations FIRST, so a crash mid-collect finishes
+    // (and reaps its own sandbox) before the orphan sweep would kill it.
+    recover_finalizations(&state).await;
+
+    match state.provider.list_managed().await {
+        Ok(managed) => {
+            for (session_id, handle) in managed {
                 let terminal = match fluidbox_db::get_session(&state.pool, session_id).await {
                     Ok(Some(s)) => s.status_enum().is_terminal(),
                     _ => true, // unknown session → orphan
@@ -27,10 +33,26 @@ pub async fn boot_orphan_sweep(state: AppState) {
     }
 }
 
+/// Re-drive every session that has a persisted finalization intent but hasn't
+/// reached terminal — the restart-recovery + crashed-driver path. Claim-
+/// guarded in `drive_finalization`, so this never double-finalizes.
+async fn recover_finalizations(state: &AppState) {
+    match fluidbox_db::pending_finalizations(&state.pool).await {
+        Ok(ids) => {
+            for id in ids {
+                tracing::info!("resuming interrupted finalization for {id}");
+                orchestrator::drive_finalization(state, id).await;
+            }
+        }
+        Err(e) => tracing::warn!("finalization recovery query failed: {e}"),
+    }
+}
+
 pub fn spawn_all(state: AppState) {
     tokio::spawn(watchdog(state.clone()));
     tokio::spawn(budget_sweeper(state.clone()));
-    tokio::spawn(approval_expiry(state));
+    tokio::spawn(approval_expiry(state.clone()));
+    tokio::spawn(finalize_worker(state));
 }
 
 /// A healthy orchestrator moves created → provisioning → initializing in
@@ -100,10 +122,12 @@ async fn sandbox_dead(state: &AppState, handle_json: &Option<serde_json::Value>)
     let Ok(handle) = serde_json::from_value::<SandboxHandle>(json.clone()) else {
         return true;
     };
-    matches!(
-        state.provider.state(&handle).await,
-        Ok(SandboxState::Exited(_)) | Ok(SandboxState::Gone)
-    )
+    match state.provider.state(&handle).await {
+        Ok(st) => !st.is_live(),
+        // A transient provider error is NOT proof of death — leave it for the
+        // next tick rather than failing a possibly-live session.
+        Err(_) => false,
+    }
 }
 
 /// Enforce wall-clock budgets (token/cost budgets are enforced inline in the
@@ -165,5 +189,17 @@ async fn approval_expiry(state: AppState) {
             }
             Err(e) => tracing::warn!("approval expiry sweep failed: {e}"),
         }
+    }
+}
+
+/// Restart-recoverable finalize driver: re-drives any session stuck in
+/// `cancelling`/`finalizing` with a persisted intent whose driver died
+/// (stale claim). The claim in `drive_finalization` makes this idempotent —
+/// a healthy in-progress finalization is never disturbed.
+async fn finalize_worker(state: AppState) {
+    let mut tick = tokio::time::interval(Duration::from_secs(20));
+    loop {
+        tick.tick().await;
+        recover_finalizations(&state).await;
     }
 }

--- a/crates/fluidbox-workspace/Cargo.toml
+++ b/crates/fluidbox-workspace/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fluidbox-workspace"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "fluidbox workspace lifecycle: materialization, pristine baselines, hardened diff collection"
+
+[dependencies]
+fluidbox-core = { workspace = true }
+thiserror = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+uuid = { workspace = true }

--- a/crates/fluidbox-workspace/src/collect.rs
+++ b/crates/fluidbox-workspace/src/collect.rs
@@ -1,0 +1,461 @@
+//! Hardened terminal diff collection.
+//!
+//! Principle (design 2026-07-15): **never execute git against
+//! agent-controlled `.git` state — on any provider.** An agent can write
+//! `diff.external`, clean/smudge filters, `core.fsmonitor`, or hooks into
+//! its workspace's `.git`; running plain `git diff` there executes attacker
+//! code on whatever machine collects.
+//!
+//! Instead, collection reconstructs a throwaway repository from the
+//! PRISTINE baseline (the `.git` saved at materialization, before the agent
+//! ever ran) pointed at the final worktree, and runs git with a scrubbed
+//! environment: no system/global config, no hooks, no fsmonitor, no
+//! external diff, no prompts, controlled HOME. Output is bounded in size
+//! and the child is killed on a deadline — a hostile worktree can waste the
+//! cap, never the collector.
+
+use crate::{WorkspaceError, BASELINE_DIR};
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Bounds on one collection run.
+#[derive(Debug, Clone)]
+pub struct DiffCaps {
+    /// Stored diff ceiling; larger output is truncated and flagged.
+    pub max_bytes: usize,
+    /// Per-git-invocation wall-clock ceiling (the child is killed past it).
+    pub git_timeout: Duration,
+}
+
+impl Default for DiffCaps {
+    fn default() -> Self {
+        Self {
+            max_bytes: 8 * 1024 * 1024,
+            git_timeout: Duration::from_secs(90),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CollectedDiff {
+    /// Unified `--binary` patch text (lossy UTF-8; possibly truncated).
+    pub patch: String,
+    pub truncated: bool,
+    /// Size in bytes of the stored (post-truncation) content.
+    pub bytes: u64,
+    /// Digest of the stored content.
+    pub sha256: String,
+}
+
+/// Collection either produces a (possibly empty) diff, or an EXPLICIT
+/// missing marker — never a silent "(no changes)".
+#[derive(Debug)]
+pub enum CollectionOutcome {
+    Diff(CollectedDiff),
+    Missing { reason: String },
+}
+
+/// Collect the agent's changes from a session workspace root
+/// (`<data_dir>/workspaces/<sid>`), diffing the final `repo/` worktree
+/// against `base_commit` using ONLY the pristine baseline's `.git`.
+pub fn collect_diff(
+    workspace_root: &Path,
+    base_commit: Option<&str>,
+    caps: &DiffCaps,
+) -> CollectionOutcome {
+    let repo = workspace_root.join("repo");
+    let baseline = workspace_root.join(BASELINE_DIR);
+    if !repo.is_dir() {
+        return CollectionOutcome::Missing {
+            reason: "workspace worktree missing (never materialized, or already cleaned)".into(),
+        };
+    }
+    if !baseline.is_dir() {
+        return CollectionOutcome::Missing {
+            reason: "pristine baseline missing — refusing to touch the agent-controlled .git"
+                .into(),
+        };
+    }
+    match collect_inner(workspace_root, &repo, &baseline, base_commit, caps) {
+        Ok(diff) => CollectionOutcome::Diff(diff),
+        Err(e) => CollectionOutcome::Missing {
+            reason: format!("collection failed: {e}"),
+        },
+    }
+}
+
+fn collect_inner(
+    workspace_root: &Path,
+    worktree: &Path,
+    baseline: &Path,
+    base_commit: Option<&str>,
+    caps: &DiffCaps,
+) -> Result<CollectedDiff, WorkspaceError> {
+    // Scratch space lives INSIDE the session root (cleaned with it) but
+    // outside repo/ (never visible to any sandbox transport).
+    let scratch = workspace_root.join("collect-tmp");
+    if scratch.exists() {
+        std::fs::remove_dir_all(&scratch)?;
+    }
+    let git_dir = scratch.join("git");
+    let home = scratch.join("home");
+    let hooks = scratch.join("hooks"); // exists and is empty — hooksPath target
+    std::fs::create_dir_all(&home)?;
+    std::fs::create_dir_all(&hooks)?;
+    crate::copy_dir_all(baseline, &git_dir)?;
+    // A stale lock from a crashed materialization must not wedge collection.
+    std::fs::remove_file(git_dir.join("index.lock")).ok();
+
+    let result = (|| {
+        // Stage everything the agent produced (into OUR index), then diff
+        // against the base. --ignore-errors: an unreadable file skips, it
+        // doesn't forfeit the whole diff.
+        let add = run_git_scrubbed(
+            &git_dir,
+            worktree,
+            &home,
+            &hooks,
+            &["add", "-A", "--ignore-errors"],
+            64 * 1024,
+            caps.git_timeout,
+        )?;
+        if !add.ok() {
+            return Err(WorkspaceError::Git(format!(
+                "git add -A: {}",
+                add.describe()
+            )));
+        }
+
+        let base = base_commit.unwrap_or("HEAD");
+        let diff = run_git_scrubbed(
+            &git_dir,
+            worktree,
+            &home,
+            &hooks,
+            &["diff", "--binary", "--no-color", "--no-ext-diff", base],
+            caps.max_bytes,
+            caps.git_timeout,
+        )?;
+        if !diff.ok() {
+            return Err(WorkspaceError::Git(format!(
+                "git diff {base}: {}",
+                diff.describe()
+            )));
+        }
+
+        let bytes = diff.stdout;
+        let truncated = diff.stdout_truncated;
+        let sha256 = {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(&bytes);
+            format!("sha256:{}", hex::encode(h.finalize()))
+        };
+        Ok(CollectedDiff {
+            bytes: bytes.len() as u64,
+            patch: String::from_utf8_lossy(&bytes).into_owned(),
+            truncated,
+            sha256,
+        })
+    })();
+
+    std::fs::remove_dir_all(&scratch).ok();
+    result
+}
+
+struct BoundedOutput {
+    status: Option<i32>,
+    timed_out: bool,
+    stdout: Vec<u8>,
+    stdout_truncated: bool,
+    stderr_head: String,
+}
+
+impl BoundedOutput {
+    fn ok(&self) -> bool {
+        !self.timed_out && self.status == Some(0)
+    }
+    fn describe(&self) -> String {
+        if self.timed_out {
+            return "killed on collection deadline".into();
+        }
+        format!(
+            "exit {:?}: {}",
+            self.status,
+            self.stderr_head
+                .trim()
+                .chars()
+                .take(400)
+                .collect::<String>()
+        )
+    }
+}
+
+/// Run git against the throwaway GIT_DIR + the agent worktree with a fully
+/// scrubbed environment, bounded stdout, and a kill-on-deadline watchdog.
+fn run_git_scrubbed(
+    git_dir: &Path,
+    worktree: &Path,
+    home: &Path,
+    empty_hooks: &Path,
+    args: &[&str],
+    max_out: usize,
+    timeout: Duration,
+) -> Result<BoundedOutput, WorkspaceError> {
+    let mut cmd = Command::new("git");
+    cmd
+        // Belt and braces on top of the pristine config: even if a hostile
+        // value somehow reached the baseline, these -c overrides win.
+        .arg("--no-pager")
+        .arg("-c")
+        .arg(format!("core.hooksPath={}", empty_hooks.display()))
+        .arg("-c")
+        .arg("core.fsmonitor=false")
+        .arg("-c")
+        .arg("gc.auto=0")
+        .args(args)
+        .current_dir(worktree)
+        // env_clear drops every ambient GIT_*/agent-set variable; git then
+        // sees ONLY what we hand it. PATH survives so `git` subprocesses
+        // (e.g. git-diff helpers shipped with git itself) resolve.
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .env("GIT_DIR", git_dir)
+        .env("GIT_WORK_TREE", worktree)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("LC_ALL", "C")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+    let mut stdout_pipe = child.stdout.take().expect("stdout piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr piped");
+
+    // Reader threads keep the pipes drained (a full pipe would deadlock the
+    // child); the main thread owns the deadline and the kill.
+    let out_reader = std::thread::spawn(move || {
+        let mut kept: Vec<u8> = Vec::new();
+        let mut truncated = false;
+        let mut buf = [0u8; 64 * 1024];
+        loop {
+            match stdout_pipe.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if kept.len() < max_out {
+                        let take = n.min(max_out - kept.len());
+                        kept.extend_from_slice(&buf[..take]);
+                        if take < n {
+                            truncated = true;
+                        }
+                    } else {
+                        truncated = true;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        (kept, truncated)
+    });
+    let err_reader = std::thread::spawn(move || {
+        let mut kept: Vec<u8> = Vec::new();
+        let mut buf = [0u8; 8 * 1024];
+        loop {
+            match stderr_pipe.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if kept.len() < 4096 {
+                        let take = n.min(4096 - kept.len());
+                        kept.extend_from_slice(&buf[..take]);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        String::from_utf8_lossy(&kept).into_owned()
+    });
+
+    let started = Instant::now();
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait()? {
+            Some(st) => break Some(st),
+            None => {
+                if started.elapsed() > timeout {
+                    timed_out = true;
+                    child.kill().ok();
+                    break child.wait().ok();
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    };
+
+    let (stdout, stdout_truncated) = out_reader.join().unwrap_or_default();
+    let stderr_head = err_reader.join().unwrap_or_default();
+    Ok(BoundedOutput {
+        status: status.and_then(|s| s.code()),
+        timed_out,
+        stdout,
+        stdout_truncated,
+        stderr_head,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::materialize_local;
+    use uuid::Uuid;
+
+    fn fixture() -> (std::path::PathBuf, crate::MaterializedWorkspace) {
+        let tmp = std::env::temp_dir().join(format!("fbx-collect-test-{}", Uuid::now_v7()));
+        let src = tmp.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("a.txt"), "hello\n").unwrap();
+        let ws = materialize_local(&tmp.join("data"), Uuid::now_v7(), &src).unwrap();
+        (tmp, ws)
+    }
+
+    fn root_of(ws: &crate::MaterializedWorkspace) -> &Path {
+        ws.host_dir.parent().unwrap()
+    }
+
+    #[test]
+    fn clean_worktree_yields_empty_diff_not_missing() {
+        let (tmp, ws) = fixture();
+        match collect_diff(
+            root_of(&ws),
+            ws.base_commit.as_deref(),
+            &DiffCaps::default(),
+        ) {
+            CollectionOutcome::Diff(d) => {
+                assert!(d.patch.is_empty(), "expected empty diff, got: {}", d.patch);
+                assert!(!d.truncated);
+            }
+            CollectionOutcome::Missing { reason } => panic!("unexpected missing: {reason}"),
+        }
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn hostile_git_config_is_never_executed() {
+        let (tmp, ws) = fixture();
+        let marker = tmp.join("pwned-by-diff-external");
+        // The "agent" poisons ITS copy of .git and .gitattributes with every
+        // classic config-driven execution vector…
+        std::fs::write(ws.host_dir.join("a.txt"), "changed\n").unwrap();
+        std::fs::write(
+            ws.host_dir.join(".git/config"),
+            format!(
+                "[user]\n\temail = t@t\n\tname = t\n[diff]\n\texternal = touch {}\n[core]\n\tfsmonitor = touch {}\n\thooksPath = /tmp\n[filter \"evil\"]\n\tclean = touch {}\n\trequired = true\n",
+                marker.display(),
+                marker.display(),
+                marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(ws.host_dir.join(".gitattributes"), "* filter=evil\n").unwrap();
+        let hook = ws.host_dir.join(".git/hooks/pre-auto-gc");
+        std::fs::create_dir_all(hook.parent().unwrap()).unwrap();
+        std::fs::write(&hook, format!("#!/bin/sh\ntouch {}\n", marker.display())).unwrap();
+
+        // …and collection still produces the true diff without running any of it.
+        match collect_diff(
+            root_of(&ws),
+            ws.base_commit.as_deref(),
+            &DiffCaps::default(),
+        ) {
+            CollectionOutcome::Diff(d) => {
+                assert!(
+                    d.patch.contains("changed"),
+                    "diff lost the edit: {}",
+                    d.patch
+                );
+                // .gitattributes is a real (hostile but inert) file change —
+                // it may appear in the diff; the marker must not exist.
+            }
+            CollectionOutcome::Missing { reason } => panic!("unexpected missing: {reason}"),
+        }
+        assert!(
+            !marker.exists(),
+            "agent-controlled git config was EXECUTED during collection"
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn oversized_diff_is_truncated_and_flagged() {
+        let (tmp, ws) = fixture();
+        let big = "x".repeat(64 * 1024);
+        std::fs::write(ws.host_dir.join("big.txt"), &big).unwrap();
+        let caps = DiffCaps {
+            max_bytes: 4 * 1024,
+            git_timeout: Duration::from_secs(30),
+        };
+        match collect_diff(root_of(&ws), ws.base_commit.as_deref(), &caps) {
+            CollectionOutcome::Diff(d) => {
+                assert!(d.truncated, "expected truncation flag");
+                assert!(d.bytes <= 4 * 1024);
+                assert!(d.sha256.starts_with("sha256:"));
+            }
+            CollectionOutcome::Missing { reason } => panic!("unexpected missing: {reason}"),
+        }
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn missing_baseline_is_explicit_not_no_changes() {
+        let (tmp, ws) = fixture();
+        std::fs::remove_dir_all(root_of(&ws).join(BASELINE_DIR)).unwrap();
+        match collect_diff(
+            root_of(&ws),
+            ws.base_commit.as_deref(),
+            &DiffCaps::default(),
+        ) {
+            CollectionOutcome::Missing { reason } => {
+                assert!(reason.contains("baseline"), "reason: {reason}");
+            }
+            CollectionOutcome::Diff(_) => panic!("must not diff without the pristine baseline"),
+        }
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn missing_worktree_is_explicit() {
+        let (tmp, ws) = fixture();
+        let root = root_of(&ws).to_path_buf();
+        std::fs::remove_dir_all(&ws.host_dir).unwrap();
+        match collect_diff(&root, ws.base_commit.as_deref(), &DiffCaps::default()) {
+            CollectionOutcome::Missing { reason } => {
+                assert!(reason.contains("worktree"), "reason: {reason}");
+            }
+            CollectionOutcome::Diff(_) => panic!("must not report a diff with no worktree"),
+        }
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn deleted_and_added_files_appear() {
+        let (tmp, ws) = fixture();
+        std::fs::remove_file(ws.host_dir.join("a.txt")).unwrap();
+        std::fs::write(ws.host_dir.join("b.txt"), "new file\n").unwrap();
+        match collect_diff(
+            root_of(&ws),
+            ws.base_commit.as_deref(),
+            &DiffCaps::default(),
+        ) {
+            CollectionOutcome::Diff(d) => {
+                assert!(d.patch.contains("deleted file"), "{}", d.patch);
+                assert!(d.patch.contains("b.txt"), "{}", d.patch);
+            }
+            CollectionOutcome::Missing { reason } => panic!("unexpected missing: {reason}"),
+        }
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+}

--- a/crates/fluidbox-workspace/src/lib.rs
+++ b/crates/fluidbox-workspace/src/lib.rs
@@ -1,12 +1,32 @@
-//! Control-plane-side workspace materialization and diff capture.
+//! fluidbox-workspace — the workspace lifecycle both execution providers
+//! share: control-plane-side materialization, the pristine `.git` baseline,
+//! and hardened terminal diff collection.
 //!
-//! This runs during the session's `initializing` phase, BEFORE the agent
-//! starts. The credentialed fetch (git URL) never happens inside the
-//! sandbox — the agent only ever sees a copy bind-mounted at /workspace.
+//! Materialization runs during the session's `initializing` phase, BEFORE
+//! the agent starts. The credentialed fetch (git URL) never happens inside
+//! the sandbox — the agent only ever sees a copy of the tree.
+//!
+//! Collection (see [`collect`]) NEVER executes git against agent-controlled
+//! `.git` state, on any provider: it reconstructs a throwaway repository
+//! from the pristine baseline saved here at materialization time.
+//!
+//! This crate deliberately has no bollard/kube dependencies (it is shared
+//! by every provider), and `fluidbox-core` stays I/O-free (git subprocess
+//! I/O lives here — settled Q13 of the 2026-07-15 design).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use uuid::Uuid;
+
+pub mod collect;
+
+pub use collect::{collect_diff, CollectedDiff, CollectionOutcome, DiffCaps};
+
+/// Directory (under the per-session workspace root) holding the pristine
+/// copy of the materialized `.git` — saved before the agent ever runs,
+/// never mounted into the sandbox, and the ONLY `.git` state collection
+/// will execute against.
+pub const BASELINE_DIR: &str = "baseline-git";
 
 pub struct MaterializedWorkspace {
     pub host_dir: PathBuf,
@@ -81,6 +101,26 @@ fn count_files(dir: &Path) -> u64 {
     n
 }
 
+pub fn session_workspace_root(data_dir: &Path, session: Uuid) -> PathBuf {
+    data_dir.join("workspaces").join(session.to_string())
+}
+
+/// Save the pristine baseline: a full copy of the just-materialized `.git`,
+/// beside the workspace (outside anything a sandbox ever sees). Collection
+/// reconstructs its throwaway repo from THIS, so agent mutations to the
+/// workspace's own `.git` (config, hooks, attributes) are never executed.
+fn save_pristine_baseline(repo: &Path) -> Result<(), WorkspaceError> {
+    let root = repo
+        .parent()
+        .ok_or_else(|| WorkspaceError::Invalid("workspace repo has no parent".into()))?;
+    let baseline = root.join(BASELINE_DIR);
+    if baseline.exists() {
+        std::fs::remove_dir_all(&baseline)?;
+    }
+    copy_dir_all(&repo.join(".git"), &baseline)?;
+    Ok(())
+}
+
 /// Materialize a local directory into an isolated per-session workspace.
 /// Uses a git-tracked copy so we can diff at the end; the original tree is
 /// never touched.
@@ -92,10 +132,7 @@ pub fn materialize_local(
     if !source.exists() {
         return Err(WorkspaceError::NoSource(source.display().to_string()));
     }
-    let dest = data_dir
-        .join("workspaces")
-        .join(session.to_string())
-        .join("repo");
+    let dest = session_workspace_root(data_dir, session).join("repo");
     std::fs::create_dir_all(&dest)?;
 
     // Copy contents (excluding any existing .git so we control history).
@@ -123,15 +160,13 @@ pub fn materialize_local(
     );
     let base_commit = run_git(&dest, &["rev-parse", "HEAD"]).ok();
 
+    save_pristine_baseline(&dest)?;
+
     Ok(MaterializedWorkspace {
         file_count: count_files(&dest),
         host_dir: dest,
         base_commit,
     })
-}
-
-fn session_workspace_root(data_dir: &Path, session: Uuid) -> PathBuf {
-    data_dir.join("workspaces").join(session.to_string())
 }
 
 fn validate_clone_url(url: &str) -> Result<(), WorkspaceError> {
@@ -277,6 +312,9 @@ fn fetch_and_checkout(
     let _ = std::fs::write(dest.join(".git/info/exclude"), LOCAL_EXCLUDES);
 
     let base_commit = run_git(dest, &["rev-parse", "HEAD"]).ok();
+
+    save_pristine_baseline(dest)?;
+
     Ok(MaterializedWorkspace {
         file_count: count_files(dest),
         host_dir: dest.to_path_buf(),
@@ -284,8 +322,9 @@ fn fetch_and_checkout(
     })
 }
 
-/// Remove a session's workspace directory. Idempotent: missing dir is fine.
-/// Only ever touches `<data_dir>/workspaces/<session>` by construction.
+/// Remove a session's workspace directory (repo + baseline + collection
+/// scratch). Idempotent: missing dir is fine. Only ever touches
+/// `<data_dir>/workspaces/<session>` by construction.
 pub fn cleanup_workspace(data_dir: &Path, session: Uuid) -> Result<(), WorkspaceError> {
     let root = session_workspace_root(data_dir, session);
     match std::fs::remove_dir_all(&root) {
@@ -293,20 +332,6 @@ pub fn cleanup_workspace(data_dir: &Path, session: Uuid) -> Result<(), Workspace
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e.into()),
     }
-}
-
-/// Capture the agent's changes as a binary-safe unified diff artifact.
-pub fn capture_diff(host_dir: &Path, base_commit: Option<&str>) -> Result<String, WorkspaceError> {
-    // Stage everything the agent produced, then diff against the base.
-    run_git(host_dir, &["add", "-A"])?;
-    let base = base_commit.unwrap_or("HEAD");
-    // Use --binary so the diff can be applied; --no-color for a clean artifact.
-    let diff = run_git(host_dir, &["diff", "--binary", "--no-color", base])?;
-    if !diff.is_empty() {
-        return Ok(diff);
-    }
-    // Fall back to a cached diff (in case the agent already committed).
-    run_git(host_dir, &["diff", "--binary", "--no-color", base, "HEAD"])
 }
 
 fn copy_tree(src: &Path, dst: &Path) -> Result<(), WorkspaceError> {
@@ -321,6 +346,28 @@ fn copy_tree(src: &Path, dst: &Path) -> Result<(), WorkspaceError> {
         if from.is_dir() {
             std::fs::create_dir_all(&to)?;
             copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// Full recursive copy INCLUDING dotfiles and `.git` internals (used for the
+/// baseline). Symlinks are not followed (skipped): the baseline only needs
+/// git's own object/ref/config files, which git never writes as symlinks.
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), WorkspaceError> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let meta = std::fs::symlink_metadata(&from)?;
+        if meta.is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            copy_dir_all(&from, &to)?;
         } else {
             std::fs::copy(&from, &to)?;
         }
@@ -353,6 +400,17 @@ mod tests {
         (format!("file://{}", src.display()), first, head)
     }
 
+    fn collect(ws: &MaterializedWorkspace, base: Option<&str>) -> CollectionOutcome {
+        collect_diff(ws.host_dir.parent().unwrap(), base, &DiffCaps::default())
+    }
+
+    fn diff_of(out: CollectionOutcome) -> String {
+        match out {
+            CollectionOutcome::Diff(d) => d.patch,
+            CollectionOutcome::Missing { reason } => panic!("expected diff, missing: {reason}"),
+        }
+    }
+
     #[test]
     fn materialize_git_default_head() {
         let tmp = std::env::temp_dir().join(format!("fbx-git-test-{}", Uuid::now_v7()));
@@ -368,10 +426,18 @@ mod tests {
         );
         // The sandbox copy has no remote to push to.
         assert_eq!(run_git(&ws.host_dir, &["remote"]).unwrap(), "");
+        // The pristine baseline exists beside the repo.
+        assert!(ws
+            .host_dir
+            .parent()
+            .unwrap()
+            .join(BASELINE_DIR)
+            .join("HEAD")
+            .exists());
 
-        // Diff capture works over the real cloned history.
+        // Diff capture works over the pristine baseline.
         std::fs::write(ws.host_dir.join("a.txt"), "three\n").unwrap();
-        let diff = capture_diff(&ws.host_dir, ws.base_commit.as_deref()).unwrap();
+        let diff = diff_of(collect(&ws, ws.base_commit.as_deref()));
         assert!(diff.contains("three"));
 
         std::fs::remove_dir_all(&tmp).ok();
@@ -514,7 +580,7 @@ mod tests {
         std::fs::write(ws.host_dir.join("a.txt"), "hello world\n").unwrap();
         std::fs::write(ws.host_dir.join("b.txt"), "new\n").unwrap();
 
-        let diff = capture_diff(&ws.host_dir, ws.base_commit.as_deref()).unwrap();
+        let diff = diff_of(collect(&ws, ws.base_commit.as_deref()));
         assert!(diff.contains("a.txt"));
         assert!(diff.contains("b.txt"));
         assert!(diff.contains("hello world"));

--- a/images/codex-runner/runner/index.mjs
+++ b/images/codex-runner/runner/index.mjs
@@ -411,11 +411,27 @@ function spawnCodex() {
 }
 
 let shuttingDown = false;
+let quiesced = false;
 
 async function main() {
   await client.emit("harness", {
     type: "agent.message",
     data: { role: "system", text: `codex runner starting (autonomy=${env.AUTONOMY}, model=${MODEL})` },
+  });
+  // Cancellation quiesce (shared runner contract): on the heartbeat signal we
+  // interrupt the codex turn and finish WITHOUT posting /result — the control
+  // plane's cancel finalizer owns the terminal outcome and collects the diff.
+  client.onQuiesce(() => {
+    quiesced = true;
+    try {
+      if (threadId && turnId) {
+        rpcSend({ jsonrpc: "2.0", id: nextId++, method: "turn/interrupt", params: { threadId, turnId } });
+      }
+    } catch {
+      /* best effort */
+    }
+    turnDone = true;
+    finishRun();
   });
   client.startHeartbeat();
   client.startTokenRenew();
@@ -511,7 +527,7 @@ async function finishRun() {
   if (finished) return;
   finished = true;
   shuttingDown = true;
-  if (hadError) {
+  if (hadError && !quiesced) {
     await client.emit("harness", {
       type: "run.error",
       data: { message: String(hadError?.message || hadError) },
@@ -523,6 +539,12 @@ async function finishRun() {
     if (child && !child.killed) child.kill("SIGKILL");
   } catch {
     /* ignore */
+  }
+  // Quiesced (cancelled): exit WITHOUT posting /result — the cancel finalizer
+  // records the terminal outcome and collects the diff.
+  if (quiesced) {
+    console.error("fluidbox-codex: quiesced on cancel — exiting without /result");
+    process.exit(0);
   }
   try {
     await client.postResult(hadError ? "failed" : "completed", hadError ? String(hadError.message || hadError) : finalText);

--- a/images/runner-lib/contract.mjs
+++ b/images/runner-lib/contract.mjs
@@ -110,6 +110,31 @@ export class RunnerClient {
     // a full interval later.
     this.renewOkMs = 45 * 60 * 1000;
     this.renewRetryMs = 2 * 60 * 1000;
+    // Quiesce (the sole additive runner-contract field): the heartbeat
+    // response carries {"action":"quiesce"} once the control plane cancels the
+    // run. We invoke the harness-registered abort callback ONCE, which stops
+    // the agent and exits WITHOUT posting /result (the cancel finalizer owns
+    // the outcome). Registered via onQuiesce(); harness-specific, one place.
+    this.quiesceCb = null;
+    this.quiesced = false;
+  }
+
+  /// Register the harness abort callback fired when the control plane asks the
+  /// run to quiesce (cancellation). Called at most once. The callback should
+  /// stop the agent loop and let the process exit 0 without posting /result.
+  onQuiesce(cb) {
+    this.quiesceCb = cb;
+  }
+
+  #maybeQuiesce(res) {
+    if (this.quiesced || !res || res.action !== "quiesce") return;
+    this.quiesced = true;
+    console.error("fluidbox-runner: control plane requested quiesce — stopping agent");
+    try {
+      this.quiesceCb?.();
+    } catch (e) {
+      console.error("fluidbox-runner: quiesce callback threw:", e?.message || e);
+    }
   }
 
   sessionBase() {
@@ -190,7 +215,9 @@ export class RunnerClient {
 
   startHeartbeat() {
     this.heartbeatTimer = setInterval(() => {
-      this.#post(`${this.sessionBase()}/heartbeat`, {}, { retries: 1 }).catch(() => {});
+      this.#post(`${this.sessionBase()}/heartbeat`, {}, { retries: 1 })
+        .then((res) => this.#maybeQuiesce(res))
+        .catch(() => {});
     }, 10000);
     this.heartbeatTimer.unref?.();
   }

--- a/images/sandbox-runner/runner/index.mjs
+++ b/images/sandbox-runner/runner/index.mjs
@@ -100,6 +100,7 @@ async function main() {
 
   let finalText = "";
   let hadError = null;
+  let quiesced = false;
   try {
     const response = query({
       prompt: env.TASK,
@@ -119,7 +120,20 @@ async function main() {
       },
     });
 
+    // Cancellation quiesce: the control plane signals via the heartbeat
+    // response; we interrupt the SDK stream and exit WITHOUT posting /result,
+    // so the cancel finalizer owns the outcome and collects a settled tree.
+    client.onQuiesce(() => {
+      quiesced = true;
+      try {
+        response.interrupt?.();
+      } catch {
+        /* best effort; the break below stops iteration regardless */
+      }
+    });
+
     for await (const msg of response) {
+      if (quiesced) break;
       if (msg.type === "assistant") {
         const text = textFromMessage(msg);
         if (text.trim()) {
@@ -137,12 +151,24 @@ async function main() {
       }
     }
   } catch (e) {
-    hadError = e;
-    console.error("fluidbox-runner: query failed:", e);
-    await client.emit("harness", { type: "run.error", data: { message: String(e?.message || e) } });
+    if (quiesced) {
+      // An interrupt during quiesce surfaces as a throw — expected, not a
+      // failure. Fall through to the quiesce exit below.
+    } else {
+      hadError = e;
+      console.error("fluidbox-runner: query failed:", e);
+      await client.emit("harness", { type: "run.error", data: { message: String(e?.message || e) } });
+    }
   } finally {
     client.stopHeartbeat();
     client.stopTokenRenew();
+  }
+
+  // Quiesced (cancelled): exit WITHOUT posting /result — the control plane's
+  // cancel finalizer records the terminal outcome and collects the diff.
+  if (quiesced) {
+    console.error("fluidbox-runner: quiesced on cancel — exiting without /result");
+    process.exit(0);
   }
 
   try {

--- a/migrations/0011_finalization_intent.sql
+++ b/migrations/0011_finalization_intent.sql
@@ -1,0 +1,31 @@
+-- Durable finalization intent (K8s design 2026-07-15, Phase 0).
+--
+-- The terminal finalizer is "collect BEFORE terminal, on every path". That
+-- means there is a window — enter finalizing → collect diff → terminal — that
+-- must survive a control-plane restart, or a crash strands the session (the
+-- lossy `tokio::spawn` in /result today). This table is the persisted intent:
+-- the outcome/summary to apply once collection completes, plus claim metadata
+-- so a restart-recoverable worker can resume an interrupted finalization.
+--
+-- `sessions.status` is unconstrained text, so `cancelling`/`finalizing` need
+-- no enum migration (settled Q11). One row per session; first writer wins the
+-- outcome (idempotent begin), and the finalizing→terminal transition is the
+-- single-winner gate that actually enqueues delivery.
+
+create table session_finalizations (
+    session_id uuid primary key references sessions(id) on delete cascade,
+    -- terminal state to land once collection completes.
+    outcome text not null,            -- completed|failed|cancelled|budget_exceeded
+    summary text,
+    reason text,                      -- status_reason carried to the terminal transition
+    -- cancel needs a runner quiesce (heartbeat-response) before collection;
+    -- result/fail/budget collect immediately.
+    needs_quiesce boolean not null default false,
+    quiesce_deadline timestamptz,     -- past it: hard-stop + artifact_missing(quiesce_timeout)
+    -- restart-recoverable claim: a driver takes the row (claimed_at), and a
+    -- stale claim (driver crashed mid-finalize) is retaken by the worker.
+    claimed_at timestamptz,
+    attempts int not null default 0,
+    created_at timestamptz not null default now()
+);
+create index session_finalizations_claim on session_finalizations(claimed_at);

--- a/scripts/e2e-schedule.sh
+++ b/scripts/e2e-schedule.sh
@@ -207,7 +207,12 @@ FINAL_C=$(wait_terminal "$SC1" 90) || true
 fake_running "$SC1"
 rewind "$SUBC" "now()"
 wait_trig "$SUBC" "len(d['sessions']) >= 2" 15 1 && ok "replace fired a new run" || no "no replacement run"
-[ "$(sfield "$SC1" "['status']")" = "cancelled" ] && ok "stale run cancelled" || no "stale run status: $(sfield "$SC1" "['status']")"
+# Cancel is asynchronous by design (K8s finalizer, 2026-07-15): it asks the
+# runner to quiesce and collects the diff BEFORE the terminal transition, so
+# the stale run reaches `cancelled` via cancelling→finalizing rather than
+# instantly. Wait for it to wind down instead of racing the drive.
+STALE_C=$(wait_terminal "$SC1" 60)
+[ "$STALE_C" = "cancelled" ] && ok "stale run cancelled" || no "stale run status: $STALE_C"
 sfield "$SC1" "['status_reason']" | grep -q "replaced" && ok "cancel reason names the replacement" || no "reason: $(sfield "$SC1" "['status_reason']")"
 
 say "MISSED skip — SUB D: a 10-minute gap records ONE skip and resumes the cadence"


### PR DESCRIPTION
## K8s Phase 0 — provider seam + collection hardening (Docker-only)

Part of #48 (design `docs/plans/2026-07-15-kubernetes-native-provider-design.md`, "Implementation sequence / Phase 0"). No Kubernetes code — this lands the seam and fixes live defects #1–#5 so the Kubernetes provider (Phase 1) drops in behind a trait that already has the right shape, and so diff/finalizer correctness is proven on Docker first.

Merges into `release/kubernetes-native-provider` (#47).

### What changed

**Provider seam (dual-provider permanence, settled Q17)**
- `AppState.provider` is now `Arc<dyn ExecutionProvider>`, selected by `FLUIDBOX_PROVIDER` (default `docker`). The Docker-specific `ping` health check generalized to a provider `healthcheck()` boot probe (non-fatal) surfaced at `/v1/health/ready`.
- **Trait v2**: `state()` → structured `SandboxStatus{Pending|Running|Terminated|Unknown + reason}`; new `collect_artifacts()` (bounded, returns `Collected` or explicit `Missing{reason}`); `list_orphans` → `list_managed`; added `healthcheck`.

**`fluidbox-workspace` crate (new)** — materialization + archiving + baselines + hardened git + caps + artifact types, no bollard/kube deps (`fluidbox-core` stays I/O-free, settled Q13). Docker's `collect_artifacts` delegates to it; the Kubernetes collector will too.

**Collection hardening (fixes live defect #4 — a hostile-`.git` RCE surface on the control-plane host, TODAY, in the Docker path)**
- A **pristine `.git` baseline** is saved at materialization (before the agent runs). Collection reconstructs a throwaway repo from the baseline pointed at the final worktree and runs git with a **scrubbed environment** (`env_clear`, `GIT_CONFIG_NOSYSTEM`, empty `core.hooksPath`, `core.fsmonitor=false`, `--no-ext-diff`, controlled HOME) — never against the agent's `.git`. Bounded output + kill-on-deadline.
- New unit test proves agent-written `diff.external` / clean filters / hooks are **never executed** during collection.
- Diff size caps + explicit truncation flag (artifacts were unbounded text).
- A diff that can't be collected records **`artifact_missing(reason)`** — never a silent "(no changes)".

**Durable finalizer (fixes live defects #1–#3)**
- New non-terminal states **`cancelling`** / **`finalizing`** (real, persisted, audit-visible). The state machine has **no direct active→terminal edge** — terminal is reachable only through `finalizing`, so "collect before terminal" is structural. Delivery enqueue rides terminal entry, so it can never race the artifact.
- One `begin_finalize` → persisted `session_finalizations` intent (migration 0011) → `drive_finalization` funnel for **every** terminal path (result / cancel / fail / watchdog / budget). `fail()` now collects (was defect #1); cancel collects before terminal (was #2); `/result` persists intent **before** ACK instead of a lossy `tokio::spawn` (was #3).
- **Restart-recoverable**: a boot sweep + a finalize worker re-drive any interrupted finalization (claim-guarded; the finalizing→terminal transition is the single-winner gate).

**Heartbeat quiesce (the ONLY runner-contract change — additive)**
- On cancel, the session enters `cancelling`; the heartbeat response carries `{"action":"quiesce"}`. Runner-lib fires a harness-registered abort callback ONCE, stops the agent, and exits **without** posting `/result`. 30 s deadline → `artifact_missing(quiesce_timeout)` (a racing worktree is never collected). Wired into both harnesses (Claude SDK `interrupt()`, Codex `turn/interrupt`); lives in shared `runner-lib`.

**Other Phase-0 items**
- `pg_advisory_xact_lock` (keyed on connection id) around OAuth refresh rotation — replaces reliance on the in-process `oauth_locks` mutex so a second replica can't double-rotate into `invalid_grant`.
- 512 KiB serialized runner-env ceiling: a 422 at run creation with per-component size diagnostics, re-checked at launch.
- `NetworkMode` derived from config (`FLUIDBOX_NETWORK_MODE`) instead of the `orchestrator.rs:150` hardcode.
- Dashboard/SSE awareness of `cancelling`/`finalizing` (pills) and the new `run.quiesce_requested` / `artifact.collected` / `artifact.missing` events.

### Verification

- `just check` green (fmt + clippy `-D warnings` + workspace unit tests + web test/build). New collection tests (incl. the hostile-git-config no-execution proof) pass.
- **Full Docker e2e green** (maintainer-run, live haiku): all 10 phases — live demo A produced a real diff through the new collector (`diff contains the multiply fix`, `original repo untouched`); governance (approval pause/resume, idempotency, autonomy); failure paths (tool-call budget, watchdog fail+reap, restart+orphan-sweep+finalize-recovery, stale-launch); codex second harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
