### PR TITLE
fix(k8s): numeric runAsUser for bundled LiteLLM

### DIFF
--- a/deploy/helm/fluidbox/templates/litellm.yaml
+++ b/deploy/helm/fluidbox/templates/litellm.yaml
@@ -48,7 +48,13 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
+        # The upstream LiteLLM image declares a non-numeric root USER, so the
+        # kubelet can't verify non-root from runAsNonRoot alone — pin a numeric
+        # uid (the image runs fine as an arbitrary uid).
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile: { type: RuntimeDefault }
       containers:
         - name: litellm


### PR DESCRIPTION
The LiteLLM image runs as root (non-numeric USER), rejected under runAsNonRoot → CreateContainerConfigError. Pin uid/gid 1000. Found live on EKS.