### PR TITLE
Local-dev Postgres, app-store composer UX, e2e deflakes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,20 @@
-# ── Database (Neon Postgres) ──────────────────────────────────────────────
-# Use the DIRECT (non "-pooler") connection string — PgBouncer transaction mode
-# breaks sqlx prepared statements and LISTEN/NOTIFY.
-# `just neon-setup` provisions a project and writes this line for you.
-DATABASE_URL=postgres://user:password@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
+# ── Database (Postgres) ───────────────────────────────────────────────────
+# LOCAL DEV (default): a Postgres container with a persistent named volume.
+#   just db-up          start it (data survives restarts)
+#   just db-reset       destroy the data and start clean
+# Published on 5433, not 5432 — 5432 is commonly already taken by a Homebrew
+# postgres, and silently connecting to the wrong server is worse than an
+# unusual port. The server runs all migrations on boot, so there is no
+# separate provisioning step.
+DATABASE_URL=postgres://fluidbox:fluidbox@127.0.0.1:5433/fluidbox
+POSTGRES_USER=fluidbox
+POSTGRES_PASSWORD=fluidbox
+POSTGRES_DB=fluidbox
+
+# HOSTED (Neon or any managed Postgres): replace DATABASE_URL with the DIRECT
+# (non "-pooler") connection string — PgBouncer transaction mode breaks sqlx
+# prepared statements and LISTEN/NOTIFY. `just neon-setup` writes it for you.
+# DATABASE_URL=postgres://user:password@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
 
 # ── fluidbox server ───────────────────────────────────────────────────────
 # Must be 0.0.0.0, not loopback: sandboxes reach the control plane via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,19 @@ just check          # fmt + clippy -D warnings + test + web build (the full bar)
 just e2e            # full acceptance: live demo A + governance + git workspaces + api triggers + schedules + github fan-out + capability catalog + connector catalog/oauth + failure paths (owns the stack; stop `just dev` first)
 
 cargo test -p fluidbox-core                              # fast, no DB needed
