### PR TITLE
docs(readme): lead with the product film instead of a still

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ fluidbox is the authority layer between an external event and an AI agent. Regis
 
 fluidbox is not another chat UI, and a trigger is not a second execution system. Manual, API, schedule, and event-driven invocations all converge on one Rust control plane and one immutable run contract.
 
-![A completed fluidbox run showing its live timeline, policy decisions, model usage, and frozen RunSpec](./docs/assets/run-detail.png)
+https://github.com/user-attachments/assets/579df2f1-9c55-4946-988b-952d15feb35d
 
-*A real run: the agent fixes a failing test in an isolated workspace while fluidbox records tool decisions, model usage, lifecycle events, and the final result.*
+*The product film (2:56, narrated): register a versioned agent, connect an event, then follow one incident through frozen authority, a disposable sandbox, the policy gate, and three independently owned reviews to a delivered pull request. A [full-resolution 1080p copy](https://fluidbox-oss-assets.s3.us-east-1.amazonaws.com/demo-film/v7/fluidbox-demo.mp4) is available for download.*
 
 ## Why fluidbox
 


### PR DESCRIPTION
Replaces the static hero screenshot in the README with the 2:56 narrated product film (v7).

https://github.com/user-attachments/assets/579df2f1-9c55-4946-988b-952d15feb35d

## Why the README carries a bare URL

Two constraints decide the form, both verified rather than assumed:

- **GitHub's markdown sanitizer strips `<video>` tags.** Rendering `<video src=...>` through `POST /markdown` returns `<p></p>`, for both an S3 `src` and a `github.com/...raw/...` one. Control tests in the same harness show `<img>` and `<details>` surviving, so the tag is simply not on the allowlist.
- **`Content-Security-Policy: media-src` on github.com is an allowlist of GitHub's own media hosts** (`github.com`, `user-images.githubusercontent.com`, `github-production-user-asset-6210df.s3.amazonaws.com`, …). Media served from anywhere else is blocked by the browser even if the markup survives.

A bare attachment URL is therefore the only form that yields a native inline player. No media is committed to the repository.

## Encoding

The attachment ceiling is 10 MB, so the film is encoded to 1280x720 at 391 kbps (two-pass x264, `+faststart`); the display width on a README is ~880 px, so 720p is oversampled at rest. The full-resolution 1080p master is linked from the caption for download.

`docs/assets/run-detail.png` is left in place and is now unreferenced.