### PR TITLE
chore: ignore local-only *.local.md notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ apps/web/out/
 # Logs
 *.log
 apps/web/.env.local
+
+# Local-only notes (artifact index, scratch docs) — never committed
+*.local.md


### PR DESCRIPTION
## What

One `.gitignore` line: `*.local.md`.

## Why

`docs/artifacts.local.md` is a personal index of the published architecture
artifacts (the 2026-07-24 explainer series and the ARB pack). It is useful
sitting beside `PLAN.md` and `ARCHITECTURE.md` while working, but it points at
private claude.ai URLs and is not something every clone should carry.

Ignored as a glob rather than the single path so future local scratch notes
need no further `.gitignore` commits.

## Risk

None. No code, no migrations, no CI surface touched — `*.local.md` matches no
tracked file in the repository today.