### PR TITLE
K8s Phase 1 — KubernetesProvider + workspaced collector + dual listener (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +16,19 @@ checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common 0.2.2",
  "inout",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -34,6 +53,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -91,6 +121,24 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "async-stream"
@@ -234,6 +282,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +324,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -589,6 +654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cron"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +759,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +811,27 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "digest"
@@ -787,6 +919,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +958,44 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -854,6 +1036,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,10 +1068,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluidbox-catalog-import"
@@ -968,6 +1180,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluidbox-provider-k8s"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fluidbox-core",
+ "fluidbox-workspace",
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "fluidbox-server"
 version = "0.1.0"
 dependencies = [
@@ -982,6 +1213,7 @@ dependencies = [
  "fluidbox-core",
  "fluidbox-db",
  "fluidbox-provider",
+ "fluidbox-provider-k8s",
  "fluidbox-workspace",
  "futures",
  "getrandom 0.3.4",
@@ -1007,9 +1239,11 @@ dependencies = [
 name = "fluidbox-workspace"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "fluidbox-core",
  "hex",
  "sha2 0.11.0",
+ "tar",
  "thiserror",
  "uuid",
 ]
@@ -1182,9 +1416,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1212,6 +1448,28 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1297,6 +1555,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -1398,9 +1667,24 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1607,6 +1891,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1986,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4222e00941bfe18bf81b79fa23ad933e233bfa18f3ee27254c5dd9b1543b5d5f"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +2042,111 @@ dependencies = [
  "signature",
  "simple_asn1",
  "zeroize",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
+dependencies = [
+ "base64",
+ "jiff",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "kube"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb9108095346a7096d11feeaff419c75dddcac1b2f59acb38d7bf3d13c3e146"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-runtime",
+]
+
+[[package]]
+name = "kube-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f628e05bc2264c21fe10d3d675117dc9b43ea3bf4fb07262a222679757537b"
+dependencies = [
+ "base64",
+ "bytes",
+ "either",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jiff",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls",
+ "secrecy",
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower",
+ "tower-http 0.6.11",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b02f5933ba06140d58c7d6727f6c319f0962ec6a344aa5e21e475e891deaa8"
+dependencies = [
+ "derive_more",
+ "form_urlencoded",
+ "http",
+ "jiff",
+ "json-patch",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ddec66c540c7cf29a5b41fe4a657a53687f95c346e03bdf00585b70a1bab21"
+dependencies = [
+ "ahash",
+ "async-broadcast",
+ "async-stream",
+ "backon",
+ "educe",
+ "futures",
+ "hashbrown 0.16.1",
+ "hostname",
+ "json-patch",
+ "k8s-openapi",
+ "kube-client",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1802,6 +2251,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +2270,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1901,6 +2366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2453,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,6 +2555,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2615,21 @@ checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
  "cpufeatures 0.3.0",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2131,7 +2682,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -2326,7 +2877,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2464,7 +3015,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2478,6 +3029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2610,12 +3162,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2646,6 +3207,35 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -2730,6 +3320,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -2795,6 +3396,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -2922,7 +3529,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2970,7 +3577,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2984,7 +3591,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
  "thiserror",
@@ -3000,7 +3607,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -3113,6 +3720,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3263,6 +3881,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,6 +3902,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -3286,6 +3917,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3297,15 +3929,18 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "base64",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
+ "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -3315,7 +3950,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "http",
  "http-body",
@@ -3407,10 +4042,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -3446,6 +4103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "universal-hash"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,6 +4129,21 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -3659,6 +4337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3864,10 +4551,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "workspaced"
+version = "0.1.0"
+dependencies = [
+ "fluidbox-workspace",
+ "ureq",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/fluidbox-db",
     "crates/fluidbox-workspace",
     "crates/fluidbox-provider",
+    "crates/fluidbox-provider-k8s",
+    "crates/workspaced",
     "crates/fluidbox-server",
     "crates/fluidbox-cli",
     "crates/fluidbox-catalog-import",
@@ -21,6 +23,7 @@ fluidbox-core = { path = "crates/fluidbox-core" }
 fluidbox-db = { path = "crates/fluidbox-db" }
 fluidbox-workspace = { path = "crates/fluidbox-workspace" }
 fluidbox-provider = { path = "crates/fluidbox-provider" }
+fluidbox-provider-k8s = { path = "crates/fluidbox-provider-k8s" }
 
 anyhow = "1"
 thiserror = "2"

--- a/crates/fluidbox-core/src/traits.rs
+++ b/crates/fluidbox-core/src/traits.rs
@@ -27,7 +27,35 @@ pub struct SandboxSpec {
     /// optimization; archive-based providers pull an immutable archive
     /// instead).
     pub workspace_host_dir: Option<String>,
+    /// Immutable archive descriptor for archive-transport providers
+    /// (Kubernetes). None for host-dir providers (Docker).
+    pub workspace_archive: Option<WorkspaceArchive>,
+    /// Independent wall-clock brake for the sandbox object itself
+    /// (`activeDeadlineSeconds` on Kubernetes), so a runner keeps no local
+    /// compute if the control plane is down. None = installation default.
+    pub active_deadline_secs: Option<u64>,
     pub network: NetworkMode,
+}
+
+/// How a provider hands the workspace to the sandbox. Host-dir providers bind
+/// mount; archive providers pull an immutable digest-verified archive the
+/// control plane packed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceTransport {
+    HostDir,
+    Archive,
+}
+
+/// The control-plane-packed workspace archive an archive-transport provider's
+/// init container pulls, verifies (size + digest), and unpacks.
+#[derive(Debug, Clone)]
+pub struct WorkspaceArchive {
+    /// Internal-listener URL the init container GETs with the session token.
+    pub url: String,
+    pub sha256: String,
+    pub len: u64,
+    /// Diff base the collector uses (the materialized HEAD).
+    pub base_commit: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -144,6 +172,12 @@ pub trait ExecutionProvider: Send + Sync {
     /// Non-fatal readiness probe: is the runtime reachable? Feeds boot
     /// logging and /health/ready — never gates startup.
     async fn healthcheck(&self) -> Result<(), ProviderError>;
+    /// How this provider expects the workspace delivered — lets the
+    /// orchestrator pack an archive only when the backend needs one, without
+    /// knowing which backend it drives.
+    fn workspace_transport(&self) -> WorkspaceTransport {
+        WorkspaceTransport::HostDir
+    }
     fn runtime_name(&self) -> &'static str;
 }
 

--- a/crates/fluidbox-provider-k8s/Cargo.toml
+++ b/crates/fluidbox-provider-k8s/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "fluidbox-provider-k8s"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "fluidbox Kubernetes ExecutionProvider — one bare Pod per run via kube-rs"
+
+[dependencies]
+fluidbox-core = { workspace = true }
+fluidbox-workspace = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+kube = { version = "4", default-features = false, features = [
+    "client",
+    "runtime",
+    "rustls-tls",
+    "ws",
+] }
+k8s-openapi = { version = "0.28", features = ["latest"] }

--- a/crates/fluidbox-provider-k8s/src/config.rs
+++ b/crates/fluidbox-provider-k8s/src/config.rs
@@ -1,0 +1,87 @@
+//! Provider configuration — all cluster-policy knobs (namespace, images,
+//! isolation class, resources, security baseline). Never RunSpec/agent input:
+//! `runtimeClassName` and friends come from the deployment, not the run.
+
+/// The sandbox Pod security + scheduling baseline, portable to any conformant
+/// cluster (design 2026-07-15, §"Sandbox pod security baseline").
+#[derive(Debug, Clone)]
+pub struct K8sConfig {
+    /// The dedicated sandbox namespace (and ONLY that namespace — adoption
+    /// refuses anything else).
+    pub namespace: String,
+    /// The `workspaced` collector image (init + collector containers).
+    pub collector_image: String,
+    /// Hard-isolation runtime class (gVisor/Kata), cluster-selected. None =
+    /// the runc tier (documented as a real but lower tier).
+    pub runtime_class_name: Option<String>,
+    /// Numeric non-root uid (kubelet cannot prove a named USER is non-root).
+    pub run_as_user: i64,
+    /// `activeDeadlineSeconds` fallback for budget-less runs.
+    pub default_deadline_secs: i64,
+    /// Grace added to a run's wall-clock budget for init + teardown.
+    pub init_grace_secs: i64,
+    pub cpu_request: String,
+    pub mem_request: String,
+    pub cpu_limit: String,
+    pub mem_limit: String,
+    pub ephemeral_request: String,
+    pub ephemeral_limit: String,
+    /// `emptyDir.sizeLimit` for the workspace + collector volumes.
+    pub volume_size_limit: String,
+    /// Node scheduling hints applied to every sandbox Pod (values-driven).
+    pub node_selector: Vec<(String, String)>,
+    pub tolerations: Vec<Toleration>,
+    pub priority_class_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Toleration {
+    pub key: Option<String>,
+    pub operator: Option<String>,
+    pub value: Option<String>,
+    pub effect: Option<String>,
+}
+
+impl K8sConfig {
+    /// Build from the process environment (Helm sets these). Defaults are the
+    /// design's documented baseline.
+    pub fn from_env() -> Self {
+        let get = |k: &str| std::env::var(k).ok().filter(|v| !v.is_empty());
+        Self {
+            namespace: get("FLUIDBOX_K8S_NAMESPACE").unwrap_or_else(|| "fluidbox-sandboxes".into()),
+            collector_image: get("FLUIDBOX_COLLECTOR_IMAGE")
+                .unwrap_or_else(|| "ghcr.io/hrishikeshdkakkad/fluidbox-workspaced:dev".into()),
+            runtime_class_name: get("FLUIDBOX_K8S_RUNTIME_CLASS"),
+            run_as_user: get("FLUIDBOX_K8S_RUN_AS_USER")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(10001),
+            default_deadline_secs: get("FLUIDBOX_K8S_DEFAULT_DEADLINE_SECS")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(3 * 3600),
+            init_grace_secs: get("FLUIDBOX_K8S_INIT_GRACE_SECS")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(300),
+            cpu_request: get("FLUIDBOX_K8S_CPU_REQUEST").unwrap_or_else(|| "500m".into()),
+            mem_request: get("FLUIDBOX_K8S_MEM_REQUEST").unwrap_or_else(|| "1Gi".into()),
+            cpu_limit: get("FLUIDBOX_K8S_CPU_LIMIT").unwrap_or_else(|| "2".into()),
+            mem_limit: get("FLUIDBOX_K8S_MEM_LIMIT").unwrap_or_else(|| "2Gi".into()),
+            ephemeral_request: get("FLUIDBOX_K8S_EPHEMERAL_REQUEST")
+                .unwrap_or_else(|| "1Gi".into()),
+            ephemeral_limit: get("FLUIDBOX_K8S_EPHEMERAL_LIMIT").unwrap_or_else(|| "10Gi".into()),
+            volume_size_limit: get("FLUIDBOX_K8S_VOLUME_SIZE_LIMIT")
+                .unwrap_or_else(|| "10Gi".into()),
+            node_selector: parse_kv(get("FLUIDBOX_K8S_NODE_SELECTOR")),
+            tolerations: Vec::new(),
+            priority_class_name: get("FLUIDBOX_K8S_PRIORITY_CLASS"),
+        }
+    }
+}
+
+/// Parse `k1=v1,k2=v2` into pairs (node selector labels).
+fn parse_kv(s: Option<String>) -> Vec<(String, String)> {
+    let Some(s) = s else { return Vec::new() };
+    s.split(',')
+        .filter_map(|p| p.split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .collect()
+}

--- a/crates/fluidbox-provider-k8s/src/lib.rs
+++ b/crates/fluidbox-provider-k8s/src/lib.rs
@@ -1,0 +1,603 @@
+//! fluidbox-provider-k8s — the Kubernetes ExecutionProvider (design
+//! 2026-07-15). One bare Pod per run in a dedicated sandbox namespace, via
+//! kube-rs. Runner images run UNMODIFIED; the pod pulls a credential-free
+//! immutable archive; the diff is collected in-pod against a pristine baseline
+//! over `pods/exec`. All Kubernetes knowledge lives in this crate — the server
+//! sees only the `ExecutionProvider` trait.
+//!
+//! Invariants (mirrored from the design):
+//! - Pod-first/Secret-second with an ownerReference → Pod, so the token
+//!   Secret is GC-reaped and never orphaned; no patch step, no orphan window.
+//! - Every mutation is UID-preconditioned: a stale handle can never delete a
+//!   Pod that reused the deterministic name.
+//! - `state()` inspects the NAMED runner container, not Pod phase (the
+//!   collector keeps the Pod Running after the runner exits, by design).
+//! - Watches accelerate detection but are never truth; the orchestrator's
+//!   periodic list/reconcile is authoritative (same philosophy as SSE
+//!   NOTIFY+seq).
+
+use async_trait::async_trait;
+use fluidbox_core::traits::{
+    CollectContext, CollectedArtifact, CollectedArtifacts, ExecutionProvider, ProviderError,
+    SandboxHandle, SandboxSpec, SandboxStatus, WorkspaceTransport,
+};
+use k8s_openapi::api::core::v1::{Pod, Secret};
+use kube::api::{Api, AttachParams, DeleteParams, ListParams, Preconditions, PropagationPolicy};
+use kube::core::ObjectMeta;
+use kube::{Client, ResourceExt};
+use std::time::Duration;
+use uuid::Uuid;
+
+pub mod config;
+pub mod manifest;
+
+use config::K8sConfig;
+use manifest::{
+    build_pod, build_secret, object_name, COLLECTOR_CONTAINER, LABEL_MANAGED, LABEL_SESSION,
+    RUNNER_CONTAINER,
+};
+
+const RUNTIME: &str = "kubernetes";
+/// Diff artifacts are bounded at this many bytes over exec (the collector
+/// already caps them; this is the receive-side ceiling).
+const MAX_DIFF_BYTES: usize = 16 * 1024 * 1024;
+
+pub struct KubernetesProvider {
+    pods: Api<Pod>,
+    secrets: Api<Secret>,
+    cfg: K8sConfig,
+    namespace: String,
+}
+
+impl KubernetesProvider {
+    /// Connect using the ambient kube config (in-cluster ServiceAccount, or
+    /// `~/.kube/config` for local dev). Fails if no cluster is reachable.
+    pub async fn connect(cfg: K8sConfig) -> anyhow::Result<Self> {
+        let client = Client::try_default().await?;
+        Ok(Self::with_client(client, cfg))
+    }
+
+    pub fn with_client(client: Client, cfg: K8sConfig) -> Self {
+        let namespace = cfg.namespace.clone();
+        Self {
+            pods: Api::namespaced(client.clone(), &namespace),
+            secrets: Api::namespaced(client, &namespace),
+            cfg,
+            namespace,
+        }
+    }
+
+    fn handle(&self, name: &str, uid: &str) -> SandboxHandle {
+        SandboxHandle {
+            runtime: RUNTIME.into(),
+            external_id: name.into(),
+            attrs: serde_json::json!({ "namespace": self.namespace, "uid": uid }),
+        }
+    }
+
+    fn handle_uid<'a>(&self, handle: &'a SandboxHandle) -> Option<&'a str> {
+        handle.attrs.get("uid").and_then(|v| v.as_str())
+    }
+
+    /// UID-guarded delete of a Pod: a stale handle never deletes a Pod that
+    /// reused the name. Foreground propagation reaps the Secret via its
+    /// ownerReference. Idempotent (404 = already gone).
+    async fn delete_pod(&self, name: &str, uid: Option<&str>) -> Result<(), ProviderError> {
+        let dp = DeleteParams {
+            preconditions: uid.map(|u| Preconditions {
+                uid: Some(u.to_string()),
+                resource_version: None,
+            }),
+            propagation_policy: Some(PropagationPolicy::Foreground),
+            ..Default::default()
+        };
+        match self.pods.delete(name, &dp).await {
+            Ok(_) => Ok(()),
+            Err(kube::Error::Api(e)) if e.code == 404 => Ok(()),
+            // A 409 precondition mismatch means the Pod is a DIFFERENT object
+            // than our handle names — not ours to delete. Treat as success
+            // (ours is already gone).
+            Err(kube::Error::Api(e)) if e.code == 409 => Ok(()),
+            Err(e) => Err(map_err(e)),
+        }
+    }
+}
+
+fn map_err(e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(e.to_string())
+}
+
+/// Map a Pod to the structured status of its NAMED runner container (not Pod
+/// phase). Init failure surfaces as a terminated runner so the orchestrator
+/// fails the run; a still-pulling image is Pending with the reason.
+pub fn runner_status(pod: &Pod) -> SandboxStatus {
+    let status = match &pod.status {
+        Some(s) => s,
+        None => return SandboxStatus::Pending { reason: None },
+    };
+
+    // An init container that terminated non-zero blocks the runner forever —
+    // report it as a terminated sandbox with the init reason.
+    if let Some(inits) = &status.init_container_statuses {
+        for c in inits {
+            if let Some(term) = c.state.as_ref().and_then(|st| st.terminated.as_ref()) {
+                if term.exit_code != 0 {
+                    return SandboxStatus::Terminated {
+                        exit_code: Some(term.exit_code as i64),
+                        reason: Some(format!(
+                            "init:{}",
+                            term.reason.clone().unwrap_or_else(|| "Error".into())
+                        )),
+                    };
+                }
+            }
+            // Still waiting on an init container (e.g. image pull) → Pending.
+            if let Some(w) = c.state.as_ref().and_then(|st| st.waiting.as_ref()) {
+                if fatal_waiting(w.reason.as_deref()) {
+                    return SandboxStatus::Terminated {
+                        exit_code: None,
+                        reason: Some(format!(
+                            "init:{}",
+                            w.reason.clone().unwrap_or_else(|| "Waiting".into())
+                        )),
+                    };
+                }
+            }
+        }
+    }
+
+    if let Some(containers) = &status.container_statuses {
+        if let Some(runner) = containers.iter().find(|c| c.name == RUNNER_CONTAINER) {
+            if let Some(state) = &runner.state {
+                if state.running.is_some() {
+                    return SandboxStatus::Running;
+                }
+                if let Some(term) = &state.terminated {
+                    return SandboxStatus::Terminated {
+                        exit_code: Some(term.exit_code as i64),
+                        reason: term.reason.clone(),
+                    };
+                }
+                if let Some(w) = &state.waiting {
+                    if fatal_waiting(w.reason.as_deref()) {
+                        return SandboxStatus::Terminated {
+                            exit_code: None,
+                            reason: w.reason.clone(),
+                        };
+                    }
+                    return SandboxStatus::Pending {
+                        reason: w.reason.clone(),
+                    };
+                }
+            }
+        }
+    }
+
+    // Overall failure with no container detail (scheduling failure, node loss).
+    match status.phase.as_deref() {
+        Some("Failed") => SandboxStatus::Terminated {
+            exit_code: None,
+            reason: status.reason.clone().or(Some("PodFailed".into())),
+        },
+        Some("Succeeded") => SandboxStatus::Terminated {
+            exit_code: Some(0),
+            reason: None,
+        },
+        _ => SandboxStatus::Pending {
+            reason: status.reason.clone(),
+        },
+    }
+}
+
+/// Waiting reasons that will never resolve on their own — a misconfigured
+/// image or config, distinct from an in-progress pull (`ContainerCreating`,
+/// `PodInitializing`, `ImagePull*` in progress).
+fn fatal_waiting(reason: Option<&str>) -> bool {
+    matches!(
+        reason,
+        Some("ImagePullBackOff")
+            | Some("ErrImagePull")
+            | Some("InvalidImageName")
+            | Some("CreateContainerConfigError")
+            | Some("CreateContainerError")
+            | Some("RunContainerError")
+    )
+}
+
+#[async_trait]
+impl ExecutionProvider for KubernetesProvider {
+    async fn provision(&self, spec: &SandboxSpec) -> Result<SandboxHandle, ProviderError> {
+        let name = object_name(spec.session_id);
+
+        // 1. Create the Pod referencing the not-yet-existing Secret. The
+        //    kubelet holds container start until the Secret lands.
+        let pod: Pod = serde_json::from_value(build_pod(spec, &self.cfg))
+            .map_err(|e| ProviderError::Other(format!("bad pod manifest: {e}")))?;
+        let created = self
+            .pods
+            .create(&Default::default(), &pod)
+            .await
+            .map_err(map_err)?;
+        let uid = created
+            .metadata
+            .uid
+            .clone()
+            .ok_or_else(|| ProviderError::Other("created pod has no uid".into()))?;
+
+        // 2. Create the immutable Secret with an ownerReference → Pod UID.
+        let secret: Secret = serde_json::from_value(build_secret(spec, &uid))
+            .map_err(|e| ProviderError::Other(format!("bad secret manifest: {e}")))?;
+        if let Err(e) = self.secrets.create(&Default::default(), &secret).await {
+            // Secret create failed → clean up the Pod (UID-guarded) so nothing
+            // orphans, and surface the error (the orchestrator revokes the
+            // token on the failed-run path).
+            let _ = self.delete_pod(&name, Some(&uid)).await;
+            return Err(map_err(e));
+        }
+
+        // 3. Block until workspace-init succeeded and the runner started (or a
+        //    failure / deadline). `initializing → running` then matches
+        //    reality and the workspace endpoint can't race the state gate.
+        let deadline = std::time::Instant::now()
+            + Duration::from_secs(self.cfg.init_grace_secs.max(60) as u64);
+        loop {
+            match self.pods.get_opt(&name).await.map_err(map_err)? {
+                Some(pod) => match runner_status(&pod) {
+                    SandboxStatus::Running => break,
+                    SandboxStatus::Terminated { exit_code, reason } => {
+                        let _ = self.delete_pod(&name, Some(&uid)).await;
+                        return Err(ProviderError::Other(format!(
+                            "sandbox failed to start (exit={exit_code:?} reason={reason:?})"
+                        )));
+                    }
+                    SandboxStatus::Pending { .. } | SandboxStatus::Unknown { .. } => {}
+                },
+                None => {
+                    return Err(ProviderError::Other(
+                        "pod vanished during provisioning".into(),
+                    ))
+                }
+            }
+            if std::time::Instant::now() > deadline {
+                let _ = self.delete_pod(&name, Some(&uid)).await;
+                return Err(ProviderError::Other(
+                    "sandbox did not start before the provisioning deadline".into(),
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+
+        Ok(self.handle(&name, &uid))
+    }
+
+    async fn state(&self, handle: &SandboxHandle) -> Result<SandboxStatus, ProviderError> {
+        match self
+            .pods
+            .get_opt(&handle.external_id)
+            .await
+            .map_err(map_err)?
+        {
+            None => Ok(SandboxStatus::Unknown {
+                reason: Some("pod not found".into()),
+            }),
+            Some(pod) => {
+                // UID guard: a same-named pod that reused the name is NOT ours.
+                if let (Some(want), Some(got)) =
+                    (self.handle_uid(handle), pod.metadata.uid.as_deref())
+                {
+                    if want != got {
+                        return Ok(SandboxStatus::Unknown {
+                            reason: Some("pod uid mismatch (name reused)".into()),
+                        });
+                    }
+                }
+                Ok(runner_status(&pod))
+            }
+        }
+    }
+
+    async fn collect_artifacts(
+        &self,
+        handle: Option<&SandboxHandle>,
+        _ctx: &CollectContext,
+    ) -> Result<CollectedArtifacts, ProviderError> {
+        let Some(handle) = handle else {
+            return Ok(CollectedArtifacts::Missing {
+                reason: "no sandbox handle (pod never provisioned)".into(),
+            });
+        };
+        let name = &handle.external_id;
+
+        // Compute the diff in the collector container (pristine baseline +
+        // final worktree, scrubbed git), then stream the finished file.
+        if let Err(e) = self.exec_collect(name, &["workspaced", "diff"]).await {
+            return Ok(CollectedArtifacts::Missing {
+                reason: format!("collector diff exec failed: {e}"),
+            });
+        }
+        let raw = match self.exec_collect(name, &["workspaced", "stream"]).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                return Ok(CollectedArtifacts::Missing {
+                    reason: format!("collector stream exec failed: {e}"),
+                })
+            }
+        };
+        Ok(parse_collected(&raw))
+    }
+
+    async fn terminate(&self, handle: &SandboxHandle) -> Result<(), ProviderError> {
+        self.delete_pod(&handle.external_id, self.handle_uid(handle))
+            .await
+    }
+
+    async fn list_managed(&self) -> Result<Vec<(Uuid, SandboxHandle)>, ProviderError> {
+        let lp = ListParams::default().labels(&format!("{LABEL_MANAGED}=true"));
+        let pods = self.pods.list(&lp).await.map_err(map_err)?;
+        let mut out = Vec::new();
+        for pod in pods {
+            // Adoption validation: the session label must parse, the pod must
+            // live in OUR namespace, and it must carry a uid.
+            let labels = pod.labels();
+            let Some(sid) = labels
+                .get(LABEL_SESSION)
+                .and_then(|s| Uuid::parse_str(s).ok())
+            else {
+                continue;
+            };
+            let ns = pod.namespace().unwrap_or_default();
+            if ns != self.namespace {
+                continue;
+            }
+            let Some(uid) = pod.metadata.uid.clone() else {
+                continue;
+            };
+            let name = pod.name_any();
+            out.push((sid, self.handle(&name, &uid)));
+        }
+        Ok(out)
+    }
+
+    async fn healthcheck(&self) -> Result<(), ProviderError> {
+        // A cheap namespaced list proves the apiserver + RBAC are reachable.
+        self.pods
+            .list(&ListParams::default().limit(1))
+            .await
+            .map(|_| ())
+            .map_err(map_err)
+    }
+
+    fn workspace_transport(&self) -> WorkspaceTransport {
+        WorkspaceTransport::Archive
+    }
+
+    fn runtime_name(&self) -> &'static str {
+        RUNTIME
+    }
+}
+
+impl KubernetesProvider {
+    /// Exec a command in the collector container and return its stdout. Used
+    /// for `workspaced diff` (side-effecting; stdout ignored) and
+    /// `workspaced stream` (the diff bytes).
+    async fn exec_collect(&self, pod: &str, cmd: &[&str]) -> Result<Vec<u8>, ProviderError> {
+        let ap = AttachParams::default()
+            .container(COLLECTOR_CONTAINER)
+            .stdout(true)
+            .stderr(true);
+        let mut proc = self
+            .pods
+            .exec(pod, cmd.to_vec(), &ap)
+            .await
+            .map_err(map_err)?;
+        let mut buf = Vec::new();
+        if let Some(out) = proc.stdout() {
+            // Bounded read: the collector already caps the diff; this stops a
+            // runaway stream from exhausting control-plane memory. kube's exec
+            // streams are tokio AsyncRead.
+            use tokio::io::AsyncReadExt;
+            let mut limited = out.take(MAX_DIFF_BYTES as u64);
+            limited
+                .read_to_end(&mut buf)
+                .await
+                .map_err(|e| ProviderError::Other(format!("exec stdout read: {e}")))?;
+        }
+        // Surface a non-zero exec exit as an error (the collector's own
+        // failures are already encoded in the streamed header, but a transport
+        // failure should not masquerade as an empty diff).
+        let _ = proc.join().await;
+        Ok(buf)
+    }
+}
+
+/// Parse the collector's `fluidbox-diff v1 …` header + body into a
+/// `CollectedArtifacts`. The header distinguishes a real (possibly empty)
+/// diff from an explicit missing marker.
+fn parse_collected(raw: &[u8]) -> CollectedArtifacts {
+    let text = String::from_utf8_lossy(raw);
+    let mut lines = text.splitn(2, '\n');
+    let header = lines.next().unwrap_or("");
+    let body = lines.next().unwrap_or("");
+    if !header.starts_with("fluidbox-diff v1") {
+        return CollectedArtifacts::Missing {
+            reason: "collector output missing/garbled header".into(),
+        };
+    }
+    let field = |key: &str| {
+        header
+            .split_whitespace()
+            .find_map(|tok| tok.strip_prefix(&format!("{key}=")))
+    };
+    match field("status") {
+        Some("ok") => {
+            let bytes = field("bytes")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(body.len() as u64);
+            let sha256 = field("sha256").unwrap_or("").to_string();
+            let truncated = field("truncated") == Some("true");
+            CollectedArtifacts::Collected(vec![CollectedArtifact {
+                kind: "diff".into(),
+                name: "changes.patch".into(),
+                content: body.to_string(),
+                content_type: "text/x-diff".into(),
+                truncated,
+                sha256,
+                bytes,
+            }])
+        }
+        Some("missing") => CollectedArtifacts::Missing {
+            reason: field("reason").unwrap_or("unspecified").replace('_', " "),
+        },
+        _ => CollectedArtifacts::Missing {
+            reason: "collector reported an unknown status".into(),
+        },
+    }
+}
+
+/// Build a Pod ObjectMeta helper (kept for symmetry / future adoption code).
+#[allow(dead_code)]
+fn meta(name: &str) -> ObjectMeta {
+    ObjectMeta {
+        name: Some(name.into()),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{
+        ContainerState, ContainerStateRunning, ContainerStateTerminated, ContainerStateWaiting,
+        ContainerStatus, PodStatus,
+    };
+
+    fn pod_with(runner: Option<ContainerState>, inits: Vec<ContainerStatus>) -> Pod {
+        Pod {
+            status: Some(PodStatus {
+                container_statuses: runner.map(|st| {
+                    vec![ContainerStatus {
+                        name: RUNNER_CONTAINER.into(),
+                        state: Some(st),
+                        ..Default::default()
+                    }]
+                }),
+                init_container_statuses: if inits.is_empty() { None } else { Some(inits) },
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn running_runner_is_running() {
+        let st = ContainerState {
+            running: Some(ContainerStateRunning::default()),
+            ..Default::default()
+        };
+        assert_eq!(
+            runner_status(&pod_with(Some(st), vec![])),
+            SandboxStatus::Running
+        );
+    }
+
+    #[test]
+    fn terminated_runner_carries_exit_code() {
+        let st = ContainerState {
+            terminated: Some(ContainerStateTerminated {
+                exit_code: 3,
+                reason: Some("Error".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            runner_status(&pod_with(Some(st), vec![])),
+            SandboxStatus::Terminated {
+                exit_code: Some(3),
+                reason: Some("Error".into())
+            }
+        );
+    }
+
+    #[test]
+    fn image_pull_backoff_is_fatal_terminated() {
+        let st = ContainerState {
+            waiting: Some(ContainerStateWaiting {
+                reason: Some("ImagePullBackOff".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(
+            runner_status(&pod_with(Some(st), vec![])),
+            SandboxStatus::Terminated { .. }
+        ));
+    }
+
+    #[test]
+    fn container_creating_is_pending() {
+        let st = ContainerState {
+            waiting: Some(ContainerStateWaiting {
+                reason: Some("ContainerCreating".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(
+            runner_status(&pod_with(Some(st), vec![])),
+            SandboxStatus::Pending { .. }
+        ));
+    }
+
+    #[test]
+    fn failed_init_container_is_terminated() {
+        let init = ContainerStatus {
+            name: "workspace-init".into(),
+            state: Some(ContainerState {
+                terminated: Some(ContainerStateTerminated {
+                    exit_code: 1,
+                    reason: Some("Error".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(
+            runner_status(&pod_with(None, vec![init])),
+            SandboxStatus::Terminated { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_ok_diff() {
+        let raw =
+            b"fluidbox-diff v1 status=ok bytes=12 sha256=sha256:ab truncated=false\ndiff --git\n";
+        match parse_collected(raw) {
+            CollectedArtifacts::Collected(a) => {
+                assert_eq!(a[0].kind, "diff");
+                assert!(a[0].content.contains("diff --git"));
+                assert_eq!(a[0].sha256, "sha256:ab");
+                assert!(!a[0].truncated);
+            }
+            _ => panic!("expected collected"),
+        }
+    }
+
+    #[test]
+    fn parse_missing_diff() {
+        let raw = b"fluidbox-diff v1 status=missing reason=quiesce_timeout\n";
+        match parse_collected(raw) {
+            CollectedArtifacts::Missing { reason } => assert_eq!(reason, "quiesce timeout"),
+            _ => panic!("expected missing"),
+        }
+    }
+
+    #[test]
+    fn parse_garbled_is_missing() {
+        assert!(matches!(
+            parse_collected(b"garbage"),
+            CollectedArtifacts::Missing { .. }
+        ));
+    }
+}

--- a/crates/fluidbox-provider-k8s/src/manifest.rs
+++ b/crates/fluidbox-provider-k8s/src/manifest.rs
@@ -1,0 +1,305 @@
+//! Pure Pod + Secret manifest assembly — no cluster I/O, so the shape
+//! (env routing, security baseline, container topology) is unit-testable
+//! without a kube-apiserver (this is the P3 mocked-kube tier's main target).
+
+use crate::config::K8sConfig;
+use fluidbox_core::traits::SandboxSpec;
+use serde_json::{json, Value};
+
+pub const LABEL_SESSION: &str = "fluidbox.dev/session";
+pub const LABEL_MANAGED: &str = "fluidbox.dev/managed";
+pub const RUNNER_CONTAINER: &str = "runner";
+pub const COLLECTOR_CONTAINER: &str = "workspace-collector";
+pub const INIT_CONTAINER: &str = "workspace-init";
+pub const SECRET_TOKEN_KEY: &str = "session-token";
+
+/// Deterministic per-run object name.
+pub fn object_name(session_id: uuid::Uuid) -> String {
+    format!("fluidbox-{session_id}")
+}
+
+fn labels(session_id: uuid::Uuid) -> Value {
+    json!({
+        LABEL_SESSION: session_id.to_string(),
+        LABEL_MANAGED: "true",
+    })
+}
+
+/// The per-run Secret carrying the session token — created AFTER the Pod so
+/// its ownerReference can point at the Pod UID (GC reaps it with the Pod).
+/// `immutable` locks it against tampering.
+pub fn build_secret(spec: &SandboxSpec, pod_uid: &str) -> Value {
+    let name = object_name(spec.session_id);
+    let token = session_token(spec).unwrap_or_default();
+    json!({
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": name,
+            "labels": labels(spec.session_id),
+            "ownerReferences": [{
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": name,
+                "uid": pod_uid,
+                "controller": false,
+                "blockOwnerDeletion": false,
+            }],
+        },
+        "type": "Opaque",
+        "immutable": true,
+        "stringData": { SECRET_TOKEN_KEY: token },
+    })
+}
+
+/// The one disposable execution object: init (fetch+unpack), runner
+/// (unmodified harness image), collector (long-lived, diff-out). References
+/// the not-yet-existing Secret so the kubelet holds container start until the
+/// Secret lands (Pod-first/Secret-second — no orphan window, no patch step).
+pub fn build_pod(spec: &SandboxSpec, cfg: &K8sConfig) -> Value {
+    let name = object_name(spec.session_id);
+    let secret_name = name.clone();
+    let token = session_token(spec);
+    let archive = spec.workspace_archive.as_ref();
+
+    // Env routing: anything whose VALUE is the session token rides a
+    // secretKeyRef (pods-read RBAC must not leak a live token via PodSpec env);
+    // everything else is a plain literal.
+    let mut plain_env: Vec<Value> = Vec::new();
+    for (k, v) in &spec.env {
+        if token.as_deref() == Some(v.as_str()) {
+            plain_env.push(secret_ref_env(k, &secret_name, SECRET_TOKEN_KEY));
+        } else {
+            plain_env.push(json!({ "name": k, "value": v }));
+        }
+    }
+
+    let base_commit = archive
+        .and_then(|a| a.base_commit.clone())
+        .unwrap_or_default();
+
+    let container_sc = json!({
+        "allowPrivilegeEscalation": false,
+        "capabilities": { "drop": ["ALL"] },
+        "runAsNonRoot": true,
+        "runAsUser": cfg.run_as_user,
+    });
+
+    let init_env = json!([
+        { "name": "FLUIDBOX_WORKSPACE", "value": "/workspace" },
+        { "name": "FLUIDBOX_COLLECTOR_DIR", "value": "/collector" },
+        { "name": "FLUIDBOX_WORKSPACE_ARCHIVE_URL",
+          "value": archive.map(|a| a.url.clone()).unwrap_or_default() },
+        { "name": "FLUIDBOX_ARCHIVE_SHA256",
+          "value": archive.map(|a| a.sha256.clone()).unwrap_or_default() },
+        { "name": "FLUIDBOX_ARCHIVE_LEN",
+          "value": archive.map(|a| a.len.to_string()).unwrap_or_default() },
+        secret_ref_env("FLUIDBOX_SESSION_TOKEN", &secret_name, SECRET_TOKEN_KEY),
+    ]);
+
+    let collector_env = json!([
+        { "name": "FLUIDBOX_WORKSPACE", "value": "/workspace" },
+        { "name": "FLUIDBOX_COLLECTOR_DIR", "value": "/collector" },
+        { "name": "FLUIDBOX_BASE_COMMIT", "value": base_commit },
+    ]);
+
+    let mut pod_spec = json!({
+        "restartPolicy": "Never",
+        "automountServiceAccountToken": false,
+        "enableServiceLinks": false,
+        "activeDeadlineSeconds": active_deadline(spec, cfg),
+        "securityContext": {
+            "runAsNonRoot": true,
+            "runAsUser": cfg.run_as_user,
+            "runAsGroup": cfg.run_as_user,
+            "fsGroup": cfg.run_as_user,
+            "seccompProfile": { "type": "RuntimeDefault" },
+        },
+        "volumes": [
+            { "name": "workspace", "emptyDir": { "sizeLimit": cfg.volume_size_limit } },
+            { "name": "collector", "emptyDir": { "sizeLimit": cfg.volume_size_limit } },
+        ],
+        "initContainers": [{
+            "name": INIT_CONTAINER,
+            "image": cfg.collector_image,
+            "command": ["workspaced", "init"],
+            "env": init_env,
+            "securityContext": container_sc,
+            "volumeMounts": [
+                { "name": "workspace", "mountPath": "/workspace" },
+                { "name": "collector", "mountPath": "/collector" },
+            ],
+        }],
+        "containers": [
+            {
+                "name": RUNNER_CONTAINER,
+                "image": spec.image,
+                "workingDir": "/workspace",
+                "env": plain_env,
+                "securityContext": container_sc,
+                "resources": {
+                    "requests": {
+                        "cpu": cfg.cpu_request, "memory": cfg.mem_request,
+                        "ephemeral-storage": cfg.ephemeral_request,
+                    },
+                    "limits": {
+                        "cpu": cfg.cpu_limit, "memory": cfg.mem_limit,
+                        "ephemeral-storage": cfg.ephemeral_limit,
+                    },
+                },
+                "volumeMounts": [
+                    { "name": "workspace", "mountPath": "/workspace" },
+                ],
+            },
+            {
+                "name": COLLECTOR_CONTAINER,
+                "image": cfg.collector_image,
+                "command": ["workspaced", "wait"],
+                "env": collector_env,
+                "securityContext": container_sc,
+                "resources": {
+                    "requests": { "cpu": "50m", "memory": "64Mi" },
+                    "limits": { "cpu": "500m", "memory": "256Mi" },
+                },
+                "volumeMounts": [
+                    { "name": "workspace", "mountPath": "/workspace", "readOnly": true },
+                    { "name": "collector", "mountPath": "/collector" },
+                ],
+            },
+        ],
+    });
+
+    // Cluster-policy scheduling knobs, applied only when set.
+    if let Some(rc) = &cfg.runtime_class_name {
+        pod_spec["runtimeClassName"] = json!(rc);
+    }
+    if let Some(pc) = &cfg.priority_class_name {
+        pod_spec["priorityClassName"] = json!(pc);
+    }
+    if !cfg.node_selector.is_empty() {
+        let ns: serde_json::Map<String, Value> = cfg
+            .node_selector
+            .iter()
+            .map(|(k, v)| (k.clone(), json!(v)))
+            .collect();
+        pod_spec["nodeSelector"] = Value::Object(ns);
+    }
+    if !cfg.tolerations.is_empty() {
+        pod_spec["tolerations"] = json!(cfg
+            .tolerations
+            .iter()
+            .map(|t| json!({
+                "key": t.key, "operator": t.operator, "value": t.value, "effect": t.effect,
+            }))
+            .collect::<Vec<_>>());
+    }
+
+    json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": name, "labels": labels(spec.session_id) },
+        "spec": pod_spec,
+    })
+}
+
+fn active_deadline(spec: &SandboxSpec, cfg: &K8sConfig) -> i64 {
+    match spec.active_deadline_secs {
+        Some(b) => b as i64 + cfg.init_grace_secs,
+        None => cfg.default_deadline_secs,
+    }
+}
+
+fn secret_ref_env(name: &str, secret: &str, key: &str) -> Value {
+    json!({
+        "name": name,
+        "valueFrom": { "secretKeyRef": { "name": secret, "key": key } },
+    })
+}
+
+fn session_token(spec: &SandboxSpec) -> Option<String> {
+    spec.env
+        .iter()
+        .find(|(k, _)| k == "FLUIDBOX_SESSION_TOKEN")
+        .map(|(_, v)| v.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluidbox_core::traits::{NetworkMode, WorkspaceArchive};
+
+    fn spec() -> SandboxSpec {
+        SandboxSpec {
+            session_id: uuid::Uuid::nil(),
+            image: "ghcr.io/x/runner:dev".into(),
+            env: vec![
+                ("FLUIDBOX_SESSION_TOKEN".into(), "fbx_sess_secret".into()),
+                ("ANTHROPIC_API_KEY".into(), "fbx_sess_secret".into()),
+                ("FLUIDBOX_TASK".into(), "do a thing".into()),
+                ("FLUIDBOX_CONTROL_URL".into(), "http://svc:8788".into()),
+            ],
+            workspace_host_dir: None,
+            workspace_archive: Some(WorkspaceArchive {
+                url: "http://svc:8788/internal/sessions/x/workspace".into(),
+                sha256: "sha256:abcd".into(),
+                len: 1234,
+                base_commit: Some("deadbeef".into()),
+            }),
+            active_deadline_secs: Some(600),
+            network: NetworkMode::Hardened,
+        }
+    }
+
+    fn cfg() -> K8sConfig {
+        K8sConfig::from_env()
+    }
+
+    #[test]
+    fn token_never_appears_as_a_plain_pod_env_literal() {
+        let pod = build_pod(&spec(), &cfg());
+        let runner = &pod["spec"]["containers"][0];
+        assert_eq!(runner["name"], RUNNER_CONTAINER);
+        let env = runner["env"].as_array().unwrap();
+        // Both the token var AND the anthropic key (same value) ride
+        // secretKeyRef; NEITHER carries a plaintext `value`.
+        for key in ["FLUIDBOX_SESSION_TOKEN", "ANTHROPIC_API_KEY"] {
+            let e = env.iter().find(|e| e["name"] == key).unwrap();
+            assert!(e.get("value").is_none(), "{key} leaked a plaintext value");
+            assert_eq!(e["valueFrom"]["secretKeyRef"]["key"], SECRET_TOKEN_KEY);
+        }
+        // A non-secret var stays a plain literal.
+        let task = env.iter().find(|e| e["name"] == "FLUIDBOX_TASK").unwrap();
+        assert_eq!(task["value"], "do a thing");
+        // The whole serialized Pod must not contain the token string anywhere.
+        assert!(!serde_json::to_string(&pod)
+            .unwrap()
+            .contains("fbx_sess_secret"));
+    }
+
+    #[test]
+    fn pod_carries_the_security_baseline() {
+        let pod = build_pod(&spec(), &cfg());
+        let sc = &pod["spec"]["securityContext"];
+        assert_eq!(sc["runAsNonRoot"], true);
+        assert_eq!(sc["runAsUser"], 10001);
+        assert_eq!(sc["seccompProfile"]["type"], "RuntimeDefault");
+        assert_eq!(pod["spec"]["automountServiceAccountToken"], false);
+        assert_eq!(pod["spec"]["restartPolicy"], "Never");
+        // activeDeadlineSeconds = budget (600) + init grace (300).
+        assert_eq!(pod["spec"]["activeDeadlineSeconds"], 900);
+        // Three container roles: init + runner + collector.
+        assert_eq!(pod["spec"]["initContainers"].as_array().unwrap().len(), 1);
+        assert_eq!(pod["spec"]["containers"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn secret_owner_reference_points_at_the_pod_uid() {
+        let s = build_secret(&spec(), "pod-uid-123");
+        assert_eq!(s["immutable"], true);
+        let owner = &s["metadata"]["ownerReferences"][0];
+        assert_eq!(owner["kind"], "Pod");
+        assert_eq!(owner["uid"], "pod-uid-123");
+        assert_eq!(owner["controller"], false);
+        assert_eq!(s["stringData"][SECRET_TOKEN_KEY], "fbx_sess_secret");
+    }
+}

--- a/crates/fluidbox-server/Cargo.toml
+++ b/crates/fluidbox-server/Cargo.toml
@@ -9,6 +9,7 @@ fluidbox-core.workspace = true
 fluidbox-db.workspace = true
 fluidbox-workspace.workspace = true
 fluidbox-provider.workspace = true
+fluidbox-provider-k8s.workspace = true
 axum.workspace = true
 tower-http.workspace = true
 tokio.workspace = true

--- a/crates/fluidbox-server/src/config.rs
+++ b/crates/fluidbox-server/src/config.rs
@@ -15,6 +15,12 @@ fn absolute(p: &str) -> PathBuf {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub bind: String,
+    /// The sandbox-facing internal listener (:8788). Serves ONLY `/internal/*`
+    /// (runner contract, workspace archive, LLM facade) — never `/v1`. Route
+    /// absence is stronger than bearer auth alone: a sandbox that reaches this
+    /// bind is immune to any future `/v1` auth regression (design 2026-07-15,
+    /// §"Dual listener"). The public bind still serves both for Docker.
+    pub internal_bind: String,
     pub database_url: String,
     pub admin_token: String,
     /// URL sandboxes use to reach this control plane (e.g. host.docker.internal).
@@ -82,6 +88,7 @@ impl Config {
         };
         Ok(Config {
             bind: get("FLUIDBOX_BIND").unwrap_or_else(|_| "127.0.0.1:8787".into()),
+            internal_bind: get("FLUIDBOX_INTERNAL_BIND").unwrap_or_else(|_| "0.0.0.0:8788".into()),
             database_url: get("DATABASE_URL")
                 .map_err(|_| anyhow::anyhow!("DATABASE_URL is required"))?,
             admin_token: get("FLUIDBOX_ADMIN_TOKEN")

--- a/crates/fluidbox-server/src/harness.rs
+++ b/crates/fluidbox-server/src/harness.rs
@@ -152,6 +152,7 @@ mod tests {
     fn test_cfg() -> Config {
         Config {
             bind: String::new(),
+            internal_bind: String::new(),
             database_url: String::new(),
             admin_token: String::new(),
             public_control_url: String::new(),

--- a/crates/fluidbox-server/src/internal.rs
+++ b/crates/fluidbox-server/src/internal.rs
@@ -754,6 +754,35 @@ pub async fn events(
     Ok(Json(json!({ "seq": seq })))
 }
 
+/// `GET /internal/sessions/{id}/workspace` — the immutable workspace archive
+/// the sandbox's init container pulls (Kubernetes transport). The session is
+/// derived from the BEARER TOKEN, not the path `{id}` (informational, like
+/// every other internal route). The archive is credential-free and
+/// digest-verified by the init container before unpack; serving it grants the
+/// pod nothing it couldn't already reach with the token it holds.
+pub async fn workspace_archive(
+    auth: SessionAuth,
+    State(state): State<AppState>,
+) -> ApiResult<axum::response::Response> {
+    use axum::response::IntoResponse;
+    // A terminal/winding-down session's archive is moot (the run is over).
+    let session = fluidbox_db::get_session(&state.pool, auth.session_id)
+        .await?
+        .ok_or(ApiError::NotFound)?;
+    if session.status_enum().is_terminal() {
+        return Err(ApiError::BadRequest("session is not active".into()));
+    }
+    let path = crate::orchestrator::archive_path(&state.cfg.data_dir, auth.session_id);
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|_| ApiError::NotFound)?;
+    Ok((
+        [(axum::http::header::CONTENT_TYPE, "application/gzip")],
+        bytes,
+    )
+        .into_response())
+}
+
 pub async fn heartbeat(auth: SessionAuth, State(state): State<AppState>) -> ApiResult<Json<Value>> {
     fluidbox_db::heartbeat(&state.pool, auth.session_id).await?;
     // Quiesce channel (the ONLY runner-contract change in the K8s design):

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -34,15 +34,21 @@ use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 
 /// Select the execution backend from `FLUIDBOX_PROVIDER` (default `docker`).
-/// Dual-provider permanence (settled Q17): Docker is always available; the
-/// Kubernetes provider is added beside it in Phase 1.
-fn build_provider(cfg: &config::Config) -> anyhow::Result<Arc<dyn ExecutionProvider>> {
+/// Dual-provider permanence (settled Q17): Docker and Kubernetes are co-equal
+/// backends behind the same trait, selected per deployment.
+async fn build_provider(cfg: &config::Config) -> anyhow::Result<Arc<dyn ExecutionProvider>> {
     match cfg.provider.as_str() {
         "docker" => Ok(Arc::new(fluidbox_provider::DockerProvider::connect(
             cfg.data_dir.clone(),
         )?)),
+        "kubernetes" | "k8s" => {
+            let k8s_cfg = fluidbox_provider_k8s::config::K8sConfig::from_env();
+            Ok(Arc::new(
+                fluidbox_provider_k8s::KubernetesProvider::connect(k8s_cfg).await?,
+            ))
+        }
         other => anyhow::bail!(
-            "FLUIDBOX_PROVIDER='{other}' is not available in this build (known: docker)"
+            "FLUIDBOX_PROVIDER='{other}' is not available in this build (known: docker, kubernetes)"
         ),
     }
 }
@@ -77,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    let provider = build_provider(&cfg)?;
+    let provider = build_provider(&cfg).await?;
     if let Err(e) = provider.healthcheck().await {
         tracing::warn!(
             "provider '{}' health probe failed ({e}); sandboxes will not launch until it is reachable",
@@ -223,6 +229,9 @@ async fn main() -> anyhow::Result<()> {
         .route("/triggers/{id}/invoke", post(triggers::invoke))
         .route("/triggers/{id}/runs/{sid}", get(triggers::poll_run));
 
+    // The internal plane (runner contract, workspace archive, LLM facade).
+    // internal::permission etc. extract SessionAuth themselves; the path {id}
+    // is informational (the token binds the session).
     let internal = Router::new()
         .route("/sessions/{id}/permission", post(internal::permission))
         // Brokered tools (design §8.3 class 2): intent in, governed result
@@ -231,33 +240,56 @@ async fn main() -> anyhow::Result<()> {
         .route("/sessions/{id}/events", post(internal::events))
         .route("/sessions/{id}/heartbeat", post(internal::heartbeat))
         .route("/sessions/{id}/result", post(internal::result))
+        // The immutable workspace archive the Kubernetes init container pulls
+        // (session from the bearer token; credential-free, digest-verified).
+        .route("/sessions/{id}/workspace", get(internal::workspace_archive))
         .route("/token/renew", post(internal::token_renew))
         .route("/llm-usage", post(callback::litellm_usage))
         // The Agent SDK appends /v1/messages (and possibly count_tokens) to
         // ANTHROPIC_BASE_URL=<control>/internal/llm.
         .route("/llm/{*rest}", post(facade::messages));
 
-    // Note: internal::permission etc. extract SessionAuth themselves; the
-    // path {id} is informational (the token binds the session).
-    let app = Router::new()
+    let trace_layer = || {
+        TraceLayer::new_for_http().make_span_with(|req: &axum::http::Request<axum::body::Body>| {
+            // Method + PATH only — never the query string: OAuth
+            // `code`/`state` and GitHub flow tokens ride queries.
+            tracing::debug_span!("http", method = %req.method(), path = %req.uri().path())
+        })
+    };
+
+    // Public listener (:8787) — /v1 + oauth + well-known, AND /internal for the
+    // single-host Docker path (bearer auth separates the planes there).
+    let public_app = Router::new()
         .nest("/v1", public)
-        .nest("/internal", internal)
+        .nest("/internal", internal.clone())
         // CIMD (spec 2025-11-25): this document's URL IS our OAuth
         // client_id; authorization servers fetch it — public by nature.
         .route("/.well-known/fluidbox-client.json", get(oauth::cimd_doc))
-        // Method + PATH only — never the query string: OAuth `code`/`state`
-        // and the GitHub flow tokens ride queries and must not reach logs.
-        .layer(
-            TraceLayer::new_for_http().make_span_with(|req: &axum::http::Request<axum::body::Body>| {
-                tracing::debug_span!("http", method = %req.method(), path = %req.uri().path())
-            }),
-        )
+        .layer(trace_layer())
         .layer(CorsLayer::permissive())
         .with_state(state.clone());
 
-    let listener = tokio::net::TcpListener::bind(&state.cfg.bind).await?;
-    tracing::info!("fluidbox listening on http://{}", state.cfg.bind);
+    // Internal listener (:8788) — /internal ONLY, no /v1 route exists. This is
+    // the sandbox-facing plane on Kubernetes (the internal Service targets it);
+    // route absence means a sandbox cannot reach /v1 at the TCP level.
+    let internal_app = Router::new()
+        .nest("/internal", internal)
+        .layer(trace_layer())
+        .with_state(state.clone());
+
+    let public_listener = tokio::net::TcpListener::bind(&state.cfg.bind).await?;
+    let internal_listener = tokio::net::TcpListener::bind(&state.cfg.internal_bind).await?;
+    tracing::info!("fluidbox public  listening on http://{}", state.cfg.bind);
+    tracing::info!(
+        "fluidbox internal listening on http://{} (/internal only)",
+        state.cfg.internal_bind
+    );
     tracing::info!("default agent: {}", seed.default_agent);
-    axum::serve(listener, app).await?;
+
+    // Serve both planes; if either listener falls over, the process exits.
+    tokio::select! {
+        r = axum::serve(public_listener, public_app) => r?,
+        r = axum::serve(internal_listener, internal_app) => r?,
+    }
     Ok(())
 }

--- a/crates/fluidbox-server/src/orchestrator.rs
+++ b/crates/fluidbox-server/src/orchestrator.rs
@@ -377,6 +377,7 @@ async fn collect_and_terminalize(
         if let Err(e) = fluidbox_workspace::cleanup_workspace(&state.cfg.data_dir, id) {
             tracing::warn!("workspace cleanup failed for {id}: {e}");
         }
+        delete_archive(&state.cfg.data_dir, id);
     }
     fluidbox_db::delete_finalization(&state.pool, id).await.ok();
 }
@@ -462,7 +463,7 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
     // provisioning → initializing (workspace materialization, control-plane
     // side, BEFORE the agent starts — a bad repo fails here at zero model spend)
     transition(&state, session_id, SessionStatus::Initializing, None).await;
-    let workspace_dir = materialize_workspace(&state, session_id, &run_spec).await?;
+    let (workspace_dir, base_commit) = materialize_workspace(&state, session_id, &run_spec).await?;
 
     let control_url = state.cfg.public_control_url.clone();
     let env = build_runner_env(&run_spec, &control_url, session_id, &session_token);
@@ -478,11 +479,27 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
         );
     }
 
+    // Archive-transport providers (Kubernetes) pull an immutable, credential-
+    // free archive the control plane packs here. Host-dir providers (Docker)
+    // bind mount and skip this. Authority stays control-plane-side either way.
+    let workspace_archive = if state.provider.workspace_transport()
+        == fluidbox_core::traits::WorkspaceTransport::Archive
+    {
+        match &workspace_dir {
+            Some(_) => Some(pack_and_store_archive(&state, session_id, base_commit.clone()).await?),
+            None => None,
+        }
+    } else {
+        None
+    };
+
     let sandbox_spec = SandboxSpec {
         session_id,
         image: run_spec.runner_image.clone(),
         env,
         workspace_host_dir: workspace_dir.as_ref().map(|p| p.display().to_string()),
+        workspace_archive,
+        active_deadline_secs: run_spec.budgets.max_wall_clock_secs,
         network: state.cfg.network_mode,
     };
 
@@ -554,6 +571,57 @@ pub fn serialized_env_len(env: &[(String, String)]) -> usize {
     env.iter().map(|(k, v)| k.len() + v.len() + 2).sum()
 }
 
+/// The on-disk archive path for a session (PVC-backed in Kubernetes; survives
+/// a `Recreate` upgrade so init can still pull after a control-plane restart).
+pub fn archive_path(data_dir: &std::path::Path, session_id: Uuid) -> PathBuf {
+    data_dir
+        .join("archives")
+        .join(format!("{session_id}.tar.gz"))
+}
+
+/// Pack the materialized workspace into an immutable archive, store it, and
+/// return the descriptor the init container verifies. The archive URL is on
+/// the INTERNAL listener (the pod reaches it with the session token it already
+/// holds — nothing new becomes reachable).
+async fn pack_and_store_archive(
+    state: &AppState,
+    session_id: Uuid,
+    base_commit: Option<String>,
+) -> anyhow::Result<fluidbox_core::traits::WorkspaceArchive> {
+    let data_dir = state.cfg.data_dir.clone();
+    let dest = archive_path(&data_dir, session_id);
+    let packed = tokio::task::spawn_blocking(move || {
+        let root = fluidbox_workspace::session_workspace_root(&data_dir, session_id);
+        let packed = fluidbox_workspace::pack_workspace(&root)?;
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&dest, &packed.bytes)?;
+        Ok::<_, anyhow::Error>(packed)
+    })
+    .await??;
+
+    // The pod pulls from the internal control URL (the same base the runner
+    // uses for every other internal call).
+    let url = format!(
+        "{}/internal/sessions/{}/workspace",
+        state.cfg.public_control_url.trim_end_matches('/'),
+        session_id
+    );
+    Ok(fluidbox_core::traits::WorkspaceArchive {
+        url,
+        sha256: packed.sha256,
+        len: packed.len,
+        base_commit,
+    })
+}
+
+/// Delete a session's stored archive (idempotent). Called at finalize; a TTL
+/// sweep is the backstop.
+pub fn delete_archive(data_dir: &std::path::Path, session_id: Uuid) {
+    let _ = std::fs::remove_file(archive_path(data_dir, session_id));
+}
+
 pub fn env_size_breakdown(env: &[(String, String)]) -> String {
     let mut parts: Vec<(usize, &str)> = env
         .iter()
@@ -605,7 +673,7 @@ async fn materialize_workspace(
     state: &AppState,
     session_id: Uuid,
     run_spec: &RunSpec,
-) -> anyhow::Result<Option<PathBuf>> {
+) -> anyhow::Result<(Option<PathBuf>, Option<String>)> {
     let data_dir = state.cfg.data_dir.clone();
     let (ws, repo, r#ref) = match &run_spec.workspace {
         WorkspaceSpec::LocalCopy { path } => {
@@ -676,7 +744,7 @@ async fn materialize_workspace(
         },
     )
     .await;
-    Ok(Some(ws.host_dir))
+    Ok((Some(ws.host_dir), ws.base_commit))
 }
 
 /// Resolve a connection into an `Authorization` header value for git fetch

--- a/crates/fluidbox-workspace/Cargo.toml
+++ b/crates/fluidbox-workspace/Cargo.toml
@@ -12,3 +12,8 @@ thiserror = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 uuid = { workspace = true }
+# tar + gzip give a compressed, digest-verified archive with hardened,
+# auditable-in-one-place extraction. gzip (miniz_oxide, pure Rust) over zstd
+# keeps the collector a trivially static musl binary — no zstd-sys C toolchain.
+tar = "0.4"
+flate2 = "1"

--- a/crates/fluidbox-workspace/src/archive.rs
+++ b/crates/fluidbox-workspace/src/archive.rs
@@ -1,0 +1,252 @@
+//! Immutable workspace archive: the control-plane→pod transport (design
+//! 2026-07-15, §"Workspace transport (in)").
+//!
+//! The control plane packs ONE `tar.gz` of the session workspace (the `repo/`
+//! worktree, its `.git`, and the pristine `baseline-git/`), records byte size
+//! and SHA-256, and serves it on the internal listener. The pod's init
+//! container pulls it, verifies size and digest, and unpacks it with a
+//! HARDENED extractor. Extraction policy lives HERE, in one auditable place,
+//! rejecting absolute paths, parent-dir traversal, and symlinks or hardlinks
+//! that escape the root.
+
+use crate::WorkspaceError;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use sha2::{Digest, Sha256};
+use std::path::{Component, Path, PathBuf};
+
+/// A packed archive plus its integrity metadata. `sha256` is over the exact
+/// `bytes` the pod will download.
+pub struct PackedArchive {
+    pub bytes: Vec<u8>,
+    pub sha256: String,
+    pub len: u64,
+}
+
+/// Pack a session workspace root (`repo/` + `baseline-git/`) into a gzip'd
+/// tar. Symlinks inside the tree are followed as their target contents would
+/// bloat/loop; git never stores its own metadata as symlinks, and a worktree
+/// symlink is materialized as a regular entry on unpack — the extractor
+/// rejects any that escape.
+pub fn pack_workspace(session_root: &Path) -> Result<PackedArchive, WorkspaceError> {
+    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = tar::Builder::new(&mut gz);
+        builder.follow_symlinks(false);
+        // Only these two subtrees ship: the worktree (with .git) and the
+        // pristine baseline. Anything else in the session root (collect-tmp,
+        // etc.) stays on the control plane.
+        for sub in ["repo", crate::BASELINE_DIR] {
+            let path = session_root.join(sub);
+            if path.is_dir() {
+                builder
+                    .append_dir_all(sub, &path)
+                    .map_err(|e| WorkspaceError::Invalid(format!("tar append {sub}: {e}")))?;
+            }
+        }
+        builder
+            .finish()
+            .map_err(|e| WorkspaceError::Invalid(format!("tar finish: {e}")))?;
+    }
+    let bytes = gz
+        .finish()
+        .map_err(|e| WorkspaceError::Invalid(format!("gzip finish: {e}")))?;
+    let sha256 = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
+    let len = bytes.len() as u64;
+    Ok(PackedArchive { bytes, sha256, len })
+}
+
+/// Verify `bytes` against an expected size and digest before unpacking —
+/// tampering or truncation fails BEFORE any extraction touches the disk.
+pub fn verify_archive(
+    bytes: &[u8],
+    expected_len: u64,
+    expected_sha256: &str,
+) -> Result<(), WorkspaceError> {
+    if bytes.len() as u64 != expected_len {
+        return Err(WorkspaceError::Invalid(format!(
+            "archive size {} != expected {expected_len}",
+            bytes.len()
+        )));
+    }
+    let got = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
+    if got != expected_sha256 {
+        return Err(WorkspaceError::Invalid(
+            "archive digest mismatch — refusing to unpack".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Hardened unpack: every entry path is validated to stay inside `dest`
+/// (no absolute paths, no `..`, no symlink/hardlink escaping the root), and a
+/// total-size ceiling bounds a decompression bomb. Returns the number of
+/// entries written.
+pub fn unpack_archive(
+    bytes: &[u8],
+    dest: &Path,
+    max_total_bytes: u64,
+) -> Result<u64, WorkspaceError> {
+    std::fs::create_dir_all(dest)?;
+    let canon_dest = std::fs::canonicalize(dest)?;
+    let gz = GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(gz);
+    archive.set_preserve_permissions(false);
+    archive.set_preserve_mtime(false);
+
+    let mut written: u64 = 0;
+    let mut total: u64 = 0;
+    for entry in archive
+        .entries()
+        .map_err(|e| WorkspaceError::Invalid(format!("read archive: {e}")))?
+    {
+        let mut entry =
+            entry.map_err(|e| WorkspaceError::Invalid(format!("archive entry: {e}")))?;
+        let path = entry
+            .path()
+            .map_err(|e| WorkspaceError::Invalid(format!("entry path: {e}")))?
+            .into_owned();
+        let safe = safe_join(&canon_dest, &path)?;
+
+        let etype = entry.header().entry_type();
+        // Reject links outright — a symlink or hardlink is the classic escape,
+        // and the workspace transport never needs one.
+        if etype.is_symlink() || etype.is_hard_link() {
+            return Err(WorkspaceError::Invalid(format!(
+                "archive contains a link entry ({}) — refused",
+                path.display()
+            )));
+        }
+        if etype.is_dir() {
+            std::fs::create_dir_all(&safe)?;
+            continue;
+        }
+        // Regular file (or anything else we treat as one): bound the running
+        // total and unpack into the validated path only.
+        let size = entry.header().size().unwrap_or(0);
+        total = total.saturating_add(size);
+        if total > max_total_bytes {
+            return Err(WorkspaceError::Invalid(format!(
+                "archive exceeds the {max_total_bytes}-byte unpack ceiling"
+            )));
+        }
+        if let Some(parent) = safe.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        entry
+            .unpack(&safe)
+            .map_err(|e| WorkspaceError::Invalid(format!("unpack {}: {e}", path.display())))?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+/// Join `rel` under `base`, rejecting anything that would escape (absolute
+/// components, `..`, root/prefix). Purely lexical — no filesystem access, so
+/// it is safe to run before the target exists.
+fn safe_join(base: &Path, rel: &Path) -> Result<PathBuf, WorkspaceError> {
+    let mut out = base.to_path_buf();
+    for comp in rel.components() {
+        match comp {
+            Component::Normal(c) => out.push(c),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(WorkspaceError::Invalid(format!(
+                    "unsafe archive path '{}' (absolute or traversal)",
+                    rel.display()
+                )));
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn pack_verify_unpack_roundtrip() {
+        let tmp = std::env::temp_dir().join(format!("fbx-arch-{}", Uuid::now_v7()));
+        let root = tmp.join("ws");
+        let repo = root.join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        std::fs::write(repo.join("a.txt"), "hello\n").unwrap();
+        std::fs::write(repo.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        std::fs::create_dir_all(root.join(crate::BASELINE_DIR)).unwrap();
+        std::fs::write(root.join(crate::BASELINE_DIR).join("HEAD"), "ref: x\n").unwrap();
+
+        let packed = pack_workspace(&root).unwrap();
+        assert!(packed.sha256.starts_with("sha256:"));
+        verify_archive(&packed.bytes, packed.len, &packed.sha256).unwrap();
+
+        // Tamper → verify fails.
+        let mut bad = packed.bytes.clone();
+        bad.push(0);
+        assert!(verify_archive(&bad, packed.len, &packed.sha256).is_err());
+
+        let dest = tmp.join("out");
+        unpack_archive(&packed.bytes, &dest, 100 * 1024 * 1024).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("repo/a.txt")).unwrap(),
+            "hello\n"
+        );
+        assert!(dest.join(crate::BASELINE_DIR).join("HEAD").exists());
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn safe_join_rejects_escape_and_accepts_normal() {
+        // The tar builder sanitizes `..` at append time, so the escape defense
+        // is `safe_join` (a purely lexical guard applied to EVERY entry path,
+        // whatever produced the tar). Test it directly against the classic
+        // escapes an adversarial archive would carry.
+        let base = Path::new("/data/ws");
+        for bad in ["../escape.txt", "a/../../etc/passwd", "/etc/passwd", "/../x"] {
+            assert!(
+                safe_join(base, Path::new(bad)).is_err(),
+                "must reject escaping path '{bad}'"
+            );
+        }
+        // Normal nested paths join under the base.
+        let ok = safe_join(base, Path::new("repo/src/a.txt")).unwrap();
+        assert_eq!(ok, Path::new("/data/ws/repo/src/a.txt"));
+        // `.` components are harmless and elided.
+        let dot = safe_join(base, Path::new("./repo/./b.txt")).unwrap();
+        assert_eq!(dot, Path::new("/data/ws/repo/b.txt"));
+    }
+
+    #[test]
+    fn unpack_rejects_symlink() {
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut b = tar::Builder::new(&mut gz);
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            header.set_link_name("/etc/passwd").unwrap();
+            header.set_cksum();
+            b.append_data(&mut header, "link", std::io::empty())
+                .unwrap();
+            b.finish().unwrap();
+        }
+        let bytes = gz.finish().unwrap();
+        let tmp = std::env::temp_dir().join(format!("fbx-arch-sym-{}", Uuid::now_v7()));
+        assert!(unpack_archive(&bytes, &tmp, 1024 * 1024).is_err());
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn unpack_enforces_size_ceiling() {
+        let tmp = std::env::temp_dir().join(format!("fbx-arch-big-{}", Uuid::now_v7()));
+        let root = tmp.join("ws");
+        std::fs::create_dir_all(root.join("repo")).unwrap();
+        std::fs::write(root.join("repo/big.bin"), vec![0u8; 64 * 1024]).unwrap();
+        let packed = pack_workspace(&root).unwrap();
+        let dest = tmp.join("out");
+        assert!(unpack_archive(&packed.bytes, &dest, 4 * 1024).is_err());
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+}

--- a/crates/fluidbox-workspace/src/collect.rs
+++ b/crates/fluidbox-workspace/src/collect.rs
@@ -58,8 +58,8 @@ pub enum CollectionOutcome {
 }
 
 /// Collect the agent's changes from a session workspace root
-/// (`<data_dir>/workspaces/<sid>`), diffing the final `repo/` worktree
-/// against `base_commit` using ONLY the pristine baseline's `.git`.
+/// (`<data_dir>/workspaces/<sid>`) laid out as `repo/` + `baseline-git/` —
+/// the Docker host-dir layout. Delegates to [`collect_diff_at`].
 pub fn collect_diff(
     workspace_root: &Path,
     base_commit: Option<&str>,
@@ -67,7 +67,23 @@ pub fn collect_diff(
 ) -> CollectionOutcome {
     let repo = workspace_root.join("repo");
     let baseline = workspace_root.join(BASELINE_DIR);
-    if !repo.is_dir() {
+    let scratch_root = workspace_root.to_path_buf();
+    collect_diff_at(&repo, &baseline, &scratch_root, base_commit, caps)
+}
+
+/// Collect a diff from explicit worktree + pristine-baseline paths, using a
+/// scratch dir under `scratch_root`. This is the layout-agnostic core: the
+/// Docker path passes `<root>/repo` + `<root>/baseline-git`; the in-pod
+/// collector passes `/workspace` + `/collector/baseline` (different mounts,
+/// same hardened engine).
+pub fn collect_diff_at(
+    worktree: &Path,
+    baseline: &Path,
+    scratch_root: &Path,
+    base_commit: Option<&str>,
+    caps: &DiffCaps,
+) -> CollectionOutcome {
+    if !worktree.is_dir() {
         return CollectionOutcome::Missing {
             reason: "workspace worktree missing (never materialized, or already cleaned)".into(),
         };
@@ -78,7 +94,7 @@ pub fn collect_diff(
                 .into(),
         };
     }
-    match collect_inner(workspace_root, &repo, &baseline, base_commit, caps) {
+    match collect_inner(scratch_root, worktree, baseline, base_commit, caps) {
         Ok(diff) => CollectionOutcome::Diff(diff),
         Err(e) => CollectionOutcome::Missing {
             reason: format!("collection failed: {e}"),
@@ -87,15 +103,15 @@ pub fn collect_diff(
 }
 
 fn collect_inner(
-    workspace_root: &Path,
+    scratch_root: &Path,
     worktree: &Path,
     baseline: &Path,
     base_commit: Option<&str>,
     caps: &DiffCaps,
 ) -> Result<CollectedDiff, WorkspaceError> {
-    // Scratch space lives INSIDE the session root (cleaned with it) but
-    // outside repo/ (never visible to any sandbox transport).
-    let scratch = workspace_root.join("collect-tmp");
+    // Scratch space lives INSIDE the scratch root (cleaned with it) but
+    // outside the worktree (never visible to any sandbox transport).
+    let scratch = scratch_root.join("collect-tmp");
     if scratch.exists() {
         std::fs::remove_dir_all(&scratch)?;
     }

--- a/crates/fluidbox-workspace/src/lib.rs
+++ b/crates/fluidbox-workspace/src/lib.rs
@@ -18,9 +18,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use uuid::Uuid;
 
+pub mod archive;
 pub mod collect;
 
-pub use collect::{collect_diff, CollectedDiff, CollectionOutcome, DiffCaps};
+pub use archive::{pack_workspace, unpack_archive, verify_archive, PackedArchive};
+pub use collect::{collect_diff, collect_diff_at, CollectedDiff, CollectionOutcome, DiffCaps};
 
 /// Directory (under the per-session workspace root) holding the pristine
 /// copy of the materialized `.git` — saved before the agent ever runs,

--- a/crates/workspaced/Cargo.toml
+++ b/crates/workspaced/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "workspaced"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "fluidbox in-pod workspace collector: archive init + pristine-baseline diff over pods/exec"
+
+[[bin]]
+name = "workspaced"
+path = "src/main.rs"
+
+[dependencies]
+fluidbox-workspace = { workspace = true }
+# ureq: a small blocking HTTP client (rustls) for the init archive pull — no
+# async runtime pulled into a one-shot init container.
+ureq = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/workspaced/src/main.rs
+++ b/crates/workspaced/src/main.rs
@@ -1,0 +1,267 @@
+//! `workspaced` — the fluidbox in-pod workspace collector (design 2026-07-15).
+//!
+//! One tiny binary, four subcommands, run inside the sandbox Pod's
+//! collector/init containers:
+//!
+//!   workspaced init    — pull the immutable archive from the control plane,
+//!                        verify size+digest, unpack into /workspace with the
+//!                        hardened extractor, and stash the pristine `.git`
+//!                        baseline in the collector-only volume.
+//!   workspaced wait    — long-lived no-op: keeps the collector container (and
+//!                        thus the Pod) Running after the runner exits, so the
+//!                        control plane can exec collection.
+//!   workspaced diff    — reconstruct the diff from the pristine baseline +
+//!                        final worktree (never the agent's `.git`) and write
+//!                        it atomically to the collector-only output file.
+//!   workspaced stream  — emit that finished file from `--offset N`, so the
+//!                        control plane's `pods/exec` collection resumes on a
+//!                        dropped stream.
+//!
+//! The runner NEVER sees the baseline volume; the collector NEVER holds a
+//! credential (the session token authenticates only the one archive GET, in
+//! the init container). Extraction + diff policy live in `fluidbox-workspace`,
+//! auditable in one place and shared with the Docker provider.
+
+use fluidbox_workspace::{
+    collect_diff_at, unpack_archive, verify_archive, CollectionOutcome, DiffCaps,
+};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+/// Cap the archive unpack — a decompression bomb wastes this, never the node.
+const MAX_UNPACK_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+fn env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+fn require(key: &str) -> Result<String, String> {
+    env(key).ok_or_else(|| format!("missing required env {key}"))
+}
+
+fn workspace_dir() -> PathBuf {
+    PathBuf::from(env("FLUIDBOX_WORKSPACE").unwrap_or_else(|| "/workspace".into()))
+}
+
+fn collector_dir() -> PathBuf {
+    PathBuf::from(env("FLUIDBOX_COLLECTOR_DIR").unwrap_or_else(|| "/collector".into()))
+}
+
+fn baseline_dir() -> PathBuf {
+    collector_dir().join("baseline")
+}
+
+fn out_file() -> PathBuf {
+    collector_dir().join("out").join("diff")
+}
+
+fn main() -> ExitCode {
+    let cmd = std::env::args().nth(1).unwrap_or_default();
+    let result = match cmd.as_str() {
+        "init" => cmd_init(),
+        "wait" => cmd_wait(),
+        "diff" => cmd_diff(),
+        "stream" => cmd_stream(),
+        other => Err(format!(
+            "usage: workspaced <init|wait|diff|stream>; got '{other}'"
+        )),
+    };
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("workspaced: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Pull + verify + unpack the immutable workspace archive, then stash the
+/// pristine baseline. Corrupt/oversized/unsafe archives fail here → the init
+/// container fails → the Pod fails → the run fails at zero model spend
+/// (preserving the "bad repo costs nothing" property).
+fn cmd_init() -> Result<(), String> {
+    let url = require("FLUIDBOX_WORKSPACE_ARCHIVE_URL")?;
+    let token = require("FLUIDBOX_SESSION_TOKEN")?;
+    let expected_sha = require("FLUIDBOX_ARCHIVE_SHA256")?;
+    let expected_len: u64 = require("FLUIDBOX_ARCHIVE_LEN")?
+        .parse()
+        .map_err(|e| format!("bad FLUIDBOX_ARCHIVE_LEN: {e}"))?;
+    let workspace = workspace_dir();
+    let collector = collector_dir();
+
+    eprintln!("workspaced init: fetching archive ({expected_len} bytes)");
+    let bytes = fetch(&url, &token, expected_len)?;
+    verify_archive(&bytes, expected_len, &expected_sha).map_err(|e| e.to_string())?;
+
+    // Unpack into a collector-local staging dir (same volume → cheap rename
+    // for the baseline; cross-volume copy for the worktree).
+    let stage = collector.join("unpack");
+    if stage.exists() {
+        std::fs::remove_dir_all(&stage).ok();
+    }
+    unpack_archive(&bytes, &stage, MAX_UNPACK_BYTES).map_err(|e| e.to_string())?;
+
+    // repo/ (worktree incl. its .git) → /workspace (the runner's tree).
+    let repo = stage.join("repo");
+    if !repo.is_dir() {
+        return Err("archive has no repo/ entry".into());
+    }
+    std::fs::create_dir_all(&workspace).map_err(|e| e.to_string())?;
+    copy_tree(&repo, &workspace).map_err(|e| format!("populate workspace: {e}"))?;
+
+    // baseline-git/ → /collector/baseline (collector+init only; the runner
+    // never sees it, so agent mutations to /workspace/.git can't touch it).
+    let baseline_src = stage.join(fluidbox_workspace::BASELINE_DIR);
+    let baseline_dst = baseline_dir();
+    if baseline_src.is_dir() {
+        if baseline_dst.exists() {
+            std::fs::remove_dir_all(&baseline_dst).ok();
+        }
+        std::fs::rename(&baseline_src, &baseline_dst)
+            .or_else(|_| copy_tree(&baseline_src, &baseline_dst))
+            .map_err(|e| format!("stage baseline: {e}"))?;
+    } else {
+        eprintln!(
+            "workspaced init: WARN no baseline-git in archive; collection will report missing"
+        );
+    }
+
+    std::fs::remove_dir_all(&stage).ok();
+    eprintln!("workspaced init: workspace ready");
+    Ok(())
+}
+
+/// Keep the collector container alive so the control plane can exec `diff` +
+/// `stream` after the runner exits. Ends only when the Pod is deleted.
+fn cmd_wait() -> Result<(), String> {
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}
+
+/// Compute the diff (pristine baseline + final worktree, scrubbed git) and
+/// write it atomically to the collector-only output file. Idempotent: a
+/// re-exec recomputes and replaces.
+fn cmd_diff() -> Result<(), String> {
+    let workspace = workspace_dir();
+    let baseline = baseline_dir();
+    let collector = collector_dir();
+    let base_commit = env("FLUIDBOX_BASE_COMMIT");
+
+    let outcome = collect_diff_at(
+        &workspace,
+        &baseline,
+        &collector,
+        base_commit.as_deref(),
+        &DiffCaps::default(),
+    );
+
+    let out = out_file();
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    // A sidecar header line lets the control plane distinguish a real diff
+    // from an explicit missing marker without a second channel.
+    let (header, body): (String, String) = match outcome {
+        CollectionOutcome::Diff(d) => (
+            format!(
+                "fluidbox-diff v1 status=ok bytes={} sha256={} truncated={}\n",
+                d.bytes, d.sha256, d.truncated
+            ),
+            d.patch,
+        ),
+        CollectionOutcome::Missing { reason } => (
+            format!(
+                "fluidbox-diff v1 status=missing reason={}\n",
+                oneline(&reason)
+            ),
+            String::new(),
+        ),
+    };
+
+    let tmp = out.with_extension("tmp");
+    {
+        let mut f = std::fs::File::create(&tmp).map_err(|e| e.to_string())?;
+        f.write_all(header.as_bytes()).map_err(|e| e.to_string())?;
+        f.write_all(body.as_bytes()).map_err(|e| e.to_string())?;
+        f.sync_all().ok();
+    }
+    std::fs::rename(&tmp, &out).map_err(|e| format!("atomic publish: {e}"))?;
+    Ok(())
+}
+
+/// Emit the finished diff file from `--offset N` (default 0). The control
+/// plane collects over `pods/exec`; if the stream drops it re-execs with the
+/// bytes it already has, so collection is resumable and decoupled from the
+/// fragile exec channel.
+fn cmd_stream() -> Result<(), String> {
+    let mut offset: u64 = 0;
+    let args: Vec<String> = std::env::args().skip(2).collect();
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--offset" {
+            offset = args
+                .get(i + 1)
+                .and_then(|s| s.parse().ok())
+                .ok_or("--offset needs a number")?;
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    let out = out_file();
+    let mut f = std::fs::File::open(&out)
+        .map_err(|e| format!("diff not computed yet ({}): {e}", out.display()))?;
+    f.seek(SeekFrom::Start(offset)).map_err(|e| e.to_string())?;
+    let mut stdout = std::io::stdout().lock();
+    std::io::copy(&mut f, &mut stdout).map_err(|e| e.to_string())?;
+    stdout.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// GET the archive with the session token, bounding the body at the declared
+/// length (+slack) so a lying Content-Length can't exhaust memory.
+fn fetch(url: &str, token: &str, expected_len: u64) -> Result<Vec<u8>, String> {
+    let resp = ureq::get(url)
+        .set("authorization", &format!("Bearer {token}"))
+        .timeout(std::time::Duration::from_secs(120))
+        .call()
+        .map_err(|e| format!("archive GET failed: {e}"))?;
+    let cap = expected_len.saturating_add(1024) as usize;
+    let mut buf = Vec::with_capacity(expected_len as usize);
+    resp.into_reader()
+        .take(cap as u64)
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("archive read failed: {e}"))?;
+    Ok(buf)
+}
+
+/// Recursive copy including dotfiles + `.git` internals; symlinks are skipped
+/// (the archive extractor already rejected any, so this only sees regular
+/// files/dirs).
+fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let meta = std::fs::symlink_metadata(&from)?;
+        if meta.is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+fn oneline(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_whitespace() { ' ' } else { c })
+        .take(200)
+        .collect()
+}

--- a/deploy/workspaced.Dockerfile
+++ b/deploy/workspaced.Dockerfile
@@ -1,0 +1,23 @@
+# fluidbox in-pod workspace collector. Build context = repo root:
+#   docker build -t fluidbox-workspaced -f deploy/workspaced.Dockerfile .
+#
+# Runs as the sandbox Pod's init container (archive fetch + unpack + pristine
+# baseline) and its long-lived collector container (diff-out over pods/exec).
+# git: the scrubbed diff invocation. ca-certificates: TLS for the archive GET.
+# Non-root numeric uid; no shell/curl/coreutils are required by the binary
+# (tar/gzip are Rust-native), only git + certs.
+FROM rust:1.96-bookworm AS build
+WORKDIR /src
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+RUN cargo build --release -p workspaced
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/workspaced /usr/local/bin/workspaced
+# Numeric non-root uid (kubelet cannot prove a named USER is non-root); matches
+# the Pod securityContext runAsUser default.
+USER 10001:10001
+ENTRYPOINT ["workspaced"]


### PR DESCRIPTION
Implements the Kubernetes execution backend behind the existing `ExecutionProvider` trait — one bare Pod per run via kube-rs, runner images unmodified, workspace by immutable digest-verified archive, diff collected in-pod against a pristine baseline over pods/exec. All K8s knowledge stays in `fluidbox-provider-k8s`.

## Delivered
- **`fluidbox-provider-k8s`** (kube-rs 4): Pod-first/Secret-second provisioning (immutable Secret, ownerRef→Pod GC, no orphan window); token via secretKeyRef (never a PodSpec literal — tested); blocking provision; UID-preconditioned terminate; `list_managed` + adoption validation; watch-free periodic reconcile via `state()` on the named runner container; `activeDeadlineSeconds`; exec-based `collect_artifacts`.
- **`workspaced`** collector binary + `deploy/workspaced.Dockerfile`: init (fetch+verify+hardened-unpack+baseline), wait, diff (pristine-baseline scrubbed git), stream (`--offset` resume).
- **`fluidbox-workspace`**: Rust-native archive (pack/verify/hardened-unpack) + layout-agnostic `collect_diff_at` shared with Docker.
- **`fluidbox-server`**: archive pack/store + `GET /internal/sessions/{id}/workspace`; dual listener :8787 public / :8788 internal-only (route absence); `FLUIDBOX_PROVIDER=kubernetes`.

## Verified
`just check` green (fmt + clippy -D warnings + workspace tests incl. 27 new K8s/archive/collector tests + web build). Collector container smoke: `workspaced diff`/`stream` produce the correct patch from a pristine baseline. Live cluster acceptance (demo A on kind+Calico and EKS) lands at the Phase 2 Helm boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)