### PR TITLE
fix(k8s): install ring CryptoProvider so the Kubernetes provider boots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,6 +1221,7 @@ dependencies = [
  "hmac 0.13.0",
  "jsonwebtoken",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/fluidbox-server/Cargo.toml
+++ b/crates/fluidbox-server/Cargo.toml
@@ -36,3 +36,6 @@ chacha20poly1305.workspace = true
 base64.workspace = true
 jsonwebtoken.workspace = true
 async-stream = "0.3"
+# kube-rs pulls rustls 0.23, which needs a process-level CryptoProvider chosen
+# explicitly when several backends are in the tree (sqlx = ring). Install ring.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -56,6 +56,10 @@ async fn build_provider(cfg: &config::Config) -> anyhow::Result<Arc<dyn Executio
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
+    // kube-rs (rustls 0.23) needs a process-level CryptoProvider; the workspace
+    // has multiple rustls backends in-tree, so pick ring explicitly or the
+    // Kubernetes client panics on first TLS use. No-op for the Docker path.
+    let _ = rustls::crypto::ring::default_provider().install_default();
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/deploy/helm/fluidbox/templates/litellm.yaml
+++ b/deploy/helm/fluidbox/templates/litellm.yaml
@@ -1,4 +1,29 @@
 {{- if .Values.litellm.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fluidbox.litellmName" . }}
+  labels: {{- include "fluidbox.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    model_list:
+      - model_name: claude-haiku-4-5
+        litellm_params:
+          model: anthropic/claude-haiku-4-5-20251001
+          api_key: os.environ/ANTHROPIC_API_KEY
+      - model_name: "claude-*"
+        litellm_params:
+          model: "anthropic/claude-*"
+          api_key: os.environ/ANTHROPIC_API_KEY
+      - model_name: "gpt-5*"
+        litellm_params:
+          model: "openai/gpt-5*"
+          api_key: os.environ/OPENAI_API_KEY
+    general_settings:
+      master_key: os.environ/LITELLM_MASTER_KEY
+    litellm_settings:
+      drop_params: true
+---
 # Bundled LiteLLM: digest-pinned image, ClusterIP-only, and — critically —
 # unreachable from sandbox pods (the sandbox egress NetworkPolicy allows only
 # the control-plane :8788). External LiteLLM is the production default.
@@ -28,7 +53,7 @@ spec:
       containers:
         - name: litellm
           image: {{ .Values.litellm.image | quote }}
-          args: ["--port", "4000", "--num_workers", "1"]
+          args: ["--config", "/etc/litellm/config.yaml", "--port", "4000", "--num_workers", "1"]
           ports:
             - { name: http, containerPort: 4000 }
           env:
@@ -36,7 +61,13 @@ spec:
               valueFrom: { secretKeyRef: { name: {{ .Values.existingSecret | quote }}, key: {{ .Values.secretKeys.litellmMasterKey | quote }} } }
             - name: ANTHROPIC_API_KEY
               valueFrom: { secretKeyRef: { name: {{ .Values.existingSecret | quote }}, key: {{ .Values.litellm.anthropicKeySecretKey | quote }} } }
+          volumeMounts:
+            - { name: config, mountPath: /etc/litellm }
           resources: {{- toYaml .Values.litellm.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "fluidbox.litellmName" . }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
With FLUIDBOX_PROVIDER=kubernetes the server panicked on first TLS use (rustls 0.23 CryptoProvider ambiguity — sqlx=ring + kube rustls-tls). Install ring explicitly at startup (no-op for Docker). Found during EKS bring-up (server pod CrashLoopBackOff). Also adds the LiteLLM model ConfigMap to the chart. 🤖 Generated with [Claude Code](https://claude.com/claude-code)