-cargo test -p fluidbox-db                                # needs DATABASE_URL (real Neon)
+cargo test -p fluidbox-db                                # needs DATABASE_URL (local container Postgres)
 cargo test -p fluidbox-core policy::tests::               # a single module's tests
 cargo run -p fluidbox-cli -- run --task "…" --repo /path # drive a run from the CLI
 ```
 
-The `fluidbox-db` and workspace-wide test runs hit **real Neon** — `set -a; source .env; set +a` first so `DATABASE_URL` is present, otherwise the DB test self-skips.
+The `fluidbox-db` and workspace-wide test runs hit the **local container Postgres** (`just db-up` first) — `set -a; source .env; set +a` so `DATABASE_URL` is present, otherwise the DB test self-skips. These no longer touch a hosted database, so they are cheap and safe to run: the full workspace suite is 850 tests in seconds.
 
 ## Environment & setup gotchas (these cost real debugging time)
 
 - **`FLUIDBOX_BIND` must be `0.0.0.0:8787`, not loopback.** Sandboxes reach the control plane via `host.docker.internal`, which resolves to the host's gateway IP — a `127.0.0.1` bind is unreachable from a container.
 - **`FLUIDBOX_DATA_DIR` is canonicalized to an absolute path at startup** (`config.rs`). Docker bind mounts reject relative paths; don't undo this.
-- **Neon: use the DIRECT (non-`-pooler`) connection string.** PgBouncer transaction mode breaks sqlx prepared statements and `LISTEN/NOTIFY` (`PgListener` needs a direct connection). `scripts/neon-setup.sh` enforces this.
+- **Local dev runs Postgres in a container, NOT Neon** (`deploy/docker-compose.dev.yml`, `just db-up`): `postgres:17-alpine`, named volume `fluidbox-pgdata`, published on **127.0.0.1:5433** — 5432 is commonly already taken by a Homebrew postgres. Data survives restarts; only `just db-reset` destroys it. The server applies all migrations on boot, so a fresh volume needs no provisioning step. The container's `POSTGRES_USER` is a SUPERUSER, i.e. the same RLS posture Neon's `neondb_owner` had (0018's policies exist but PostgreSQL skips them; boot warns, single-user tolerated) — set `FLUIDBOX_RUNTIME_ROLE=fluidbox_runtime` to actually enforce RLS locally (0018 creates that role NOLOGIN/non-super/non-bypass, verified present).
+- **Neon (hosted only): use the DIRECT (non-`-pooler`) connection string.** PgBouncer transaction mode breaks sqlx prepared statements and `LISTEN/NOTIFY` (`PgListener` needs a direct connection). `scripts/neon-setup.sh` enforces this. Nothing in the Rust is Neon-specific — `NEON_AUTOSUSPEND_SECS` only bounds the pool idle timeout — so any direct Postgres works.
 - **The Anthropic key lives ONLY in the LiteLLM container**, injected via docker-compose from `.env`. The Rust server never holds it (it authenticates to LiteLLM with `LITELLM_MASTER_KEY`). No server restart is needed after adding the key — just `just gateway-up`.
 - **`.env` is gitignored; `apps/web/.env.local` too** (it carries the admin token for the dashboard proxy). Never commit either.
 - sqlx needs the `macros` + `derive` features; clap needs `env`; reqwest 0.13 uses the `rustls` feature (not `rustls-tls`). LiteLLM is pinned by **digest** in `.env` (`LITELLM_IMAGE=...@sha256:...`); tag `main-v1.91.1` does not exist as an image — use `main-stable` and re-pin the digest.

--- a/apps/web/app/capabilities/AddServerWizard.tsx
+++ b/apps/web/app/capabilities/AddServerWizard.tsx
@@ -477,12 +477,12 @@ export function AddServerWizard({
               </Link>
             )}
             <button className="btn primary" onClick={finish}>
-              {embedded ? "Use this capability" : "Done"}
+              {embedded ? "Use this MCP server" : "Done"}
             </button>
           </div>
           {doneBundle && (
             <p className="helper" style={{ marginTop: 8 }}>
-              Pick <span className="mono">{doneBundle.name}</span> under Capabilities when composing
+              Pick <span className="mono">{doneBundle.name}</span> under MCP when composing
               the agent.
             </p>
           )}
@@ -496,11 +496,11 @@ export function AddServerWizard({
       <section className="embedded-connector" aria-label="Connect an MCP server">
         <div className="embedded-connector-head">
           <div>
-            <span className="section-kicker">Capability setup</span>
+            <span className="section-kicker">MCP setup</span>
             <h3>Add an MCP server</h3>
             <p>Detect its authentication, connect it, and attach the resulting bundle without leaving this flow.</p>
           </div>
-          <button className="btn ghost sm" type="button" onClick={requestClose}>Back to capabilities</button>
+          <button className="btn ghost sm" type="button" onClick={requestClose}>Back to MCP</button>
         </div>
         {confirmClose && (
           <div className="discard-confirm embedded-discard" role="alert">

--- a/apps/web/app/capabilities/layout.tsx
+++ b/apps/web/app/capabilities/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Capabilities",
-  description: "Tool connections and immutable capability bundles for agents.",
+  title: "MCP",
+  description: "MCP tool connections and immutable server bundles for agents.",
 };
 
 export default function CapabilitiesLayout({ children }: LayoutProps<"/capabilities">) {

--- a/apps/web/app/capabilities/page.tsx
+++ b/apps/web/app/capabilities/page.tsx
@@ -32,7 +32,12 @@ import {
   refreshConnectionTools,
 } from "../lib/api";
 import { useAuthMe } from "../lib/useAuthMe";
-import { GitHubMark, LoadingRows, ModalShell, OwnerTag, PageHead, timeAgo } from "../components/bits";
+import { LoadingRows, ModalShell, OwnerTag, PageHead, timeAgo } from "../components/bits";
+import {
+  ConnectorCard,
+  connectorAttention,
+  connectorConnected,
+} from "../components/ConnectorCard";
 import { OwnerPicker } from "../components/OwnerPicker";
 import { useSmartPolling } from "../lib/useSmartPolling";
 import { AddServerWizard } from "./AddServerWizard";
@@ -80,9 +85,9 @@ function Capabilities() {
     if (fulfilled > 0) setHasSnapshot(true);
     setLoadErr(
       fulfilled === 0
-        ? "Capabilities could not be loaded because the control plane is unavailable."
+        ? "MCP servers could not be loaded because the control plane is unavailable."
         : fulfilled < results.length
-          ? "Some capability data could not be refreshed; showing what is currently available."
+          ? "Some MCP data could not be refreshed; showing what is currently available."
           : ""
     );
     setLoading(false);
@@ -129,8 +134,8 @@ function Capabilities() {
   return (
     <>
       <PageHead
-        title="Capabilities"
-        sub="Tools your agents can call during a run. Connect a service once — every call still passes the permission gate. Attach ≠ allow."
+        title="MCP"
+        sub="MCP tools your agents can call during a run. Connect a service once — every call still passes the permission gate. Attach ≠ allow."
       />
 
       <div className="tabs">
@@ -158,7 +163,7 @@ function Capabilities() {
       ) : !hasSnapshot ? (
         <div className="panel launch-empty">
           <div>
-            <h3>Capabilities are unavailable.</h3>
+            <h3>MCP servers are unavailable.</h3>
             <p>A failed request is not treated as an empty connector store.</p>
           </div>
           <div className="empty-actions">
@@ -315,71 +320,34 @@ function Store({
   );
 }
 
+// The Store's use of the shared card: its trailing action is the CONNECT
+// lifecycle. The card shell, mark, and connected/attention predicates live in
+// components/ConnectorCard so the requirement picker cannot drift from this.
 function StoreCard({ entry, onOpen }: { entry: CatalogEntry; onOpen: () => void }) {
-  const connected =
-    entry.connection?.status === "active" || (entry.auth_mode === "none" && !!entry.bundle);
-  const attention = !!entry.connection && entry.connection.status !== "active" && !connected;
+  const connected = connectorConnected(entry);
+  const attention = connectorAttention(entry);
   // Imported `rest_action` cards are reference-only: browsable, but Connect is
   // refused until the REST action executor lands (bulk-import plan D3).
   const referenceOnly = entry.connectable === false;
 
   return (
-    <button className="connector-card" type="button" onClick={onOpen}>
-      <ConnectorMark entry={entry} />
-      <span className="connector-card-copy">
-        <span className="connector-card-title">
-          <span className="nm">{entry.name}</span>
-          {entry.tier !== "verified" && <span className="badge">{entry.tier}</span>}
-        </span>
-        <span className="desc">{entry.description || "Connect this service as a governed run capability."}</span>
-        <span className="connector-card-meta">
-          {entry.auth_mode === "none"
-            ? "No credential"
-            : entry.auth_mode === "api_key"
-              ? "API key"
-              : "OAuth"}
-          {entry.bundle ? ` · v${entry.bundle.version}` : ""}
-        </span>
-      </span>
-      <span className="connector-card-action">
-        {connected ? (
+    <ConnectorCard
+      entry={entry}
+      onClick={onOpen}
+      action={
+        connected ? (
           <span className="state ok">Connected</span>
         ) : attention ? (
-          <span className="state err">{entry.connection!.status}</span>
+          <span className="state err">{attention}</span>
         ) : referenceOnly ? (
           <span className="state" style={{ color: "var(--muted)" }}>
             Reference only
           </span>
         ) : (
           <span className="state">Connect</span>
-        )}
-      </span>
-    </button>
-  );
-}
-
-function ConnectorMark({ entry }: { entry: CatalogEntry }) {
-  const tone = [
-    "atlassian",
-    "github",
-    "linear",
-    "notion",
-    "sentry",
-    "stripe",
-    "workspace",
-  ].includes(entry.slug) ? entry.slug : "custom";
-  const initials = entry.name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase();
-
-  return (
-    <span className={`connector-mark connector-mark-${tone}`} aria-hidden="true">
-      {entry.slug === "github" ? <GitHubMark size={21} /> : <span>{initials || "C"}</span>}
-    </span>
+        )
+      }
+    />
   );
 }
 
@@ -982,20 +950,6 @@ function ConnectCatalog({
               </div>
             </div>
           )}
-          {entry.tool_hints.length > 0 && (
-            <div className="meta-row">
-              <span className="meta-label">Policy hints — your policy decides</span>
-              <div className="hint-list">
-                {entry.tool_hints.map((h) => (
-                  <div key={h.pattern} className="hint-row">
-                    <span className="hint-pattern">{h.pattern}</span>
-                    <span className="hint-arrow">→</span>
-                    <span className={`hint-action ${h.action}`}>{h.action}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
       )}
       {done ? (
@@ -1182,50 +1136,80 @@ function ConnectCatalog({
             </label>
           )}
           {entry.auth_mode === "oauth" && (
-            <>
-              <p className="helper">
-                Connecting opens the provider&apos;s consent page once. fluidbox then custodies a
-                rotating refresh token (sealed at rest) and mints short-lived access tokens at
-                call time — nothing ever enters a sandbox.
-              </p>
-              <label className="field">
-                <span className="lab">Pre-registered client id (optional)</span>
-                <input
-                  className="inp mono"
-                  value={clientId}
-                  onChange={(e) => setClientId(e.target.value)}
-                  placeholder="Leave empty to use CIMD/DCR"
-                />
-              </label>
-              <label className="field">
-                <span className="lab">Client secret (optional, confidential clients)</span>
-                <input
-                  className="inp mono"
-                  type="password"
-                  value={clientSecret}
-                  onChange={(e) => setClientSecret(e.target.value)}
-                />
-              </label>
-            </>
+            <p className="helper">
+              Connect opens {entry.name}&apos;s sign-in page once. fluidbox keeps only a sealed
+              sign-in token and mints short-lived access at call time — your agents never see it.
+            </p>
           )}
           <OwnerPicker me={me} value={owner} onChange={setOwnerChoice} />
-          <label className="field">
-            <span className="lab">Display name (optional)</span>
-            <input className="inp" value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
-          </label>
           {err && <div className="err">{err}</div>}
-          <div className="spread" style={{ marginTop: 16 }}>
+          <div className="spread" style={{ marginTop: 12 }}>
             <span className="helper">
               {entry.auth_mode === "none"
                 ? "Registers the bundle immediately."
                 : entry.auth_mode === "api_key"
                   ? "The key is sealed at rest and proven by registration."
-                  : "You will be redirected to authorize once."}
+                  : "You'll sign in once, then it's ready for every agent you allow."}
             </span>
             <button className="btn primary" onClick={submit} disabled={busy}>
               {busy ? "Connecting…" : "Connect"}
             </button>
           </div>
+          {/*
+            The 1% lives here, closed by default: a manually registered OAuth
+            client for authorization servers without DCR, a custom label, and
+            the catalog's suggested per-tool verdicts. The 99% path is the
+            Connect button above with everything empty.
+          */}
+          <details className="advanced-config" style={{ marginTop: 12 }}>
+            <summary>Advanced</summary>
+            <div className="advanced-config-body">
+              {entry.auth_mode === "oauth" && (
+                <>
+                  <label className="field">
+                    <span className="lab">Pre-registered client id (optional)</span>
+                    <input
+                      className="inp mono"
+                      value={clientId}
+                      onChange={(e) => setClientId(e.target.value)}
+                      placeholder="Leave empty — fluidbox registers its own"
+                    />
+                    <span className="field-hint">
+                      Only needed when the provider doesn&apos;t support automatic client
+                      registration.
+                    </span>
+                  </label>
+                  <label className="field">
+                    <span className="lab">Client secret (optional, confidential clients)</span>
+                    <input
+                      className="inp mono"
+                      type="password"
+                      value={clientSecret}
+                      onChange={(e) => setClientSecret(e.target.value)}
+                    />
+                  </label>
+                </>
+              )}
+              <label className="field">
+                <span className="lab">Display name (optional)</span>
+                <input className="inp" value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
+              </label>
+              {entry.tool_hints.length > 0 && (
+                <div className="meta-row">
+                  <span className="meta-label">Suggested rules — your policy decides</span>
+                  <div className="hint-list">
+                    {entry.tool_hints.map((h) => (
+                      <div key={h.pattern} className="hint-row">
+                        <span className="hint-pattern">{h.pattern}</span>
+                        <span className="hint-arrow">→</span>
+                        <span className={`hint-action ${h.action}`}>{h.action}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </details>
         </>
       )}
     </ModalShell>
@@ -1294,9 +1278,9 @@ function NewBundle({ onClose, onCreated }: { onClose: () => void; onCreated: () 
         tools inline, as above.
       </p>
       <p className="helper" style={{ marginTop: 0 }}>
-        For a brokered (remote) MCP server, connect it under{" "}
-        <Link href="/capabilities">Integrations</Link> instead — its tools are photographed into a
-        per-connection snapshot, and an agent names it through a connection requirement.
+        For a remote server, use <Link href="/capabilities">the Store&apos;s Connect flow</Link>{" "}
+        instead — its tools are photographed into a per-connection snapshot, and an agent names it
+        through a connection requirement.
       </p>
       <label className="field">
         <span className="lab">Name</span>

--- a/apps/web/app/components/AppPicker.tsx
+++ b/apps/web/app/components/AppPicker.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+// ONE app-store grid for everything an agent can use.
+//
+// The backend stores two different objects — in-sandbox tool bundles (pins,
+// §17 #7) and brokered connection requirements (Phase C) — because they have
+// different custody and security models. That split is the system's anatomy,
+// not the user's mental model: a person composing an agent thinks "let it use
+// Notion". So this picker shows one grid of app cards and routes each toggle
+// to the right object internally:
+//
+//   · catalog entry with a photographed in-image bundle (auth "none")  → pin
+//   · catalog entry with a dialable URL (Notion, Linear, …)            → requirement
+//   · registry bundle with no catalog entry (BYO wizard results)       → pin
+//   · legacy requirement rows with no catalog slug                     → visible + removable
+//
+// The full-control editors (BundlePicker / RequirementsEditor) still exist on
+// the agent edit page; this is the composer's simple surface.
+
+import { useEffect, useState } from "react";
+import {
+  apiGetCached,
+  BindingMode,
+  BundleRef,
+  CapabilityBundle,
+  CatalogEntry,
+  ConnectionRequirement,
+  ConnectionToolSnapshot,
+  fetchConnectionTools,
+} from "../lib/api";
+import { ConnectorCard, ConnectorMark, connectorConnected } from "./ConnectorCard";
+import { useAuthMe } from "../lib/useAuthMe";
+
+export function AppPicker({
+  pins,
+  requirements,
+  onPinsChange,
+  onRequirementsChange,
+  onAddServer,
+  refreshKey = 0,
+}: {
+  pins: BundleRef[];
+  requirements: ConnectionRequirement[];
+  onPinsChange: (pins: BundleRef[]) => void;
+  onRequirementsChange: (reqs: ConnectionRequirement[]) => void;
+  onAddServer?: () => void;
+  refreshKey?: number;
+}) {
+  const me = useAuthMe();
+  const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
+  const [bundles, setBundles] = useState<CapabilityBundle[]>([]);
+  const [addingSlug, setAddingSlug] = useState<string | null>(null);
+  const [addErr, setAddErr] = useState("");
+  const [snapCache, setSnapCache] = useState<Record<string, ConnectionToolSnapshot>>({});
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    Promise.allSettled([
+      apiGetCached<{ connectors: CatalogEntry[] }>("/catalog", {
+        maxAgeMs: 5 * 60_000,
+        force: refreshKey > 0 || retryKey > 0,
+      }),
+      apiGetCached<{ bundles: CapabilityBundle[] }>("/capabilities", {
+        maxAgeMs: 30_000,
+        force: refreshKey > 0 || retryKey > 0,
+      }),
+    ]).then(([cat, cap]) => {
+      if (!active) return;
+      if (cat.status === "fulfilled") setCatalog(cat.value.connectors);
+      if (cap.status === "fulfilled") setBundles(cap.value.bundles);
+      setLoadError(cat.status === "rejected" && cap.status === "rejected");
+      setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, [refreshKey, retryKey]);
+
+  // ── routing predicates ────────────────────────────────────────────────
+  const pinned = (name: string) => pins.some((p) => p.name === name);
+  const required = (slug: string) => requirements.some((r) => r.connector.slug === slug);
+
+  const togglePinByBundle = (b: { id: string; name: string; version: number }) => {
+    if (pinned(b.name)) onPinsChange(pins.filter((p) => p.name !== b.name));
+    else onPinsChange([...pins, { id: b.id, name: b.name, version: b.version }]);
+  };
+
+  const toggleRequirement = async (entry: CatalogEntry) => {
+    if (required(entry.slug)) {
+      onRequirementsChange(requirements.filter((r) => r.connector.slug !== entry.slug));
+      return;
+    }
+    if (!entry.url || !entry.connection) return;
+    // `required_tools` is not a filter — it IS the frozen tool surface a run
+    // gets (bindings.rs: "EXACTLY the required subset"), and the server
+    // refuses an empty list as dead config. So adding an app means declaring
+    // its photographed tool list, the same thing the BYO wizard does. That is
+    // also why an unconnected app cannot be added from here: no snapshot, no
+    // tool names to declare — its card routes to the Store instead.
+    setAddErr("");
+    setAddingSlug(entry.slug);
+    try {
+      const snap = snapCache[entry.slug] ?? (await fetchConnectionTools(entry.connection.id));
+      setSnapCache((prev) => ({ ...prev, [entry.slug]: snap }));
+      const tools = snap.tools.map((t) => t.name);
+      if (tools.length === 0) {
+        setAddErr(
+          `${entry.name}'s tool list is empty — refresh its tools under MCP, then try again.`
+        );
+        return;
+      }
+      onRequirementsChange([
+        ...requirements,
+        {
+          // The slot is just a stable name the run binds against; the slug is
+          // the obvious one and stays out of the user's way entirely.
+          slot: entry.slug,
+          connector: { url: entry.url, slug: entry.slug },
+          required_tools: tools,
+          // "The person running it" needs a signed-in user identity to resolve
+          // (bindings.rs refuses it otherwise). In admin mode there is none —
+          // the operator has no user_id — so the working default there is the
+          // organisation's account. SSO deployments default to personal.
+          binding_mode: me?.user_id ? "invoking_user" : "organization",
+        },
+      ]);
+    } catch {
+      setAddErr(`${entry.name}'s tools could not be loaded. Try again in a moment.`);
+    } finally {
+      setAddingSlug(null);
+    }
+  };
+
+  const setBindingMode = (slot: string, mode: BindingMode) =>
+    onRequirementsChange(
+      requirements.map((r) => (r.slot === slot ? { ...r, binding_mode: mode } : r))
+    );
+
+  const removeRequirementRow = (slot: string) =>
+    onRequirementsChange(requirements.filter((r) => r.slot !== slot));
+
+  // ── card inventory ────────────────────────────────────────────────────
+  // Catalog entries split by how attaching works. `rest_action` reference
+  // cards (connectable === false, no bundle) are not usable and are skipped.
+  const bundleEntries = catalog.filter((e) => e.auth_mode === "none" && e.bundle);
+  const reqEntries = catalog.filter((e) => !!e.url && e.connectable !== false);
+
+  // Registry bundles with no catalog card: BYO results and friends. Mirrors
+  // BundlePicker's guard — zero-tool and legacy brokered-class bundles hide
+  // unless already pinned (an attached one must stay visible to be removable).
+  const catalogBundleNames = new Set(catalog.map((e) => e.bundle?.name).filter(Boolean));
+  const latestByName = new Map<string, CapabilityBundle>();
+  for (const b of bundles) if (!latestByName.has(b.name)) latestByName.set(b.name, b);
+  const looseBundles = [...latestByName.values()].filter(
+    (b) =>
+      !catalogBundleNames.has(b.name) &&
+      (((b.tool_count ?? 0) > 0 && !(b.classes ?? []).includes("brokered")) || pinned(b.name))
+  );
+
+  // Requirement rows this grid cannot express as a catalog card (custom URLs,
+  // drafts from older flows): keep them visible and removable.
+  const knownSlugs = new Set(reqEntries.map((e) => e.slug));
+  const looseReqs = requirements.filter(
+    (r) => !r.connector.slug || !knownSlugs.has(r.connector.slug)
+  );
+
+  // Ready-to-use first — the things a user can act on with zero extra steps.
+  const orderedReqEntries = [
+    ...reqEntries.filter((e) => connectorConnected(e)),
+    ...reqEntries.filter((e) => !connectorConnected(e)),
+  ];
+
+  if (loading && catalog.length === 0 && bundles.length === 0) {
+    return (
+      <div className="field">
+        <span className="lab">Apps &amp; tools</span>
+        <span className="helper">Loading apps…</span>
+      </div>
+    );
+  }
+
+  if (loadError && catalog.length === 0 && bundles.length === 0) {
+    return (
+      <div className="field">
+        <span className="lab">Apps &amp; tools</span>
+        <div className="err" role="alert">The app list could not be loaded.</div>
+        <button className="btn" type="button" onClick={() => setRetryKey((k) => k + 1)}>
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  const added = pins.length + requirements.length;
+
+  return (
+    <div className="field">
+      <div className="bundle-picker-head">
+        <span className="lab">Apps &amp; tools</span>
+        {added > 0 && (
+          <span className="helper" style={{ margin: 0 }}>
+            {added} added
+          </span>
+        )}
+      </div>
+      {addErr && (
+        <div className="err" role="alert">
+          {addErr}
+        </div>
+      )}
+      <div className="connector-grid app-picker-grid">
+        {bundleEntries.map((entry) => {
+          const on = pinned(entry.bundle!.name);
+          return (
+            <div className="app-card-wrap" key={`b-${entry.slug}`}>
+              <ConnectorCard
+                entry={entry}
+                selected={on}
+                onClick={() => togglePinByBundle(entry.bundle!)}
+                meta="Ready to use"
+                action={
+                  on ? <span className="state ok">✓ Added</span> : <span className="state">Add</span>
+                }
+              />
+            </div>
+          );
+        })}
+
+        {orderedReqEntries.map((entry) => {
+          const on = required(entry.slug);
+          const ready = connectorConnected(entry);
+          const req = requirements.find((r) => r.connector.slug === entry.slug);
+          return (
+            <div className={`app-card-wrap${on ? " has-sub" : ""}`} key={`r-${entry.slug}`}>
+              <ConnectorCard
+                entry={entry}
+                selected={on}
+                onClick={() => {
+                  // Removing is always allowed; adding needs a connection
+                  // (its snapshot supplies the tool names) — an unconnected
+                  // card routes to the Store's Connect flow instead.
+                  if (on || ready) void toggleRequirement(entry);
+                  else window.open("/capabilities", "_blank", "noreferrer");
+                }}
+                meta={
+                  ready ? (
+                    <span className="mcp-state-ok">Ready to use</span>
+                  ) : (
+                    <span className="mcp-state-warn">Connect it first — takes about a minute</span>
+                  )
+                }
+                action={
+                  on ? (
+                    <span className="state ok">✓ Added</span>
+                  ) : addingSlug === entry.slug ? (
+                    <span className="state">Adding…</span>
+                  ) : ready ? (
+                    <span className="state">Add</span>
+                  ) : (
+                    <span className="state">Set up ↗</span>
+                  )
+                }
+              />
+              {on && req && (
+                <div className="app-card-sub">
+                  <span>Uses the account of</span>
+                  <select
+                    className="inp"
+                    value={req.binding_mode}
+                    onChange={(e) => setBindingMode(req.slot, e.target.value as BindingMode)}
+                    aria-label={`Whose ${entry.name} account`}
+                  >
+                    <option value="invoking_user">the person running it</option>
+                    <option value="organization">the organisation</option>
+                  </select>
+                  {!ready && (
+                    <span className="app-card-sub-warn">
+                      Won&apos;t start until set up —{" "}
+                      <a className="link" href="/capabilities" target="_blank" rel="noreferrer">
+                        set it up ↗
+                      </a>
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {looseBundles.map((b) => {
+          const on = pinned(b.name);
+          const stale = (b.classes ?? []).includes("brokered");
+          return (
+            <div className="app-card-wrap" key={`lb-${b.name}`}>
+              <button
+                className={`connector-card${on ? " selected" : ""}`}
+                type="button"
+                onClick={() => togglePinByBundle(b)}
+                aria-pressed={on}
+              >
+                <ConnectorMark
+                  entry={{ slug: b.name, name: b.name } as unknown as CatalogEntry}
+                />
+                <span className="connector-card-copy">
+                  <span className="connector-card-title">
+                    <span className="nm">{b.name}</span>
+                  </span>
+                  <span className="desc">{b.description || "A tool server you added."}</span>
+                  <span className="connector-card-meta">
+                    {stale ? (
+                      <span className="mcp-state-warn">Outdated — remove it</span>
+                    ) : (
+                      `${b.tool_count} tool${b.tool_count === 1 ? "" : "s"} · ready to use`
+                    )}
+                  </span>
+                </span>
+                <span className="connector-card-action">
+                  {on ? <span className="state ok">✓ Added</span> : <span className="state">Add</span>}
+                </span>
+              </button>
+            </div>
+          );
+        })}
+
+        {looseReqs.map((r) => (
+          <div className="app-card-wrap has-sub" key={`lr-${r.slot}`}>
+            <button
+              className="connector-card selected"
+              type="button"
+              onClick={() => removeRequirementRow(r.slot)}
+              aria-pressed
+            >
+              <span className="connector-mark connector-mark-custom" aria-hidden="true">
+                <span>{(r.connector.slug || r.slot || "C").slice(0, 1).toUpperCase()}</span>
+              </span>
+              <span className="connector-card-copy">
+                <span className="connector-card-title">
+                  <span className="nm">{r.connector.slug || r.slot || "Custom server"}</span>
+                </span>
+                <span className="desc">{r.connector.url || "No address set"}</span>
+                <span className="connector-card-meta">Added by hand</span>
+              </span>
+              <span className="connector-card-action">
+                <span className="state ok">✓ Added</span>
+              </span>
+            </button>
+            <div className="app-card-sub">
+              <span>Uses the account of</span>
+              <select
+                className="inp"
+                value={r.binding_mode}
+                onChange={(e) => setBindingMode(r.slot, e.target.value as BindingMode)}
+                aria-label="Whose account"
+              >
+                <option value="invoking_user">the person running it</option>
+                <option value="organization">the organisation</option>
+              </select>
+            </div>
+          </div>
+        ))}
+
+        {onAddServer && (
+          <div className="app-card-wrap">
+            <button className="connector-card" type="button" onClick={onAddServer}>
+              <span className="connector-mark connector-mark-custom" aria-hidden="true">
+                <span>+</span>
+              </span>
+              <span className="connector-card-copy">
+                <span className="connector-card-title">
+                  <span className="nm">Add your own</span>
+                </span>
+                <span className="desc">Have a server address? Connect it and it appears here.</span>
+                <span className="connector-card-meta">Takes about a minute</span>
+              </span>
+              <span className="connector-card-action">
+                <span className="state">Add →</span>
+              </span>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/BundlePicker.tsx
+++ b/apps/web/app/components/BundlePicker.tsx
@@ -36,7 +36,7 @@ export function BundlePicker({
           if (active) setRegistry(r.bundles);
         })
         .catch((error) => {
-          if (active) setLoadError(`Tool bundles could not be loaded. ${String(error)}`);
+          if (active) setLoadError(`Tools could not be loaded. ${String(error)}`);
         })
         .finally(() => {
           if (active) setLoading(false);
@@ -102,8 +102,8 @@ export function BundlePicker({
   if (loading && names.length === 0) {
     return (
       <div className="field">
-        <span className="lab">Sandbox tool bundles</span>
-        <span className="helper">Loading registered bundles…</span>
+        <span className="lab">Built-in tools</span>
+        <span className="helper">Loading…</span>
       </div>
     );
   }
@@ -111,10 +111,10 @@ export function BundlePicker({
   if (loadError && names.length === 0) {
     return (
       <div className="field">
-        <span className="lab">Sandbox tool bundles</span>
+        <span className="lab">Built-in tools</span>
         <div className="err" role="alert">{loadError}</div>
         <button className="btn" type="button" onClick={() => setRetryKey((current) => current + 1)}>
-          Retry bundles
+          Try again
         </button>
       </div>
     );
@@ -123,14 +123,14 @@ export function BundlePicker({
   if (names.length === 0) {
     return (
       <div className="field">
-        <span className="lab">Sandbox tool bundles</span>
+        <span className="lab">Built-in tools</span>
         <span className="helper">
-          None registered yet. Connect an MCP server to photograph its tools into a versioned bundle.
+          None yet. Add a tool server to make its tools available to your agents.
         </span>
         {onAddServer ? (
-          <button className="btn" type="button" onClick={onAddServer}>Connect an MCP server</button>
+          <button className="btn" type="button" onClick={onAddServer}>Add a tool server</button>
         ) : (
-          <Link href="/capabilities" className="btn">Open capabilities</Link>
+          <Link href="/capabilities" className="btn">Open MCP</Link>
         )}
       </div>
     );
@@ -138,9 +138,9 @@ export function BundlePicker({
   return (
     <div className="field">
       <div className="bundle-picker-head">
-        <span className="lab">Sandbox tool bundles — exact version pins</span>
+        <span className="lab">Built-in tools</span>
         {onAddServer && (
-          <button className="btn ghost sm" type="button" onClick={onAddServer}>Connect new MCP</button>
+          <button className="btn ghost sm" type="button" onClick={onAddServer}>Add a tool server</button>
         )}
       </div>
       {loadError && (
@@ -187,7 +187,7 @@ export function BundlePicker({
                 {shown.tool_count} tool{shown.tool_count === 1 ? "" : "s"}
                 {[...new Set(shown.classes)].map((c) => (
                   <span key={c} className={`badge ${c === "brokered" ? "brand" : ""}`}>
-                    {c}
+                    {c === "brokered" ? "needs an account" : "built in"}
                   </span>
                 ))}
               </span>

--- a/apps/web/app/components/ConnectorCard.tsx
+++ b/apps/web/app/components/ConnectorCard.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+// The connector card, shared by the two surfaces that present catalog entries:
+// the MCP Store (browse + Connect) and the agent's requirement editor (declare
+// what the agent needs). They ask different questions of the same object, so
+// the trailing ACTION is a slot rather than something this component decides —
+// the Store puts "Connect"/"Connected" there, the picker puts "Select".
+//
+// Extracting this is what makes the two surfaces read as one system: before,
+// the Store rendered a card with a logo, description and live connection state
+// while the requirement editor rendered a bare <select> of names, so the same
+// seven connectors looked like two unrelated features.
+
+import { ReactNode } from "react";
+import { CatalogEntry } from "../lib/api";
+import { GitHubMark } from "./bits";
+
+/** Slugs with a dedicated tint in globals.css (`.connector-mark-*`). */
+const TONED = ["atlassian", "github", "linear", "notion", "sentry", "stripe", "workspace"];
+
+export function ConnectorMark({ entry }: { entry: CatalogEntry }) {
+  const tone = TONED.includes(entry.slug) ? entry.slug : "custom";
+  const initials = entry.name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+
+  return (
+    <span className={`connector-mark connector-mark-${tone}`} aria-hidden="true">
+      {entry.slug === "github" ? <GitHubMark size={21} /> : <span>{initials || "C"}</span>}
+    </span>
+  );
+}
+
+/**
+ * Is this entry backed by a usable connection right now?
+ *
+ * `connection` is server-side decoration on the catalog row (the non-revoked
+ * connection covering the entry). An `auth_mode: "none"` entry needs no
+ * credential at all, so a photographed bundle is what makes it usable.
+ *
+ * Shared deliberately: the Store and the requirement picker must never disagree
+ * about whether something is connected.
+ */
+export function connectorConnected(entry: CatalogEntry): boolean {
+  return entry.connection?.status === "active" || (entry.auth_mode === "none" && !!entry.bundle);
+}
+
+/** A non-active connection that the user should be told about (error/pending). */
+export function connectorAttention(entry: CatalogEntry): string | null {
+  if (connectorConnected(entry)) return null;
+  return entry.connection && entry.connection.status !== "active" ? entry.connection.status : null;
+}
+
+export function connectorAuthLabel(entry: CatalogEntry): string {
+  return entry.auth_mode === "none"
+    ? "No credential"
+    : entry.auth_mode === "api_key"
+      ? "API key"
+      : "OAuth";
+}
+
+export function ConnectorCard({
+  entry,
+  onClick,
+  action,
+  selected = false,
+  meta,
+  title,
+}: {
+  entry: CatalogEntry;
+  onClick: () => void;
+  /** Trailing pill — the caller owns this, since the two surfaces differ. */
+  action: ReactNode;
+  selected?: boolean;
+  /** Overrides the default auth-mode line. */
+  meta?: ReactNode;
+  /** Accessible label; defaults to the connector name. */
+  title?: string;
+}) {
+  return (
+    <button
+      className={`connector-card${selected ? " selected" : ""}`}
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      aria-label={title ?? entry.name}
+    >
+      <ConnectorMark entry={entry} />
+      <span className="connector-card-copy">
+        <span className="connector-card-title">
+          <span className="nm">{entry.name}</span>
+          {entry.tier !== "verified" && <span className="badge">{entry.tier}</span>}
+        </span>
+        <span className="desc">
+          {entry.description || "Connect this service as a governed MCP server."}
+        </span>
+        <span className="connector-card-meta">
+          {meta ?? (
+            <>
+              {connectorAuthLabel(entry)}
+              {entry.bundle ? ` · v${entry.bundle.version}` : ""}
+            </>
+          )}
+        </span>
+      </span>
+      <span className="connector-card-action">{action}</span>
+    </button>
+  );
+}

--- a/apps/web/app/components/RequirementsEditor.tsx
+++ b/apps/web/app/components/RequirementsEditor.tsx
@@ -21,6 +21,7 @@ import {
   connectionMatchesConnector,
   fetchConnectionTools,
 } from "../lib/api";
+import { ConnectorCard, connectorAttention, connectorConnected } from "./ConnectorCard";
 
 interface Row {
   key: string;
@@ -31,6 +32,9 @@ interface Row {
   tools: string[];
   toolDraft: string;
   bindingMode: BindingMode;
+  /** UI-only: show the connector card grid for this row. A new row opens in
+   *  the picker; a seeded row shows its chosen connector until "Change". */
+  picking: boolean;
 }
 
 let keySeq = 0;
@@ -48,6 +52,7 @@ function seedRows(value: ConnectionRequirement[]): Row[] {
     tools: [...r.required_tools],
     toolDraft: "",
     bindingMode: r.binding_mode,
+    picking: false,
   }));
 }
 
@@ -152,19 +157,35 @@ export function RequirementsEditor({
         tools: [],
         toolDraft: "",
         bindingMode: "invoking_user",
+        picking: true,
       },
     ]);
   const removeRow = (key: string) => update(rows.filter((r) => r.key !== key));
 
-  const pickConnector = (row: Row, selectValue: string) => {
-    if (selectValue === CUSTOM) {
-      patch(row.key, { custom: true, connectorSlug: null });
+  const pickConnector = (row: Row, choice: CatalogEntry | typeof CUSTOM) => {
+    if (choice === CUSTOM) {
+      patch(row.key, { custom: true, connectorSlug: null, connectorUrl: "", picking: false });
       return;
     }
-    const entry = catalog.find((e) => e.slug === selectValue);
-    if (!entry || !entry.url) return;
-    patch(row.key, { custom: false, connectorSlug: entry.slug, connectorUrl: entry.url });
+    if (!choice.url) return;
+    patch(row.key, {
+      custom: false,
+      connectorSlug: choice.slug,
+      connectorUrl: choice.url,
+      picking: false,
+      // A slot is just a stable name the RunSpec binds against. Defaulting it
+      // to the connector's slug means the common case needs no typing at all;
+      // it stays editable for an agent that needs two slots on one connector.
+      slot: row.slot.trim() || choice.slug,
+    });
   };
+
+  /** Catalog entries usable AS a brokered requirement: a requirement is a URL
+   *  the control plane dials, so an entry without one (stdio / in-image) can
+   *  never satisfy a slot. Reference-only cards can never be connected either. */
+  const pickable = catalog.filter((e) => !!e.url && e.connectable !== false);
+  const ready = pickable.filter((e) => connectorConnected(e));
+  const needsConnecting = pickable.filter((e) => !connectorConnected(e));
 
   const addTool = (row: Row, raw: string) => {
     const parts = raw
@@ -192,25 +213,28 @@ export function RequirementsEditor({
   return (
     <div className="field">
       <div className="bundle-picker-head">
-        <span className="lab">Connection requirements — brokered tools</span>
+        <span className="lab">Apps this agent can use</span>
         <button className="btn ghost sm" type="button" onClick={addRow}>
-          Add requirement
+          Add an app
         </button>
       </div>
       {lookupError && (
         <span className="helper" role="status">
-          Connector suggestions are unavailable. Existing values and custom URL/tool entry still work.
+          The app list is unavailable right now. You can still type an address and tool names by hand.
         </span>
       )}
       {rows.length === 0 ? (
         <span className="helper">
-          None. Declare a brokered MCP server the agent must be bound to at run time — a
-          connection is chosen per run (yours or the organization&apos;s), never frozen here.
+          None yet. Pick the apps this agent should be able to use — Notion, GitHub, Linear
+          and more. You choose whose account it uses when it runs.
         </span>
       ) : (
         <div className="opt-list">
           {rows.map((row) => {
             const suggestions = suggestionsFor(row);
+            const selectedEntry = row.connectorSlug
+              ? catalog.find((e) => e.slug === row.connectorSlug)
+              : undefined;
             return (
               <div
                 key={row.key}
@@ -221,57 +245,189 @@ export function RequirementsEditor({
                   borderBottom: "1px solid var(--border)",
                 }}
               >
-                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                  <input
-                    className="inp mono"
-                    style={{ maxWidth: 160 }}
-                    placeholder="slot (e.g. issues)"
-                    value={row.slot}
-                    onChange={(e) => patch(row.key, { slot: e.target.value })}
-                    aria-label="Requirement slot"
-                  />
-                  <select
-                    className="inp"
-                    value={row.custom ? CUSTOM : (row.connectorSlug ?? CUSTOM)}
-                    onChange={(e) => pickConnector(row, e.target.value)}
-                    aria-label="Connector"
-                  >
-                    <option value={CUSTOM}>Custom URL…</option>
-                    {catalog.map((e) => (
-                      <option key={e.slug} value={e.slug}>
-                        {e.name}
-                      </option>
-                    ))}
-                  </select>
-                  <select
-                    className="inp"
-                    style={{ maxWidth: 150 }}
-                    value={row.bindingMode}
-                    onChange={(e) =>
-                      patch(row.key, { bindingMode: e.target.value as BindingMode })
-                    }
-                    aria-label="Binding mode"
-                  >
-                    <option value="invoking_user">Invoking user</option>
-                    <option value="organization">Organization</option>
-                  </select>
-                  <button
-                    className="btn ghost sm danger"
-                    type="button"
-                    onClick={() => removeRow(row.key)}
-                    aria-label="Remove requirement"
-                  >
-                    Remove
-                  </button>
-                </div>
-                {row.custom && (
-                  <input
-                    className="inp mono"
-                    placeholder="https://mcp.example.com/mcp"
-                    value={row.connectorUrl}
-                    onChange={(e) => patch(row.key, { connectorUrl: e.target.value })}
-                    aria-label="Connector URL"
-                  />
+                {/*
+                  CATALOGUE FIRST, FORM SECOND. The old row led with a bare
+                  `slot` text box — jargon before you had chosen anything. You
+                  now pick a connector from the same cards as the MCP Store,
+                  and the mechanical fields appear underneath once that choice
+                  is made.
+
+                  The split into "Ready to use" / "Needs connecting" is the
+                  load-bearing part: requirement satisfaction is
+                  ALL-or-fail-closed at run start, so a connector nobody has
+                  connected yields an agent that creates fine and can never
+                  run. Sorting by connection state makes that legible at a
+                  glance instead of one label per card.
+                */}
+                {row.picking ? (
+                  <div className="mcp-catalogue">
+                    {ready.length > 0 && (
+                      <>
+                        <div className="mcp-catalogue-head">
+                          <span className="mcp-catalogue-title">Ready to use</span>
+                          <span className="mcp-catalogue-count">{ready.length}</span>
+                        </div>
+                        <div className="connector-grid">
+                          {ready.map((entry) => (
+                            <ConnectorCard
+                              key={entry.slug}
+                              entry={entry}
+                              selected={row.connectorSlug === entry.slug}
+                              onClick={() => pickConnector(row, entry)}
+                              action={<span className="state ok">● Connected</span>}
+                            />
+                          ))}
+                        </div>
+                      </>
+                    )}
+
+                    {needsConnecting.length > 0 && (
+                      <>
+                        <div className="mcp-catalogue-head">
+                          <span className="mcp-catalogue-title">Needs connecting</span>
+                          <span className="mcp-catalogue-count">{needsConnecting.length}</span>
+                          <a
+                            className="link mcp-catalogue-link"
+                            href="/capabilities"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Set one up ↗
+                          </a>
+                        </div>
+                        <p className="mcp-catalogue-note">
+                          You can pick these now, but the agent will not be able to start until
+                          the app is set up with an account.
+                        </p>
+                        <div className="connector-grid">
+                          {needsConnecting.map((entry) => (
+                            <ConnectorCard
+                              key={entry.slug}
+                              entry={entry}
+                              selected={row.connectorSlug === entry.slug}
+                              onClick={() => pickConnector(row, entry)}
+                              action={
+                                connectorAttention(entry) ? (
+                                  <span className="state err">{connectorAttention(entry)}</span>
+                                ) : (
+                                  <span className="state mcp-state-muted">Not connected</span>
+                                )
+                              }
+                            />
+                          ))}
+                        </div>
+                      </>
+                    )}
+
+                    <div className="mcp-catalogue-head">
+                      <span className="mcp-catalogue-title">Something else</span>
+                    </div>
+                    <div className="connector-grid">
+                      <button
+                        className={`connector-card${row.custom && !row.connectorSlug ? " selected" : ""}`}
+                        type="button"
+                        onClick={() => pickConnector(row, CUSTOM)}
+                      >
+                        <span className="connector-mark connector-mark-custom" aria-hidden="true">
+                          <span>+</span>
+                        </span>
+                        <span className="connector-card-copy">
+                          <span className="connector-card-title">
+                            <span className="nm">Custom URL</span>
+                          </span>
+                          <span className="desc">
+                            An app that is not in the list above.
+                          </span>
+                          <span className="connector-card-meta">Streamable HTTP</span>
+                        </span>
+                        <span className="connector-card-action">
+                          <span className="state">Enter URL</span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    {selectedEntry && (
+                      <ConnectorCard
+                        entry={selectedEntry}
+                        selected
+                        onClick={() => patch(row.key, { picking: true })}
+                        action={<span className="state">Change</span>}
+                        meta={
+                          connectorConnected(selectedEntry) ? (
+                            <span className="mcp-state-ok">● Ready to use</span>
+                          ) : (
+                            <span className="mcp-state-warn">
+                              Not set up yet —{" "}
+                              <a
+                                className="link"
+                                href="/capabilities"
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                set it up
+                              </a>{" "}
+                              or this agent will not start
+                            </span>
+                          )
+                        }
+                      />
+                    )}
+                    {row.custom && (
+                      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                        <input
+                          className="inp mono"
+                          placeholder="https://mcp.example.com/mcp"
+                          value={row.connectorUrl}
+                          onChange={(e) => patch(row.key, { connectorUrl: e.target.value })}
+                          aria-label="Connector URL"
+                        />
+                        <button
+                          className="btn ghost sm"
+                          type="button"
+                          onClick={() => patch(row.key, { picking: true })}
+                        >
+                          Browse apps
+                        </button>
+                      </div>
+                    )}
+                    {/* The mechanical fields: secondary to the choice above. */}
+                    <div className="mcp-req-detail">
+                      <label className="mcp-req-field">
+                        <span className="mcp-req-lab">Label</span>
+                        <input
+                          className="inp mono"
+                          placeholder="e.g. notion"
+                          value={row.slot}
+                          onChange={(e) => patch(row.key, { slot: e.target.value })}
+                          aria-label="Label"
+                        />
+                      </label>
+                      <label className="mcp-req-field">
+                        <span className="mcp-req-lab">Whose account</span>
+                        <select
+                          className="inp"
+                          value={row.bindingMode}
+                          onChange={(e) =>
+                            patch(row.key, { bindingMode: e.target.value as BindingMode })
+                          }
+                          aria-label="Whose account"
+                        >
+                          <option value="invoking_user">The person running it</option>
+                          <option value="organization">The organisation</option>
+                        </select>
+                      </label>
+                      <button
+                        className="btn ghost sm danger"
+                        type="button"
+                        onClick={() => removeRow(row.key)}
+                        aria-label="Remove requirement"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </>
                 )}
                 <div>
                   <div className="chips" style={{ marginBottom: 4 }}>
@@ -297,13 +453,13 @@ export function RequirementsEditor({
                     ))}
                     {row.tools.length === 0 && (
                       <span className="faint" style={{ fontSize: 11.5 }}>
-                        no required tools yet
+                        all tools allowed
                       </span>
                     )}
                   </div>
                   <input
                     className="inp mono"
-                    placeholder="required tool, press Enter or comma"
+                    placeholder="tool name, press Enter"
                     value={row.toolDraft}
                     onChange={(e) => patch(row.key, { toolDraft: e.target.value })}
                     onKeyDown={(e) => {

--- a/apps/web/app/components/ResourceOverview.tsx
+++ b/apps/web/app/components/ResourceOverview.tsx
@@ -160,7 +160,7 @@ export function ResourceOverview({
             count={snapshot.agents.length}
             description={
               snapshot.agents.length === 0
-                ? "Create the reusable runtime, model, instructions, workspace, and capability configuration for a run."
+                ? "Create the reusable runtime, model, instructions, workspace, and MCP configuration for a run."
                 : "Versioned definitions available to manual and automated runs."
             }
             items={snapshot.agents.map((agent) => agent.name)}
@@ -194,7 +194,7 @@ export function ResourceOverview({
           <ResourceCard
             tone="capability"
             eyebrow="Optional"
-            title="Capabilities"
+            title="MCP"
             count={latestBundles.length}
             description={
               latestBundles.length === 0
@@ -202,7 +202,7 @@ export function ResourceOverview({
                 : `${activeToolConnections.length} active tool connection${activeToolConnections.length === 1 ? "" : "s"}; exact bundle versions are pinned on agents.`
             }
             items={latestBundles.map((bundle) => `${bundle.name}@${bundle.version}`)}
-            action={<button className="btn sm" type="button" onClick={onAddCapability}>{latestBundles.length === 0 ? "Add Capability" : "Add Another"}</button>}
+            action={<button className="btn sm" type="button" onClick={onAddCapability}>{latestBundles.length === 0 ? "Add MCP Server" : "Add Another"}</button>}
             secondary={<Link className="resource-secondary" href="/capabilities">Manage</Link>}
           />
         </div>

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -19,7 +19,7 @@ import {
 import { AddServerWizard } from "../capabilities/AddServerWizard";
 import { defaultModelFor, modelsFor, useHarnesses } from "../lib/harnesses";
 import { useAuthMe } from "../lib/useAuthMe";
-import { BundlePicker } from "./BundlePicker";
+import { AppPicker } from "./AppPicker";
 import { HarnessPicker } from "./HarnessPicker";
 import { describeSchedule, localTimezone, parseCron, ScheduleBuilder } from "./ScheduleBuilder";
 import {
@@ -54,6 +54,9 @@ interface RunComposerDraft {
   systemPrompt: string;
   /** New-agent policy attachment (spec A); absent in pre-attachment drafts. */
   policyName?: string;
+  /** Guardrail-preset rules switch for an EXISTING agent (rides the appended
+   *  revision as `policy`); null/absent = keep the agent's own rules. */
+  policyOverride?: string | null;
   workspace: WorkspaceDraft;
   pins: BundleRef[];
   requirements: ConnectionRequirement[];
@@ -157,6 +160,9 @@ export function RunComposer({
   // toggle instead of letting the server 400 at submit.
   const [policyName, setPolicyName] = useState("default");
   const [agentPolicyId, setAgentPolicyId] = useState<string | null>(null);
+  // Guardrail presets can switch an EXISTING agent's rules; the switch rides
+  // the same appended revision as any other change (AddRevision.policy).
+  const [policyOverride, setPolicyOverride] = useState<string | null>(null);
   const [policies, setPolicies] = useState<PolicySummary[]>([]);
   const [policiesError, setPoliciesError] = useState("");
   const [workspace, setWorkspace] = useState<WorkspaceDraft>(emptyDraft("scratch"));
@@ -172,6 +178,12 @@ export function RunComposer({
   const [connectionRefresh, setConnectionRefresh] = useState(0);
   const [addingMcp, setAddingMcp] = useState(false);
   const [addingMcpDirty, setAddingMcpDirty] = useState(false);
+  // Launching an EXISTING agent shows a one-line "uses its saved setup"
+  // summary instead of the full workspace/apps editors; this opts back into
+  // the editors. Defining a new agent always shows them.
+  const [customizeSetup, setCustomizeSetup] = useState(false);
+  // Guardrails: show the raw rules/approvals axes under the presets.
+  const [customGuardrails, setCustomGuardrails] = useState(false);
   const [pendingAgentSwitch, setPendingAgentSwitch] = useState<PendingAgentSwitch | null>(null);
 
   const [kind, setKind] = useState<TriggerKind>("api");
@@ -214,6 +226,7 @@ export function RunComposer({
       model,
       systemPrompt,
       policyName,
+      policyOverride,
       workspace,
       pins,
       requirements,
@@ -238,7 +251,7 @@ export function RunComposer({
     }),
     [
       mode, task, autonomous, agentChoice, selectedAgentName, revisionTouched, newAgentName,
-      description, harness, model, systemPrompt, policyName, workspace, pins, requirements, bindings, kind,
+      description, harness, model, systemPrompt, policyName, policyOverride, workspace, pins, requirements, bindings, kind,
       automationName, allowTask, allowWorkspace, callbackUrl, concurrency, cron, timezone,
       missedPolicy, connection, repositories, evOpened, evReopened, evSync, pubComment, pubCheck,
       capabilityKeepList,
@@ -292,6 +305,7 @@ export function RunComposer({
     setModel(saved.model);
     setSystemPrompt(saved.systemPrompt);
     setPolicyName(saved.policyName ?? "default");
+    setPolicyOverride(saved.policyOverride ?? null);
     setWorkspace(saved.workspace);
     setPins(saved.pins);
     setRequirements(saved.requirements);
@@ -434,6 +448,7 @@ export function RunComposer({
     setAgentChoice("existing");
     setSelectedAgentName(name);
     setRevisionTouched(false);
+    setPolicyOverride(null); // presets re-derive from the newly selected agent
     setPendingAgentSwitch(null);
   };
 
@@ -444,6 +459,7 @@ export function RunComposer({
     setModel(defaultModelFor(harnesses, defaultHarness) || "claude-haiku-4-5");
     setSystemPrompt("");
     setPolicyName("default");
+    setPolicyOverride(null);
     setWorkspace(emptyDraft("scratch"));
     setPins([]);
     setRequirements([]); // a new agent declares its requirements in the editor
@@ -459,8 +475,10 @@ export function RunComposer({
     () =>
       agentChoice === "new"
         ? policies.find((candidate) => candidate.name === policyName) ?? null
-        : policies.find((candidate) => candidate.id === agentPolicyId) ?? null,
-    [agentChoice, agentPolicyId, policies, policyName]
+        : policyOverride !== null
+          ? policies.find((candidate) => candidate.name === policyOverride) ?? null
+          : policies.find((candidate) => candidate.id === agentPolicyId) ?? null,
+    [agentChoice, agentPolicyId, policies, policyName, policyOverride]
   );
   // Three states, and the asymmetry is deliberate. RESOLVED + permitted →
   // offer the toggle. RESOLVED + not permitted (including a version-less
@@ -477,6 +495,74 @@ export function RunComposer({
   useEffect(() => {
     if (autonomyForbidden && autonomous) setAutonomous(false);
   }, [autonomous, autonomyForbidden]);
+
+  // ── Guardrail presets ──────────────────────────────────────────────────
+  // Rules (policy, on the revision) and approvals (autonomous, on the run)
+  // are orthogonal axes with two dead-ish cells. The presets name the three
+  // coherent bundles; Custom keeps the raw axes for anyone who wants them.
+  // "Unrestricted" is resolved by NAME from the loaded summaries — if a
+  // deployment has no such policy, Free rein disables rather than inventing
+  // one.
+  const UNRESTRICTED_RULES = "unrestricted";
+  const unrestrictedPolicy =
+    policies.find((candidate) => candidate.name === UNRESTRICTED_RULES) ?? null;
+  const governedFallback =
+    policies.find((candidate) => candidate.name === "default") ??
+    policies.find((candidate) => candidate.name !== UNRESTRICTED_RULES) ??
+    null;
+  const rulesAreUnrestricted = governingPolicy?.name === UNRESTRICTED_RULES;
+  const basePolicyName =
+    policies.find((candidate) => candidate.id === agentPolicyId)?.name ?? null;
+  // Which preset the current (rules, approvals) state corresponds to; null =
+  // Custom (e.g. unrestricted rules + supervised — the vacuous cell).
+  const activePreset: "autopilot" | "ask" | "free" | null = rulesAreUnrestricted
+    ? autonomous
+      ? "free"
+      : null
+    : autonomous
+      ? "autopilot"
+      : "ask";
+  // The rules a governed preset would run under (used for gating + honesty in
+  // the card copy): the current rules, unless they are unrestricted, in which
+  // case the preset switches to the governed fallback.
+  const governedTarget = rulesAreUnrestricted ? governedFallback : governingPolicy;
+  const applyRules = (name: string) => {
+    if (agentChoice === "new") {
+      setPolicyName(name);
+      return;
+    }
+    if (name === basePolicyName) {
+      setPolicyOverride(null);
+      return;
+    }
+    if ((governingPolicy?.name ?? null) !== name) {
+      setPolicyOverride(name);
+      touchRevision();
+    }
+  };
+  const applyPreset = (preset: "autopilot" | "ask" | "free") => {
+    if (preset === "free") {
+      if (!unrestrictedPolicy) return;
+      applyRules(UNRESTRICTED_RULES);
+      setAutonomous(true);
+      return;
+    }
+    if (rulesAreUnrestricted && governedFallback) applyRules(governedFallback.name);
+    setAutonomous(preset === "autopilot");
+  };
+  // Does picking this preset rewrite an existing agent's rules? Said on the
+  // card BEFORE the click — a run-level choice must not silently edit the
+  // agent. Returns the rules name it would switch to, or null for no change.
+  const presetChangesRules = (preset: "autopilot" | "ask" | "free"): string | null => {
+    if (agentChoice !== "existing") return null;
+    const target =
+      preset === "free"
+        ? UNRESTRICTED_RULES
+        : rulesAreUnrestricted
+          ? (governedFallback?.name ?? null)
+          : (governingPolicy?.name ?? basePolicyName);
+    return target && target !== basePolicyName ? target : null;
+  };
 
   const requestExistingAgent = (name: string) => {
     if (agentChoice === "existing" && selectedAgentName === name) return;
@@ -522,6 +608,12 @@ export function RunComposer({
         return "Choose an active GitHub App connection.";
       }
       if (mode === "once" && !task.trim()) return "Describe what this run should accomplish.";
+      // Mirrors the server's dead-config rule (triggers.rs): an automation
+      // with no task template and no caller override could never produce a
+      // task. Catch it here so the button explains instead of a raw 400.
+      if (mode === "automation" && !task.trim() && !allowTask) {
+        return "Describe the task, or allow the caller to provide one (under advanced controls).";
+      }
     }
     if (agentsLoading || revisionLoading) return "Loading the agent configuration…";
     if (agentChoice === "existing" && !selectedAgentName) return "Choose an agent or create one here.";
@@ -534,7 +626,7 @@ export function RunComposer({
     }
     return "";
   }, [
-    agentOnly, mode, automationName, kind, cron, connection, eventConnectionsError, task, agentsLoading, revisionLoading,
+    agentOnly, mode, automationName, kind, cron, connection, eventConnectionsError, task, allowTask, agentsLoading, revisionLoading,
     agentChoice, selectedAgentName, newAgentName, harnessesError, harnessesLoading, harnesses.length,
     model, workspace,
   ]);
@@ -572,6 +664,9 @@ export function RunComposer({
           default_workspace: draftToInput(workspace),
           capability_bundles: pins.map((pin) => `${pin.name}@${pin.version}`),
           ...(requirements.length > 0 ? { connection_requirements: requirements } : {}),
+          // A guardrail preset that switches rules rides the same revision;
+          // omitted, the revision inherits the agent's current policy.
+          ...(policyOverride !== null ? { policy: policyOverride } : {}),
         });
         setRevisionTouched(false);
       }
@@ -673,7 +768,7 @@ export function RunComposer({
   const kindLabel = kind === "api" ? "API call" : kind === "schedule" ? "Schedule" : "Pull request";
   const bindingLabel = (slot: string): string => {
     const id = bindings[slot];
-    if (!id) return "resolve automatically";
+    if (!id) return "chosen automatically";
     return bindableConnections.find((candidate) => candidate.id === id)?.display_name ?? "selected connection";
   };
 
@@ -682,7 +777,7 @@ export function RunComposer({
       title={agentOnly ? "Create Agent" : "Configure Run"}
       sub={
         agentOnly
-          ? "Define the agent, give it a workspace and capabilities. Everything here becomes one immutable revision."
+          ? "Give your agent a name, something to work on, and the apps it can use."
           : "Everything this run freezes is on this page. The panel on the right updates as you go."
       }
       onClose={onClose}
@@ -1022,7 +1117,7 @@ export function RunComposer({
             </label>
             {agentChoice === "new" && (
               <label className="field">
-                <span className="lab">Policy</span>
+                <span className="lab">Rules</span>
                 {policiesError ? (
                   <span className="err">{policiesError}</span>
                 ) : (
@@ -1042,8 +1137,8 @@ export function RunComposer({
                   </select>
                 )}
                 <span className="field-hint">
-                  What this agent may do, and what pauses for a human.{" "}
-                  <Link href="/governance">Author policies in Governance.</Link>
+                  What this agent may do on its own, and what must ask first.{" "}
+                  <Link href="/governance">Manage the rules in Governance.</Link>
                 </span>
               </label>
             )}
@@ -1052,14 +1147,40 @@ export function RunComposer({
 
         <ComposerSection
           index={agentOnly ? 2 : 3}
-          title="Workspace & tools"
-          hint="What the agent can see and call. Attaching a tool is not the same as allowing it — every call still passes the permission gate."
+          title="What it works on, and with what"
+          hint="Pick what the agent can see and which apps it may use. Adding a tool does not mean it runs freely — every action is still checked against your policy."
         >
           <>
+            {!agentOnly && mode === "once" && agentChoice === "existing" && !revisionTouched && !customizeSetup ? (
+              // The common case — run an existing agent as it is. One glance,
+              // zero decisions; everything stays one click away.
+              <div className="rc-quick-setup">
+                <div className="rc-quick-setup-copy">
+                  <strong>{workspaceSummary(workspace)}</strong>
+                  <span>
+                    {pins.length + requirements.length === 0
+                      ? "no apps attached"
+                      : `${pins.length + requirements.length} app${
+                          pins.length + requirements.length === 1 ? "" : "s"
+                        } attached`}
+                    {" · "}
+                    {selectedAgentName || "this agent"}&apos;s saved setup
+                  </span>
+                </div>
+                <button
+                  className="btn ghost sm"
+                  type="button"
+                  onClick={() => setCustomizeSetup(true)}
+                >
+                  Customize
+                </button>
+              </div>
+            ) : (
+              <>
             {agentChoice === "existing" && (
               <div className="revision-note">
                 <strong>Revision-safe change</strong>
-                <span>Any workspace or capability change appends a new revision to {selectedAgentName} before this run starts.</span>
+                <span>Changing anything here saves a new version of {selectedAgentName} before this run starts.</span>
               </div>
             )}
             <WorkspacePicker
@@ -1069,22 +1190,32 @@ export function RunComposer({
                 touchRevision();
               }}
             />
-            <BundlePicker
+            {/*
+              ONE grid for both tool classes (§8.3): sandbox bundle pins and
+              brokered connection requirements. AppPicker routes each card to
+              the right object internally — the split is the system's anatomy,
+              not the user's. Full-control editors live on the agent page.
+            */}
+            <AppPicker
               pins={pins}
+              requirements={requirements}
               refreshKey={capabilityRefresh}
               onAddServer={() => setAddingMcp(true)}
-              onChange={(nextPins) => {
+              onPinsChange={(nextPins) => {
                 setPins(nextPins);
+                touchRevision();
+              }}
+              onRequirementsChange={(nextRequirements) => {
+                setRequirements(nextRequirements);
                 touchRevision();
               }}
             />
             {mode === "once" && requirements.length > 0 && (
               <div className="field">
-                <span className="lab">Connection bindings</span>
+                <span className="lab">Which account each app uses</span>
                 <span className="field-hint">
-                  This agent needs brokered connections. Leave a slot on “Resolve automatically”
-                  to let the server pick per its binding mode, or bind a specific connection you
-                  can use.
+                  This agent uses apps that need an account. Leave one on “Choose automatically” and
+                  we pick the right account when it runs, or choose a specific one.
                 </span>
                 {bindingConnectionsError && (
                   <div className="catalog-state error-state" role="status">
@@ -1133,7 +1264,7 @@ export function RunComposer({
                             setBindings((current) => ({ ...current, [req.slot]: event.target.value }))
                           }
                         >
-                          <option value="">Resolve automatically</option>
+                          <option value="">Choose automatically</option>
                           {matches.map((c) => {
                             const badge = ownerBadge(c, me?.user_id);
                             const suffix = badge ? ` (${badge.label}${badge.yours ? " · yours" : ""})` : "";
@@ -1157,40 +1288,210 @@ export function RunComposer({
                 </div>
               </div>
             )}
+              </>
+            )}
           </>
         </ComposerSection>
 
         {!agentOnly && (
           <ComposerSection
             index={4}
-            title="Governance"
-            hint="Supervised runs pause before risky actions. Autonomous runs defer to the configured policy."
+            title="Guardrails"
+            hint="How much freedom this run gets. Every action is logged either way."
           >
             <>
-              <button
-                type="button"
-                className={`toggle mode-card ${autonomous ? "on" : ""}`}
-                onClick={() => setAutonomous((current) => !current)}
-                aria-pressed={autonomous}
-                disabled={autonomyForbidden}
-                title={
-                  autonomyForbidden
-                    ? `Policy '${governingPolicy?.name}' does not permit unattended runs`
-                    : undefined
-                }
-              >
-                <span className="sw" />
-                <span>
-                  <strong>{autonomous ? "Autonomous runs" : "Supervised runs"}</strong>
-                  <span className="faint mode-description">
-                    {autonomyForbidden
-                      ? `Policy '${governingPolicy?.name}' does not permit unattended runs — every risky action waits for a person.`
-                      : autonomous
-                        ? "Policy fallback decides risky actions without waiting for a person."
-                        : "Risky actions pause and wait for your approval."}
-                  </span>
+              {/*
+                Three outcome-named presets over the two raw axes (rules ×
+                approvals). Each card states its mechanics in the footer and
+                says UP FRONT when picking it would update the agent's rules —
+                a run-level click must never silently edit the agent. The raw
+                axes stay available below ("choose separately"), and a state
+                no preset matches auto-reveals them as Custom.
+              */}
+              <div className="opt-grid">
+                {(() => {
+                  const fallbackWord =
+                    governedTarget?.autonomy_summary?.default_fallback === "allow"
+                      ? "allowed automatically"
+                      : "declined automatically";
+                  const autopilotBlocked =
+                    (governedTarget !== null && !governedTarget.autonomy_summary?.permitted) ||
+                    (rulesAreUnrestricted && !governedFallback);
+                  const askBlocked = rulesAreUnrestricted && !governedFallback;
+                  const freeBlocked = !unrestrictedPolicy;
+                  const ruleNote = (preset: "autopilot" | "ask" | "free") => {
+                    const target = presetChangesRules(preset);
+                    return target ? (
+                      <>
+                        {" "}
+                        Updates {selectedAgentName || "the agent"}&apos;s rules to “{target}”.
+                      </>
+                    ) : null;
+                  };
+                  return (
+                    <>
+                      <button
+                        type="button"
+                        className={`opt ${activePreset === "autopilot" ? "on" : ""} ${autopilotBlocked ? "off" : ""}`}
+                        onClick={() => !autopilotBlocked && applyPreset("autopilot")}
+                        disabled={autopilotBlocked}
+                        aria-pressed={activePreset === "autopilot"}
+                      >
+                        <span className="t">
+                          Autopilot, reviewed
+                          {activePreset === "autopilot" && (
+                            <span className="selected-label">Selected</span>
+                          )}
+                        </span>
+                        <div className="d">
+                          {governedTarget !== null && !governedTarget.autonomy_summary?.permitted
+                            ? `The ${governedTarget.name} rules require a person to approve — autopilot is off the table.`
+                            : (
+                              <>
+                                Runs start to finish in an isolated copy. Anything the rules flag
+                                is {fallbackWord}; you review the result.
+                                {ruleNote("autopilot")}
+                              </>
+                            )}
+                        </div>
+                        <div className="id">
+                          {governedTarget?.name ?? "current"} rules · runs on its own
+                        </div>
+                      </button>
+                      <button
+                        type="button"
+                        className={`opt ${activePreset === "ask" ? "on" : ""} ${askBlocked ? "off" : ""}`}
+                        onClick={() => !askBlocked && applyPreset("ask")}
+                        disabled={askBlocked}
+                        aria-pressed={activePreset === "ask"}
+                      >
+                        <span className="t">
+                          Ask me as it works
+                          {activePreset === "ask" && <span className="selected-label">Selected</span>}
+                        </span>
+                        <div className="d">
+                          Pauses for your OK whenever it wants to do something the rules flag
+                          {mode === "automation" ? " — approvals land in Activity" : ""}.
+                          {ruleNote("ask")}
+                        </div>
+                        <div className="id">
+                          {governedTarget?.name ?? "current"} rules · waits for you
+                        </div>
+                      </button>
+                      <button
+                        type="button"
+                        className={`opt ${activePreset === "free" ? "on" : ""} ${freeBlocked ? "off" : ""}`}
+                        onClick={() => !freeBlocked && applyPreset("free")}
+                        disabled={freeBlocked}
+                        aria-pressed={activePreset === "free"}
+                      >
+                        <span className="t">
+                          Free rein
+                          {activePreset === "free" && <span className="selected-label">Selected</span>}
+                        </span>
+                        <div className="d">
+                          {freeBlocked
+                            ? "No fully-permissive rules exist yet — create them in Governance."
+                            : (
+                              <>
+                                Never asks, nothing is declined by the rules. Budgets and the
+                                isolated sandbox are the only limits.
+                                {ruleNote("free")}
+                              </>
+                            )}
+                        </div>
+                        <div className="id">unrestricted rules · runs on its own</div>
+                      </button>
+                    </>
+                  );
+                })()}
+              </div>
+              {activePreset !== null ? (
+                <button
+                  className="btn ghost sm"
+                  type="button"
+                  style={{ justifySelf: "start" }}
+                  onClick={() => setCustomGuardrails((current) => !current)}
+                >
+                  {customGuardrails
+                    ? "Hide the separate controls"
+                    : "Choose rules and approvals separately"}
+                </button>
+              ) : (
+                <span className="helper" style={{ margin: 0 }}>
+                  These settings don&apos;t match a preset — shown in full below.
                 </span>
-              </button>
+              )}
+              {(customGuardrails || activePreset === null) && (
+                <>
+              {/*
+                One explicit either/or instead of a flip-toggle whose label
+                changed under the cursor. The rules (policy) are NAMED here so
+                the relationship is visible, and the autonomous card says
+                CONCRETELY what happens to ask-first actions — read from the
+                server-computed autonomy_summary, never derived in the browser.
+              */}
+              {governingPolicy && (
+                <span className="helper" style={{ margin: 0 }}>
+                  This {mode === "once" ? "run" : "automation"} follows the{" "}
+                  <Link href={`/governance/${governingPolicy.name}`} className="link">
+                    {governingPolicy.name}
+                  </Link>{" "}
+                  rules{agentChoice === "new" ? " — chosen in the agent definition above" : ""}.
+                </span>
+              )}
+              <div className="opt-grid">
+                <button
+                  type="button"
+                  className={`opt ${!autonomous ? "on" : ""}`}
+                  onClick={() => setAutonomous(false)}
+                  aria-pressed={!autonomous}
+                >
+                  <span className="t">
+                    Wait for me
+                    {!autonomous && <span className="selected-label">Selected</span>}
+                  </span>
+                  <div className="d">
+                    When the rules say “ask first”, the run pauses until you approve or decline
+                    {mode === "automation" ? " from the Activity feed" : ""}.
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  className={`opt ${autonomous ? "on" : ""} ${autonomyForbidden ? "off" : ""}`}
+                  onClick={() => !autonomyForbidden && setAutonomous(true)}
+                  aria-pressed={autonomous}
+                  disabled={autonomyForbidden}
+                >
+                  <span className="t">
+                    Run on its own
+                    {autonomous && <span className="selected-label">Selected</span>}
+                  </span>
+                  <div className="d">
+                    {autonomyForbidden
+                      ? `The ${governingPolicy?.name ?? "current"} rules don't allow this — a person must be available to approve.`
+                      : `Never pauses. Anything that would ask first is automatically ${
+                          governingPolicy?.autonomy_summary?.default_fallback === "allow"
+                            ? "allowed"
+                            : "declined"
+                        }${
+                          (governingPolicy?.autonomy_summary?.allow_overrides ?? 0) +
+                            (governingPolicy?.autonomy_summary?.deny_overrides ?? 0) >
+                          0
+                            ? " (the rules make a few per-tool exceptions)"
+                            : ""
+                        }, and every action is logged.`}
+                  </div>
+                </button>
+              </div>
+                </>
+              )}
+              {mode === "automation" && !autonomous && (
+                <span className="field-hint">
+                  Automations can fire while you&apos;re away — approvals wait in Activity and are
+                  declined if the time limit passes.
+                </span>
+              )}
 
               {mode === "automation" && (
                 <details className="advanced-config">
@@ -1207,9 +1508,9 @@ export function RunComposer({
                       </select>
                     </label>
                     <label className="field">
-                      <span className="lab">Capability keep-list <span className="optional-label">optional</span></span>
-                      <input className="inp mono" value={capabilityKeepList} onChange={(event) => setCapabilityKeepList(event.target.value)} placeholder="Empty keeps every attached bundle" />
-                      <span className="field-hint">Comma-separated bundle names; this can only remove capabilities.</span>
+                      <span className="lab">Limit tools for this run <span className="optional-label">optional</span></span>
+                      <input className="inp mono" value={capabilityKeepList} onChange={(event) => setCapabilityKeepList(event.target.value)} placeholder="Leave empty to keep all of them" />
+                      <span className="field-hint">Comma-separated names. This can only take tools away, never add them.</span>
                     </label>
                     <label className="field">
                       <span className="lab">Signed callback URL <span className="optional-label">optional</span></span>
@@ -1226,8 +1527,8 @@ export function RunComposer({
         <aside className="rc-spec" aria-label="Configuration summary">
           <div className="rc-spec-inner">
             <div className="rc-spec-head">
-              <span className="section-kicker">{agentOnly ? "Revision 1" : "Frozen at launch"}</span>
-              <p>{agentOnly ? "This becomes the agent's first immutable revision." : "Resolved before the sandbox starts. In-flight runs keep this exact spec."}</p>
+              <span className="section-kicker">{agentOnly ? "Summary" : "Locked in at launch"}</span>
+              <p>{agentOnly ? "This is version 1. Editing it later creates a new version." : "Settled before the agent starts. A running agent keeps exactly these settings."}</p>
             </div>
 
             {!agentOnly && (
@@ -1267,15 +1568,17 @@ export function RunComposer({
             <SpecRow
               label="Workspace"
               value={workspaceSummary(workspace)}
-              sub={`${pins.length} sandbox bundle${pins.length === 1 ? "" : "s"} attached`}
+              sub={`${pins.length + requirements.length} tool${pins.length + requirements.length === 1 ? "" : "s"} added`}
             />
             <SpecRow
-              label="Policy"
+              label="Rules"
               value={governingPolicy ? `${governingPolicy.name} · v${governingPolicy.version}` : agentChoice === "new" ? policyName : "resolving…"}
               sub={
-                autonomyForbidden
-                  ? "unattended runs not permitted"
-                  : `${governingPolicy?.agents_using ?? 0} agent${(governingPolicy?.agents_using ?? 0) === 1 ? "" : "s"} governed`
+                policyOverride !== null
+                  ? `will update ${selectedAgentName || "the agent"}'s rules`
+                  : autonomyForbidden
+                    ? "someone must be available to approve"
+                    : `${governingPolicy?.agents_using ?? 0} agent${(governingPolicy?.agents_using ?? 0) === 1 ? "" : "s"} follow${(governingPolicy?.agents_using ?? 0) === 1 ? "s" : ""} these rules`
               }
             />
 
@@ -1293,9 +1596,25 @@ export function RunComposer({
 
             {!agentOnly && (
               <SpecRow
-                label="Governance"
-                value={autonomous ? "Autonomous" : "Supervised"}
-                sub={autonomous ? "policy fallback decides" : "risky actions wait for approval"}
+                label="Guardrails"
+                value={
+                  activePreset === "free"
+                    ? "Free rein"
+                    : activePreset === "autopilot"
+                      ? "Autopilot, reviewed"
+                      : activePreset === "ask"
+                        ? "Ask me as it works"
+                        : "Custom"
+                }
+                sub={
+                  autonomous
+                    ? `ask-first actions auto-${
+                        governingPolicy?.autonomy_summary?.default_fallback === "allow"
+                          ? "allowed"
+                          : "declined"
+                      }`
+                    : "ask-first actions pause for you"
+                }
               />
             )}
 

--- a/apps/web/app/geist.css
+++ b/apps/web/app/geist.css
@@ -861,6 +861,12 @@ a.row:hover,
   padding: 18px 24px;
   border-bottom: 1px solid var(--ds-gray-alpha-200);
   background: var(--surface-soft);
+  /* The header is position:sticky, and --surface-soft is translucent (0.94).
+     Without a backdrop filter the scrolled content ghosts straight through it,
+     which reads as a rendering bug rather than as frost. The sidebar rail pairs
+     the same alpha with blur(16px) — this just forgot to. */
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }
 
 .modal .mh .t {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3403,6 +3403,160 @@ select.inp {
   background: var(--surface-hover);
   transform: translateY(-1px);
 }
+/* Selection state for the requirement picker, where a card is a CHOICE rather
+   than a link into the Connect flow. The Store never sets this. */
+.connector-card.selected {
+  border-color: var(--accent, var(--ink));
+  background: var(--surface-hover);
+}
+/* The picker renders inside the run/agent composer (.rc-form), which is far
+   narrower than the Store page; two columns there would crush the copy. */
+.rc-form .connector-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+/* ── Brokered MCP catalogue (requirement picker) ───────────────────────────
+   Grouped by connection state so "what can I actually use right now" is
+   answerable at a glance. Deliberately quiet: this sits inside a composer
+   step, so it borrows the Store's card and adds only sectioning. */
+/* NO inner scroll on purpose. The composer already scrolls; a second scroll
+   region nested inside it clipped the section headers and made the picker feel
+   cramped. The curated catalogue is small — let it flow and let the modal
+   scroll. Revisit with a search field, not a scrollbox, if it ever grows. */
+.mcp-catalogue {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 60%, transparent);
+}
+.mcp-catalogue-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 4px;
+}
+.mcp-catalogue-head:first-child {
+  margin-top: 0;
+}
+.mcp-catalogue-title {
+  color: var(--ink-2);
+  font-size: 10px;
+  font-weight: 640;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.mcp-catalogue-count {
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--surface-hover);
+  color: var(--ink-3);
+  font-size: 9.5px;
+  font-variant-numeric: tabular-nums;
+}
+.mcp-catalogue-link {
+  margin-left: auto;
+  font-size: 10.5px;
+}
+.mcp-catalogue-note {
+  margin: 0 0 2px;
+  color: var(--ink-3);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+.mcp-state-muted {
+  color: var(--ink-3);
+}
+.mcp-state-ok {
+  color: var(--green);
+}
+.mcp-state-warn {
+  color: var(--amber);
+}
+
+/* ── App picker (composer) ────────────────────────────────────────────────
+   One app-store grid; a selected app that needs per-app choices grows a slim
+   attached row (whose account, setup warning) instead of a form. */
+.app-card-wrap {
+  display: grid;
+}
+.app-card-wrap.has-sub .connector-card.selected {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.app-card-sub {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border: 1px solid var(--accent, var(--ink));
+  border-top: 0;
+  border-radius: 0 0 11px 11px;
+  background: var(--surface-hover);
+  color: var(--ink-2);
+  font-size: 11px;
+}
+.app-card-sub .inp {
+  width: auto;
+  padding: 3px 8px;
+  font-size: 11px;
+}
+.app-card-sub-warn {
+  margin-left: auto;
+  color: var(--amber);
+  font-size: 10.5px;
+  text-align: right;
+}
+
+/* One-line "uses the agent's saved setup" summary shown instead of the full
+   workspace/apps editor when launching an existing agent. */
+.rc-quick-setup {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 15px;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: var(--surface-soft);
+}
+.rc-quick-setup-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.rc-quick-setup-copy strong {
+  overflow: hidden;
+  font-size: 12.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rc-quick-setup-copy span {
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
+/* The mechanical fields, subordinate to the connector choice above them. */
+.mcp-req-detail {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+.mcp-req-field {
+  display: grid;
+  flex: 1 1 0;
+  gap: 3px;
+  min-width: 0;
+}
+.mcp-req-lab {
+  color: var(--ink-3);
+  font-size: 9.5px;
+  font-weight: 620;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
 .connector-mark {
   width: 38px;
   height: 38px;

--- a/apps/web/app/sessions/[id]/page.tsx
+++ b/apps/web/app/sessions/[id]/page.tsx
@@ -537,11 +537,13 @@ function TimelineItem({ ev }: { ev: EventRow }) {
         </>
       );
       break;
+    // NOTE: the case key is the control plane's event type — do not rename it.
+    // `tag` and the body below are display copy only.
     case "capability.frozen":
-      tag = "capability";
+      tag = "mcp";
       body = (
         <>
-          capabilities frozen: <span className="em">{((d.bundles as string[]) || []).join(", ")}</span>
+          MCP servers frozen: <span className="em">{((d.bundles as string[]) || []).join(", ")}</span>
           <span className="mut"> · {s("tools")} tools photographed</span>
         </>
       );

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -5,11 +5,13 @@ import { apiGet } from "../lib/api";
 import { PageHead } from "../components/bits";
 
 export default function Settings() {
-  const [ready, setReady] = useState<{ db: boolean; docker: boolean } | null>(null);
+  // Field names must match `health_ready` in crates/fluidbox-server/src/api.rs —
+  // this generic is an unchecked assertion, not a verified contract.
+  const [ready, setReady] = useState<{ db: boolean; provider_ok: boolean } | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 
   useEffect(() => {
-    apiGet<{ db: boolean; docker: boolean }>("/health/ready")
+    apiGet<{ db: boolean; provider_ok: boolean }>("/health/ready")
       .then((response) => {
         setReady(response);
         setStatus("ready");
@@ -28,8 +30,8 @@ export default function Settings() {
         {status === "error" && (
           <p className="note">Health status is unavailable; no component is being reported down from a failed read.</p>
         )}
-        <Health label="Database (Neon Postgres)" status={status} ok={ready?.db ?? false} />
-        <Health label="Sandbox runtime (Docker)" status={status} ok={ready?.docker ?? false} />
+        <Health label="Database (Neon Postgres)" status={status} ok={ready?.db} />
+        <Health label="Sandbox runtime (Docker)" status={status} ok={ready?.provider_ok} />
 
         <div className="sectitle">Security model</div>
         <ul style={{ margin: 0, paddingLeft: 18, color: "var(--ink-2)", fontSize: 13, lineHeight: 1.9 }}>
@@ -49,9 +51,13 @@ function Health({
   status,
 }: {
   label: string;
-  ok: boolean;
+  /** `undefined` = the read succeeded but said nothing about this component. */
+  ok: boolean | undefined;
   status: "loading" | "ready" | "error";
 }) {
+  // TODO(you): decide how a successful read that OMITS this component should render.
+  // Today `undefined` falls through to "down"/err — the same output as an observed
+  // failure — which is what made the Docker row lie when the API renamed the field.
   const labelText = status === "loading" ? "checking" : status === "error" ? "unavailable" : ok ? "connected" : "down";
   const badgeTone = status === "ready" ? (ok ? "ok" : "err") : "warn";
   return (

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,9 +1,40 @@
-# Local dev composition. Only the LiteLLM model gateway runs in Docker here;
-# the fluidbox server and dashboard run on the host (`just dev`).
+# Local dev composition: the Postgres control-plane database and the LiteLLM
+# model gateway. The fluidbox server and dashboard run on the host (`just dev`).
 #
 # LiteLLM is pinned to a known-clean release and bound to loopback only.
 # Sandboxes never talk to it — only the fluidbox session facade does.
 services:
+  # The control-plane database. This is a DIRECT connection (no PgBouncer), so
+  # LISTEN/NOTIFY and sqlx prepared statements both work — the property the
+  # Neon setup had to get right by picking the non-pooler endpoint.
+  #
+  # Bound to 5433 on the host, NOT 5432: a Homebrew postgres already owns 5432
+  # on this machine and silently connecting to the wrong server is worse than
+  # a port that looks unusual.
+  #
+  # Data lives in the named volume `fluidbox-pgdata` and survives `down`,
+  # restarts, and reboots. `docker compose down -v` is the only thing that
+  # deletes it — see `just db-reset`.
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - "127.0.0.1:5433:5432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-fluidbox}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-fluidbox}
+      POSTGRES_DB: ${POSTGRES_DB:-fluidbox}
+    volumes:
+      - fluidbox-pgdata:/var/lib/postgresql/data
+    # The server runs all 26 migrations on boot and fails loudly on a half-open
+    # database, so `just dev` must not race the first-boot initdb.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-fluidbox} -d ${POSTGRES_DB:-fluidbox}"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+    restart: unless-stopped
+
   litellm:
     image: ${LITELLM_IMAGE:-ghcr.io/berriai/litellm:main-stable}
     command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
@@ -16,3 +47,6 @@ services:
     volumes:
       - ./litellm/config.yaml:/etc/litellm/config.yaml:ro
     restart: unless-stopped
+
+volumes:
+  fluidbox-pgdata:

--- a/justfile
+++ b/justfile
@@ -27,8 +27,10 @@ k8s-doctor NS="fluidbox":
 collector-build:
     docker build -t ${FLUIDBOX_COLLECTOR_IMAGE:-fluidbox-workspaced:dev} -f deploy/workspaced.Dockerfile .
 
-# Everything: LiteLLM gateway + server + web (ctrl-c stops all)
+# Everything: Postgres + LiteLLM gateway + server + web (ctrl-c stops the
+# host processes; the containers keep running — `just db-down` stops the DB).
 dev:
+    just db-up
     just gateway-up
     (trap 'kill 0' EXIT; cargo run -p fluidbox-server & (cd apps/web && pnpm dev) & wait)
 
@@ -44,8 +46,10 @@ web:
 gateway-up:
     docker compose -f deploy/docker-compose.dev.yml up -d litellm
 
+# Stops ONLY the gateway. It used to `down` the whole composition, which now
+# would take the database with it.
 gateway-down:
-    docker compose -f deploy/docker-compose.dev.yml down
+    docker compose -f deploy/docker-compose.dev.yml stop litellm
 
 # Build the Claude sandbox runner image (context = images/, shared with codex)
 sandbox-build:
@@ -56,8 +60,34 @@ codex-build:
     docker build -t ${FLUIDBOX_CODEX_SANDBOX_IMAGE:-fluidbox-codex-runner:dev} -f images/codex-runner/Dockerfile images
 
 # ── Database ─────────────────────────────────────────────────────────────
+#
+# Local development runs Postgres in a container with a named volume
+# (`fluidbox-pgdata`), published on 127.0.0.1:5433 — 5432 is commonly already
+# taken by a Homebrew postgres. Data survives restarts and reboots; only
+# `just db-reset` destroys it. The server applies all migrations on boot, so
+# a fresh volume needs no manual step.
 
-# Provision a Neon project and write the DIRECT connection string into .env
+# Start the local Postgres container and wait until it accepts connections.
+db-up:
+    docker compose -f deploy/docker-compose.dev.yml up -d --wait postgres
+
+# Stop the database, KEEPING the data volume.
+db-down:
+    docker compose -f deploy/docker-compose.dev.yml stop postgres
+
+# DESTROY the local database and start a clean one (drops the volume, then
+# re-creates it; the next server boot re-runs migrations and re-seeds).
+db-reset:
+    docker compose -f deploy/docker-compose.dev.yml rm -sf postgres
+    docker volume rm -f deploy_fluidbox-pgdata
+    just db-up
+
+# Tail the database container's logs.
+db-logs:
+    docker compose -f deploy/docker-compose.dev.yml logs -f postgres
+
+# Provision a Neon project and write the DIRECT connection string into .env.
+# Only needed for a hosted/remote deployment — local dev uses `just db-up`.
 neon-setup:
     ./scripts/neon-setup.sh
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -64,7 +64,7 @@ else
 
   db_url=$(env_get "$ENV" DATABASE_URL)
   case "$db_url" in
-    ""|*ep-xxx*) bad "DATABASE_URL not set" "run: just neon-setup   (provisions Neon and writes the DIRECT string into .env)";;
+    ""|*ep-xxx*) bad "DATABASE_URL not set" "run: just db-up   (starts the local Postgres container; for a hosted deployment use just neon-setup)";;
     *-pooler*)   bad "DATABASE_URL is the POOLED (-pooler) Neon string" "use the DIRECT endpoint — PgBouncer transaction mode breaks sqlx prepared statements and LISTEN/NOTIFY (just neon-setup fetches it)";;
     *)
       ok "DATABASE_URL set (direct endpoint)"
@@ -172,7 +172,7 @@ else
               fi;;
           esac
         else
-          warn "database not reachable right now" "Neon scale-to-zero can add a cold-start delay; retry, or check the connection string with: just db"
+          warn "database not reachable right now" "local: run 'just db-up' (container may be stopped); hosted: Neon scale-to-zero can add a cold-start delay, retry or check the string with 'just db'"
         fi
       fi
       ;;

--- a/scripts/e2e-github.sh
+++ b/scripts/e2e-github.sh
@@ -474,8 +474,11 @@ wait_req POST "/repos/acme/site/check-runs" 2 "" 40 \
 [ "$(req_count POST "/repos/acme/site/issues/1/comments" "$AGA")" = "1" ] && ok "A's comment carries agent name (attributable)" || no "A attribution"
 [ "$(req_count POST "/repos/acme/site/check-runs" "fluidbox/gh-sub-b-$$")" = "1" ] && ok "B's check named fluidbox/<subscription>" || no "B check name"
 [ "$(req_count POST "/repos/acme/site/check-runs" "$HEAD1")" = "2" ] && ok "checks pinned to the head SHA" || no "check sha"
+# A: comment. C: comment + check — checks record their own identity row since
+# #33 (adoption keys on the app-controlled external_id, which needs the row).
+# The old expectation of 2 predates that and was stale.
 ER=$(pq "select count(*) from external_results where subscription_id in ('$SUBA','$SUBC')")
-[ "$ER" = "2" ] && ok "stable comment identities recorded (one per subscription+PR)" || no "external_results: $ER"
+[ "$ER" = "3" ] && ok "stable publish identities recorded (A comment; C comment+check)" || no "external_results: $ER"
 AUTH_OK=$(python3 - "$GH_LOG" <<'PYEOF'
 import json, sys
 n = 0
@@ -661,7 +664,11 @@ C3S=$(pq "select status from integration_connections where provider='github_app'
 curl -s -X POST "http://127.0.0.1:$GH_PORT/_fixture/add/$FOREIGN_IID" -d '{"login":"acme4","app":"9876"}' >/dev/null
 pq "insert into integration_connections
       (id, tenant_id, provider, external_account_id, display_name, credential_sealed, auth_kind, status)
-    values (gen_random_uuid(), (select id from tenants limit 1), 'github_app', '$FOREIGN_IID',
+    values (gen_random_uuid(),
+            -- the REGISTRATION's tenant, never 'limit 1': the suite DB holds
+            -- dozens of tenants and an unordered pick lands the fixture in the
+            -- wrong one, where the tenant-scoped sync can't see it (flake).
+            (select tenant_id from github_app_registrations where id='$REG'), 'github_app', '$FOREIGN_IID',
             'e2e-foreign-$FOREIGN_IID', '\\x00'::bytea, 'static', 'active')" >/dev/null
 CODE=$(post "/github/app/$REG/sync" '{}')
 [ "$CODE" = "200" ] && ok "sync & activate ran (admin intent)" || no "sync: $CODE $(cat "$B")"

--- a/scripts/e2e-trigger.sh
+++ b/scripts/e2e-trigger.sh
@@ -169,17 +169,11 @@ N_RUNS=$(curl -s -H "$H" "$API/v1/triggers/$SUB1" | python3 -c "
 import sys, json; print(len(json.load(sys.stdin)['sessions']))")
 [ "$N_RUNS" = "1" ] && ok "subscription has exactly one run" || no "expected 1 run, got $N_RUNS"
 
-say "DISABLE / ENABLE / ROTATE"
+say "DISABLE / ENABLE"
 post "/triggers/$SUB1/disable" "{}" >/dev/null
 CODE=$(tpost "$TOK1" "/triggers/$SUB1/invoke" '{"context":{"ticket":"x"}}')
 [ "$CODE" = "409" ] && ok "disabled subscription → 409" || no "wanted 409, got $CODE"
 post "/triggers/$SUB1/enable" "{}" >/dev/null
-post "/triggers/$SUB1/rotate_token" "{}" >/dev/null
-TOK1_NEW=$(cat "$B" | j "['token']")
-CODE=$(tpost "$TOK1" "/triggers/$SUB1/invoke" '{"context":{"ticket":"INC-42"}}' "Idempotency-Key: key-A")
-[ "$CODE" = "401" ] && ok "old token dead after rotation" || no "wanted 401, got $CODE"
-CODE=$(tpost "$TOK1_NEW" "/triggers/$SUB1/invoke" '{"context":{"ticket":"INC-42"}}' "Idempotency-Key: key-A")
-[ "$CODE" = "200" ] && ok "new token works (and key-A still replays)" || no "wanted 200, got $CODE"
 
 say "SIGNED CALLBACK — terminal run → one verified delivery"
 FINAL1=$(wait_terminal "$S1" 420) || true
@@ -209,6 +203,21 @@ assert 'cost_usd' in p['usage'] and isinstance(p['artifacts'], list) and 'summar
   DSTAT=$(curl -s -H "$H" "$API/v1/sessions/$S1/deliveries" | j "['deliveries'][0]['status']")
   [ "$DSTAT" = "delivered" ] && ok "delivery row marked delivered" || no "delivery status '$DSTAT'"
 fi
+
+# ROTATION runs only after S1's callback has been observed. The delivery
+# recheck (#31, E1) deliberately fails closed when a run's invoking token has
+# been revoked — so rotating while S1's delivery was still in flight made this
+# phase green only when the live run happened to finish first (a race, red
+# whenever the model was slow). Sequencing rotation after the observation
+# asserts BOTH truths: a live token's run delivers, and rotation kills the old
+# credential.
+say "ROTATE — old token dies, new token carries the authority"
+post "/triggers/$SUB1/rotate_token" "{}" >/dev/null
+TOK1_NEW=$(cat "$B" | j "['token']")
+CODE=$(tpost "$TOK1" "/triggers/$SUB1/invoke" '{"context":{"ticket":"INC-42"}}' "Idempotency-Key: key-A")
+[ "$CODE" = "401" ] && ok "old token dead after rotation" || no "wanted 401, got $CODE"
+CODE=$(tpost "$TOK1_NEW" "/triggers/$SUB1/invoke" '{"context":{"ticket":"INC-42"}}' "Idempotency-Key: key-A")
+[ "$CODE" = "200" ] && ok "new token works (and key-A still replays)" || no "wanted 200, got $CODE"
 
 say "DEAD DESTINATION — the run stays terminal; only the delivery retries"
 CODE=$(tpost "$TOK3" "/triggers/$SUB3/invoke" '{"workspace":{"ref":"feature"},"context":{}}')

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -89,6 +89,22 @@ else
   note "already in sync with .env"
 fi
 
+say "local database"
+# The default DATABASE_URL points at this container. Starting it here means a
+# fresh clone can boot the server immediately — migrations run on boot, so
+# there is nothing else to provision. A hosted deployment overrides
+# DATABASE_URL and simply never uses this container.
+db_url=$(env_get "$ENV" DATABASE_URL)
+case "$db_url" in
+  *127.0.0.1:5433*|*localhost:5433*)
+    docker compose -f "$ROOT/deploy/docker-compose.dev.yml" up -d --wait postgres
+    note "local Postgres up on 127.0.0.1:5433 (named volume: fluidbox-pgdata)"
+    ;;
+  *)
+    note "DATABASE_URL points elsewhere — skipping the local Postgres container"
+    ;;
+esac
+
 say "dashboard dependencies"
 (cd "$ROOT/apps/web" && pnpm install)
 


### PR DESCRIPTION
Three strands from the 2026-07-28 working session, validated together:

**1. Local development runs on a Postgres container** (`just db-up`, port 5433, persistent volume) — Neon stays the hosted path. Motivated by the Neon transfer-quota outage; migrations/seeds/LISTEN-NOTIFY all proven locally (26/26 migrations, 850 workspace tests, full governance e2e 47/0).

**2. Composer/Store UX rebuilt for non-technical users**: one app-store grid for both tool classes (correctly declaring photographed tool lists — the empty-`required_tools` 422 was caught by clicking Start Run), guardrail presets over the rules×approvals axes, one-line quick setup for existing agents, consent-card connect modal, full plain-language sweep, plus the settings `provider_ok` fix and the translucent sticky-header fix.

**3. e2e harness deflakes**: trigger rotation race (green-when-fast vs the deliberate #31 E1 recheck) and two stale github-phase assertions. Isolated reruns: trigger 50/0, github 110/0.

Full acceptance run on this tree: phases 1–6 + codex green; four pre-existing reds (unchanged by this PR) triaged and tracked in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPeyjdcYYi7QPwFsYAH2gg