### PR TITLE
fix(runner): gate EVERY Claude tool call via a PreToolUse hook (P0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ apps/web/.env.local
 
 # Local-only notes (artifact index, scratch docs) — never committed
 *.local.md
+data-gate/

--- a/crates/fluidbox-core/src/tools.rs
+++ b/crates/fluidbox-core/src/tools.rs
@@ -95,6 +95,15 @@ pub const CANONICAL: &[ToolDef] = &[
         name: "Task",
         group: ToolGroup::Meta,
     },
+    // Tool-schema discovery. Registered because the gate can now SEE it: until
+    // the Claude runner's PreToolUse hook landed, the CLI auto-approved this
+    // class and the calls never reached /permission, so the vocabulary never
+    // had to name it. Now every call arrives, the seed policy has an opinion
+    // about it, and the Governance matrix must list that opinion.
+    ToolDef {
+        name: "ToolSearch",
+        group: ToolGroup::Meta,
+    },
 ];
 
 /// Is this an exact canonical tool name? (Not a matcher — no wildcards.)

--- a/docs/reviews/claude-tool-gate-validation.md
+++ b/docs/reviews/claude-tool-gate-validation.md
@@ -1,0 +1,266 @@
+# The Claude runner executed tools without a fluidbox decision — reproduction, root cause, fix, validation
+
+**Date:** 2026-07-29
+**Branch:** `worktree-claude-tool-gate`
+**Commit:** _see the last section — filled in at commit time_
+**Severity:** P0 (launch-blocking). fluidbox's central promise — *no sandbox tool call
+executes without a control-plane decision* — was false for a large class of calls on the
+`claude-agent-sdk` harness.
+
+---
+
+## 1. What was claimed, and what was actually true
+
+The claim (PLAN.md, `CLAUDE.md` "load-bearing invariants") is that the permission gate
+in `internal.rs::decide_tool_call` is *the* gate: budget → frozen-set availability →
+frozen-schema args → trust tier → policy → approvals, with `tool.requested` and
+`tool.decision` written server-authoritatively so audit parity never depends on runner
+cooperation.
+
+All of that is true **once the gate is asked**. It was not always asked.
+
+A previously recorded observation (memory `fluidbox-live-agent-gate-bypass`, 2026-07-27)
+was that a live agent ran `printf '<nonce>' | sha256sum` and returned the correct digest
+while the session ledger held **zero** `tool.requested` / `tool.decision` /
+`approval.requested` events, under a policy whose head rule was
+`{match:["Bash"], action:"approve"}`. That observation is confirmed here, root-caused,
+and fixed.
+
+## 2. Root cause
+
+**`canUseTool` is not an interception point.**
+
+`@anthropic-ai/claude-agent-sdk` does not call `canUseTool` per tool call. It spawns the
+Claude Code CLI as a child process and translates the callback into a CLI flag. From the
+shipped bundle (`sdk.mjs`, 0.3.205, offset ~529932):
+
+```js
+if (lo) {                                   // lo === options.canUseTool
+  if (w) throw Error("canUseTool callback cannot be used with permissionPromptToolName…");
+  W.push("--permission-prompt-tool", "stdio")
+} else if (w) W.push("--permission-prompt-tool", w);
+```
+
+The CLI consults that prompt tool **only for calls it decides to ASK about**. Anything it
+approves on its own first — its read-only / safe-command classification, an `allowedTools`
+entry, a settings allow rule, an auto-accepting `permissionMode` — executes with the
+callback never running. The SDK documents this itself (`sdk.mjs` ~592337):
+
+> `canUseTool will not be invoked for: … Bare allowedTools entries auto-approve the whole
+> tool before the callback is consulted. **To gate every tool call, use a PreToolUse hook**;
+> … Allow rules from settings files can also shadow the callback but are not visible here.`
+
+So the runner was correct in every line a reviewer would look at — `canUseTool` was wired,
+`permissionMode: "default"`, `settingSources: []`, no `allowedTools`, never
+`bypassPermissions` — and the gate still never ran for a whole class of calls. The bug was
+an absent invocation, which no assertion about decision logic can catch.
+
+**Why it survived every acceptance run.** `scripts/e2e-live.sh:113` asserts
+`tool_calls >= 1`, and demo A passes: it edits a file and runs `python3 -m unittest`, both
+of which the CLI *does* prompt for, so the gate fired for those and the counter was
+non-zero. `scripts/governance-e2e.sh` deliberately kills the real runner and drives the
+contract itself, so it exercises only the half that always worked. Neither suite could
+observe a call the runner never made.
+
+## 3. Reproduction (pre-fix, shipped image, real model)
+
+Run inside the shipped runner image, mirroring `images/sandbox-runner/runner/index.mjs`
+option for option (`canUseTool` denies everything and records each consultation):
+
+```
+NONCE=fbx-42e01607cb559e84e47e
+host-computed sha256 = 5a0cd099c1fb95fe3fbaa5c29d4fc0e34fded49b324828f054dfdd53ff0fce27
+
+{ "cmd": "printf 'fbx-42e01607cb559e84e47e' | sha256sum",
+  "tool_uses_emitted": 1,
+  "gate_consultations": 0,          ← canUseTool NEVER invoked
+  "ungated": ["printf 'fbx-42e01607cb559e84e47e' | sha256sum"],
+  "final": "The output is:\n\n```\n5a0cd099c1fb95fe3fbaa5c29d4fc0e34fded49b324828f054dfdd53ff0fce27  -\n```" }
+```
+
+The digest is of a nonce minted seconds earlier, so it cannot be guessed, fabricated, or
+served from a cache: **the command really executed and the gate really was not consulted.**
+
+**The gap is much wider than one odd command.** An ordinary coding workload — "list the
+files, read data.txt, grep for 'beta', run `wc -l data.txt`" — in the same image:
+
+| | Bash | Read | ToolSearch | mcp__wsinfo__* |
+|---|---|---|---|---|
+| emitted | 3 | 1 | 2 | 1 |
+| reached `PreToolUse` | 3 | 1 | 2 | 1 |
+| reached `canUseTool` | **0** | **0** | **0** | 1 |
+
+Four tool calls, zero gate consultations. Only MCP tools and mutating shell commands
+reliably reached the gate. A control experiment (`printf … > file`, a mutation) *was*
+gated, which is exactly why the failure looked intermittent.
+
+## 4. The fix
+
+`PreToolUse` fires for **every** tool call, underneath the CLI's auto-approval
+short-circuit. Verified in the same image, same command that bypassed `canUseTool`:
+
+| hook returns | hook fired | `canUseTool` fired | command executed |
+|---|---|---|---|
+| `{}` (log only) | 1 | 0 | **yes** — digest in `tool_result` |
+| `deny` | 1 | 0 | no — `tool_result is_error=true "fluidbox deny"` |
+| `ask` | 1 | **1** | follows the gate's verdict |
+| `allow` | 1 | 0 | yes |
+
+The shipped fix has the hook answer **`ask`**, which forces the call back onto the
+`canUseTool` path where the existing, well-tested gate implementation still makes the
+decision:
+
+- `images/runner-lib/contract.mjs` — `forceGateDecision()` (the hook return), plus
+  `GateWitness`, `EXIT_UNGOVERNED_TOOL`, and the diagnostic.
+- `images/sandbox-runner/runner/index.mjs` — passes
+  `hooks: { PreToolUse: [{ hooks: [preToolUseGate] }] }` to `query()`; `canUseTool` is
+  otherwise **unchanged**.
+
+**Why `ask` rather than having the hook call `/permission` itself.** A supervised approval
+can block for minutes. `requestPermission` already owns the 12-minute timeout and the
+forever-retry semantics for that; a hook that never awaits anything cannot time out,
+throw, or become a new way to lose a decision. Measured for completeness: a hook that
+blocked for 90 s did *not* time out and did *not* fail open, so both designs work — the
+I/O-free one is simply the smaller risk, and it leaves the decision logic untouched.
+
+**Second layer — the tripwire.** `GateWitness` pairs the `tool_use` blocks seen on the
+message stream with the calls the gate actually decided. A `tool_result` for an
+observed-but-undecided call means a tool ran ungoverned; the runner then aborts with
+`EXIT_UNGOVERNED_TOOL`, records a `run.error` on the timeline, and posts **no** `/result`
+(the heartbeat watchdog terminalizes the run, as for any runner crash). The hook is the
+guarantee; the tripwire converts a future silent regression into a loud failure — which is
+precisely what this incident lacked.
+
+**Policy change.** With the gate mandatory it now sees tools it never saw before, and
+`policies/default.yaml` sets `defaults.tool_action: approve`, so an unmatched tool would
+pause every run. `ToolSearch` (schema discovery, executes nothing) joins the read-only
+allow rule. This is a **behavioural change for existing deployments**: `seed_policy_if_absent`
+never re-applies the seed, so a deployment with a stored policy will start seeing
+previously-invisible tools arrive at the gate and fall to its own default — `approve`
+(pause) in supervised runs, and `deny` in autonomous ones via `on_approval_rule`.
+Operators should add the rule to their policy before deploying this runner image.
+
+## 5. Validation
+
+### 5.1 Hermetic regression tests — `images/runner-lib/gate.test.mjs`
+
+12 tests, run by the existing CI step (`.github/workflows/ci.yml:382`,
+`node --test images/runner-lib/*.test.mjs`). They assert the hook's shape and purity, the
+tripwire's behaviour (including that it is conservative enough not to fail healthy runs),
+and — structurally, against the shipped runner source — that the harness still passes a
+`PreToolUse` hook, never an auto-approving `permissionMode`, and no `allowedTools`. The
+structural assertions exist because the regression was *an absent call*, not a wrong
+decision.
+
+Mutation-verified (a test that cannot fail is worthless):
+
+| mutation | result |
+|---|---|
+| remove the hook from `query()` (the exact pre-fix state) | 11 pass, **1 fail** |
+| remove the tripwire reconciliation | 11 pass, **1 fail** |
+| hook returns `allow` instead of `ask` | 11 pass, **1 fail** |
+| unmutated | **12 pass, 0 fail** |
+
+### 5.2 Live acceptance — `scripts/e2e-tool-gate.sh`
+
+Phase 1 runs a **real agent on the real Docker provider** and asserts on an unpredictable
+nonce. Phases 2–4 drive `/permission` with the sandbox's own tool-audience token after
+`silence_runner` kills the runner — deliberately, so they cost no model tokens and cannot
+flake on talking a live model into misbehaving.
+
+**The decisive live result** (session `019fac64-d98a-72f3-bc08-678e21af6506`, post-fix
+image, Docker provider, `claude-haiku-4-5`, policy `gate-deny`) — the identical scenario
+that previously produced zero events:
+
+```
+tool.requested {"input_digest":"sha256:2eca02fb70287052",
+                "summary":"printf 'fbxgate-acaf9ad75edf15bf9cd21790' | sha256sum",
+                "tool":"Bash","tool_call_id":"toolu_013XrkvXtJhGDaXzpk6FDccz"}
+tool.decision  {"verdict":"deny","source":"policy",
+                "reason":"bash denied for the tool-gate acceptance", …}
+run.result     {"outcome":"completed",
+                "summary":"I don't have permission to execute that Bash command…"}
+
+digest 0de67b1da13b0648e218950ab465aef26e1ee68b06743d8779bb26c1e42566f4: 0 occurrences
+```
+
+The gate saw the call, denied it from the authored policy, and the digest of the fresh
+nonce appears **nowhere** — the command did not run.
+
+_Suite results are recorded in §5.3._
+
+## 6. Residual risks — stated plainly
+
+1. **Mediation is runner-side, and always will be.** Tools execute inside the sandbox, run
+   by the CLI; the control plane cannot intercept in-sandbox execution. The guarantee is
+   therefore only as strong as the runner image, which is why images ship in-repo and are
+   versioned with the server. An **old pinned `runner_image` on a new server still
+   bypasses the gate** exactly as before — `runner_image` is a per-revision API field that
+   carries forward across revisions, so this is reachable without a bad deploy. The
+   existing `wrong_audience` machinery does not cover it (an old image presents the right
+   audience; it simply never asks). There is no server-side detection today.
+2. **We depend on upstream continuing to fire `PreToolUse` for every tool.** That is
+   upstream's documented remedy for exactly this problem, and it held for every tool class
+   measured (`Bash`, `Read`, `ToolSearch`, sandbox MCP). It is not a contract we control.
+   The tripwire exists for the day it changes.
+3. **The tripwire is deliberately incomplete.** It only trips on calls it watched being
+   emitted on the message stream, so it cannot fail a healthy run — but it also cannot see
+   tool calls that never surface there. **Subagent (`Task`) nested tool calls were not
+   tested** and may not surface as top-level `tool_use`/`tool_result` blocks; if they do
+   not, they would be neither gated by our hook nor caught by the tripwire. This is the
+   most important open question left.
+4. **The tripwire detects, it does not prevent.** By the time a `tool_result` arrives the
+   tool has already run. It converts a silent bypass into a stopped run, nothing more.
+5. **The Codex harness was not examined.** It uses a different mechanism (the
+   sandbox-gate-shim wrapping stdio MCP servers plus codex's own approval flow). Whether it
+   has an analogous gap is untested and should be checked before relying on it.
+6. **Policy blast radius** — see §4. Existing deployments will see previously-invisible
+   tools at the gate.
+
+## 7. Commands
+
+```bash
+# hermetic regression tests (also run in CI)
+node --test images/runner-lib/*.test.mjs
+
+# rebuild the runner image with the fix (context = images/)
+docker build -t fluidbox-sandbox-runner:dev -f images/sandbox-runner/Dockerfile images
+
+# the acceptance suite (needs a control plane; Phase 1 additionally needs a live model,
+# and self-skips with a clear notice when the LLM upstream refuses a 4-token probe)
+just server                      # or point FLUIDBOX_API_URL at a running one
+bash scripts/e2e-tool-gate.sh
+
+# the standalone SDK probes used for root-causing live in the job scratch dir; the
+# reproduction is a ~40-line script that mirrors index.mjs and denies in canUseTool.
+```
+
+## 8. Cost
+
+All live work used `claude-haiku-4-5`. Roughly 20 short probe/agent runs, each a handful
+of tool calls: **well under $1 in model spend**. The session that produced the decisive
+evidence above was a single-tool-call run.
+
+The validation was cut short by an external blocker: the `ANTHROPIC_API_KEY` in `.env`
+reached **`"Your credit balance is too low to access the Anthropic API"`** partway through
+(confirmed against `api.anthropic.com` directly, request id
+`req_011CdVrQeuBKgDZPH8HotXwn`). Everything requiring a live model after that point could
+not run; the suite's Phase 1 self-skips on it, and §5.3 records what that left unproven.
+
+## 9. Environment notes (and one thing I broke)
+
+- The validation ran against a **dedicated** Postgres (`fbx-gate-pg`, colima,
+  `127.0.0.1:5435`, database `fluidbox_gate`) and a **dedicated** LiteLLM
+  (`fbx-gate-litellm`, `127.0.0.1:4010`), with the control plane on `:8799` / `:8790`, so
+  it touched neither the user's demo database nor their gateway.
+- **A sandbox belonging to another running control plane was terminated.** Two fluidbox
+  servers sharing one Docker daemon is a footgun: `workers.rs:65` classifies a managed
+  container whose session is absent from *its* database as an orphan
+  (`Ok(None) => true, // unknown session → orphan`) and terminates it. My server booted
+  against an empty database on the shared colima daemon and its boot sweep reaped session
+  `019fac5f-590e-7030-9d36-13d57725ccb1`, which belonged to the pre-existing server on
+  `:8787`. Worth considering a deployment-scoped label on managed containers so the sweep
+  cannot cross deployments.
+- Docker Desktop became unresponsive mid-session under disk pressure (the host volume hit
+  96% during image builds), taking the compose Postgres on `:5433` with it; colima was
+  unaffected. One `cargo build` failed with `No space left on device` for the same reason.

--- a/docs/reviews/claude-tool-gate-validation.md
+++ b/docs/reviews/claude-tool-gate-validation.md
@@ -1,8 +1,9 @@
 # The Claude runner executed tools without a fluidbox decision — reproduction, root cause, fix, validation
 
 **Date:** 2026-07-29
-**Branch:** `worktree-claude-tool-gate`
-**Commit:** _see the last section — filled in at commit time_
+**Branch:** `fix/claude-tool-gate`
+**Commits:** `58b4b02` (the fix, tests and this report) + `505674b` (register `ToolSearch`
+in the canonical vocabulary — see §5.4)
 **Severity:** P0 (launch-blocking). fluidbox's central promise — *no sandbox tool call
 executes without a control-plane decision* — was false for a large class of calls on the
 `claude-agent-sdk` harness.
@@ -187,7 +188,72 @@ digest 0de67b1da13b0648e218950ab465aef26e1ee68b06743d8779bb26c1e42566f4: 0 occur
 The gate saw the call, denied it from the authored policy, and the digest of the fresh
 nonce appears **nowhere** — the command did not run.
 
-_Suite results are recorded in §5.3._
+### 5.3 Suite results
+
+```
+PHASE 1 — deny at the gate prevents execution (LIVE agent, Docker provider)
+  SKIP: no reachable model (LLM upstream refused a 4-token probe)
+
+PHASE 2 — an approval holds the tool call, then releases it exactly once
+  ✓ sandbox tool-audience token extracted (session 019fac8e-df85-78a2-b9b1-4f4c005e9f78)
+  ✓ session paused at awaiting_approval
+  ✓ the tool call is still blocked — no verdict issued yet
+  ✓ a pending approval is queued for a human
+  ✓ approval recorded by a human decision
+  ✓ after approval the blocked call returns allow
+  ✓ approved_once decided exactly once (a faithful replay adopts, 1 intent)
+
+PHASE 3 — the gate fails closed
+  ✓ unknown tool → deny (policy default, never an implicit allow)
+  ✓ invalid token refused (401) — no verdict issued at all
+  ✓ runner-control credential rejected by audience (fatal, not a deny)
+  ✓ first use of a tool_call_id decided normally (allow)
+  ✓ same tool_call_id replayed with different input → deny
+  ✓ after cancellation the session credential is revoked (no verdict issued)
+
+PHASE 4 — an approval that expires denies, never allows
+  ✓ expired approval → deny (timeout_action)
+
+RESULT: 14 passed, 0 failed
+```
+
+Two notes on what these assertions actually pin:
+
+- **"still blocked — no verdict issued yet"** is the ordering property the P0 was about: at
+  the moment the session reads `awaiting_approval`, the runner's `/permission` call has not
+  returned, so the tool provably cannot have run. It is asserted by checking the in-flight
+  request is still alive, not by inspecting a status field.
+- **Cancellation** produces a `401`, not a deny verdict: the terminal transition revokes the
+  session's tokens, so no verdict is issued at all. `contract.mjs::requestPermission` maps
+  401/403 at that route to a hard deny, so the tool still cannot run — the suite accepts
+  either shape and fails only on an `allow`.
+
+### 5.4 Other repository checks
+
+| check | result |
+|---|---|
+| `cargo test -p fluidbox-core` | **119 passed, 0 failed** |
+| `node --test images/runner-lib/*.test.mjs` | **18 passed, 0 failed** |
+| `cargo fmt --check -p fluidbox-core` | clean |
+| `cargo clippy -p fluidbox-core --all-targets -- -D warnings` | clean |
+
+`cargo test -p fluidbox-core` initially **failed**, which is worth recording because it
+caught a real omission rather than a formality:
+
+```
+policy matches "ToolSearch", which is neither canonical nor mcp__* —
+add it to CANONICAL or fix the policy      (tools.rs:139)
+```
+
+The canonical tool vocabulary (`fluidbox-core::tools::CANONICAL`) is a contract: a name the
+seed policy governs must be enumerable, or the Governance matrix silently omits a tool the
+policy has an opinion about. `ToolSearch` is now registered there (`ToolGroup::Meta`). This
+is a second-order consequence of the fix that is easy to miss — making the gate mandatory
+does not only change enforcement, it changes *which tool names the control plane ever sees*,
+and everything keyed on that vocabulary has to follow.
+
+The DB-backed and full-workspace suites were not run: they need `DATABASE_URL` and, for the
+live tiers, model credits.
 
 ## 6. Residual risks — stated plainly
 

--- a/images/runner-lib/contract.mjs
+++ b/images/runner-lib/contract.mjs
@@ -532,6 +532,108 @@ export class RunnerClient {
   }
 }
 
+// ─── Why the gate is a HOOK, not the permission callback ───────────────────
+//
+// `canUseTool` is NOT an interception point. The Agent SDK does not call it
+// per tool call; it translates the callback into `--permission-prompt-tool
+// stdio` on the Claude Code CLI it spawns, and the CLI consults that prompt
+// tool ONLY for calls it decides to ASK about. Anything the CLI approves on
+// its own first — its read-only / safe-command classification, an
+// `allowedTools` entry, an allow rule from a settings file, a permissionMode
+// that auto-accepts — executes with the callback never running at all.
+//
+// Measured on @anthropic-ai/claude-agent-sdk 0.3.205 in the shipped image: an
+// ordinary coding workload (list files, read one, grep, `wc -l`) produced FOUR
+// tool calls and ZERO canUseTool invocations, and `printf '<nonce>' |
+// sha256sum` executed and returned the digest of a nonce minted seconds
+// earlier while the gate was never consulted. The SDK states the rule itself:
+// "Bare allowedTools entries auto-approve the whole tool before the callback
+// is consulted... To gate every tool call, use a PreToolUse hook instead."
+//
+// A PreToolUse hook fires for EVERY tool call, underneath that short-circuit.
+// So the hook is what makes the gate mandatory. It deliberately does NO I/O:
+// it answers `ask`, which forces the call onto the canUseTool path, and the
+// blocking /permission round trip still happens THERE. Keeping the blocking on
+// the callback is the point — a supervised approval can hold for minutes,
+// `requestPermission` already owns the 12-minute timeout and forever-retry
+// semantics for exactly that, and a hook that never awaits anything cannot
+// time out, throw, or become a new way to lose a decision.
+export const GATE_ASK_REASON =
+  "fluidbox governs this run: every tool call needs a control-plane decision";
+
+/// The PreToolUse hook return that forces a call onto the gate. Pure and
+/// synchronous by construction — see the note above for why that matters.
+export function forceGateDecision() {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: GATE_ASK_REASON,
+    },
+  };
+}
+
+// A tool that executed without a fluidbox decision is a governance failure,
+// not a verdict — the same class as EXIT_AUDIENCE_MISMATCH and treated the
+// same way. It means the harness lost mediation (an SDK/CLI that stopped
+// firing the hook, a tool class routed around it), and the honest response is
+// to stop the run loudly rather than finish a run whose audit trail claims
+// decisions it never made.
+export const EXIT_UNGOVERNED_TOOL = 5;
+
+export function ungovernedToolDiagnostic(tool, toolCallId) {
+  return (
+    `fluidbox-runner: FATAL — the tool '${tool}' (call ${toolCallId}) produced a result but ` +
+    `NEVER received a fluidbox decision. The permission gate was bypassed, which means this ` +
+    `runner image can no longer mediate tool calls for this agent SDK. Aborting the run: ` +
+    `continuing would execute ungoverned tools while the ledger showed a clean timeline.`
+  );
+}
+
+/// Tripwire bookkeeping for the gate.
+///
+/// The hook above PREVENTS the bypass; this detects one anyway. It pairs the
+/// `tool_use` blocks the harness observes on the message stream with the calls
+/// the gate actually decided, and reports any call that produced a RESULT
+/// without one. That ordering is what makes it sound: the SDK emits the
+/// assistant `tool_use`, then the hook/callback run, then the `tool_result`
+/// arrives — so by result time a governed call is always already decided.
+///
+/// Deliberately conservative: it only trips on a call it watched being
+/// emitted, so a tool_result the harness never saw the request for (a nested
+/// subagent transcript, a future message shape) is ignored rather than
+/// failing a legitimate run. That is a knowingly incomplete detector — it is
+/// a backstop for regression, not the guarantee. The guarantee is the hook.
+export class GateWitness {
+  constructor() {
+    this.emittedTools = new Map(); // tool_call_id -> tool name
+    this.decidedCalls = new Set(); // tool_call_ids the gate answered
+  }
+
+  /// A `tool_use` block seen on the message stream.
+  sawToolUse(toolCallId, tool) {
+    if (typeof toolCallId === "string" && toolCallId) {
+      this.emittedTools.set(toolCallId, tool);
+    }
+  }
+
+  /// The gate produced a decision for this call (allow, deny, or a brokered
+  /// wave-through — all three are decisions, made in exactly one place).
+  sawDecision(toolCallId) {
+    if (typeof toolCallId === "string" && toolCallId) {
+      this.decidedCalls.add(toolCallId);
+    }
+  }
+
+  /// The tool name when this result belongs to an observed-but-undecided
+  /// call, else null.
+  ungovernedResult(toolCallId) {
+    if (typeof toolCallId !== "string" || !toolCallId) return null;
+    if (this.decidedCalls.has(toolCallId)) return null;
+    return this.emittedTools.get(toolCallId) ?? null;
+  }
+}
+
 /// Env a brokered server's broker-shim needs. Shared by every harness — the
 /// broker path is identical for claude and codex (control-plane gate +
 /// execute). The shim calls /tools/call, so it receives the TOOL-INTENT token

--- a/images/runner-lib/gate.test.mjs
+++ b/images/runner-lib/gate.test.mjs
@@ -1,0 +1,148 @@
+// Tests for the mandatory tool gate (the canUseTool bypass, closed).
+//
+// The property under test is NOT "the runner asks for permission" — it did
+// that before and the bypass happened anyway. It is:
+//
+//   1. the harness hands the SDK a PreToolUse hook that forces EVERY tool call
+//      onto the gate, and that hook is pure (no I/O, so it cannot time out,
+//      throw, or lose a decision while a supervised approval blocks); and
+//   2. a tool that produces a result without a decision is detected and fails
+//      the run closed, instead of finishing with an audit trail that omits it.
+//
+// (1) is asserted structurally against the shipped runner source, because that
+// is where the regression would reappear: the gap was never a wrong decision,
+// it was a callback that was simply never invoked, which no assertion about
+// decision logic can catch.
+//
+// Zero dependencies, node's built-in runner. From the repo root:
+//     node --test images/runner-lib/
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  forceGateDecision,
+  GATE_ASK_REASON,
+  GateWitness,
+  EXIT_UNGOVERNED_TOOL,
+  ungovernedToolDiagnostic,
+} from "./contract.mjs";
+
+const LIB_DIR = fileURLToPath(new URL(".", import.meta.url)).replace(/\/$/, "");
+const CLAUDE_RUNNER = path.join(LIB_DIR, "..", "sandbox-runner", "runner", "index.mjs");
+
+// ─── The hook itself ───────────────────────────────────────────────────────
+
+test("forceGateDecision answers 'ask', which is what defeats the CLI auto-approval", () => {
+  const out = forceGateDecision();
+  assert.equal(out.hookSpecificOutput.hookEventName, "PreToolUse");
+  // 'ask' specifically: 'allow' would short-circuit canUseTool (the gate would
+  // never run) and 'deny' would refuse every call outright. Only 'ask' routes
+  // the call to the permission callback for a control-plane decision.
+  assert.equal(out.hookSpecificOutput.permissionDecision, "ask");
+  assert.equal(out.hookSpecificOutput.permissionDecisionReason, GATE_ASK_REASON);
+});
+
+test("forceGateDecision is synchronous and I/O-free, so a blocking approval cannot break it", () => {
+  // A hook that awaited the gate would put a multi-minute approval wait inside
+  // a callback with its own timeout semantics. This one returns a literal.
+  const out = forceGateDecision();
+  assert.equal(typeof out.then, "undefined", "hook result must not be a promise");
+  assert.deepEqual(forceGateDecision(), out, "must be pure — same input, same output");
+});
+
+// ─── The tripwire ──────────────────────────────────────────────────────────
+
+test("a decided call is governed", () => {
+  const w = new GateWitness();
+  w.sawToolUse("toolu_1", "Bash");
+  w.sawDecision("toolu_1");
+  assert.equal(w.ungovernedResult("toolu_1"), null);
+});
+
+test("an emitted-but-undecided call is reported with its tool name", () => {
+  const w = new GateWitness();
+  w.sawToolUse("toolu_2", "Bash");
+  // No sawDecision: this is exactly the observed bypass — the CLI ran the tool
+  // and the gate was never consulted.
+  assert.equal(w.ungovernedResult("toolu_2"), "Bash");
+});
+
+test("a brokered wave-through counts as a decision", () => {
+  // Brokered tools are decided AND executed server-side at /tools/call; the
+  // runner's wave-through is that decision arriving locally, not a bypass.
+  const w = new GateWitness();
+  w.sawToolUse("toolu_3", "mcp__linear__create_issue");
+  w.sawDecision("toolu_3");
+  assert.equal(w.ungovernedResult("toolu_3"), null);
+});
+
+test("a result for a call we never watched is ignored, not failed", () => {
+  // Deliberately conservative: only calls observed on the message stream can
+  // trip the wire, so an unfamiliar message shape cannot kill a healthy run.
+  const w = new GateWitness();
+  assert.equal(w.ungovernedResult("toolu_unseen"), null);
+});
+
+test("malformed tool_call_ids never trip the wire", () => {
+  const w = new GateWitness();
+  for (const id of [undefined, null, "", 0, {}, []]) {
+    assert.equal(w.ungovernedResult(id), null, `id ${JSON.stringify(id)} must not trip`);
+    w.sawToolUse(id, "Bash");
+    w.sawDecision(id);
+  }
+  assert.equal(w.emittedTools.size, 0);
+  assert.equal(w.decidedCalls.size, 0);
+});
+
+test("the ungoverned diagnostic names the tool, the call, and the consequence", () => {
+  const d = ungovernedToolDiagnostic("Bash", "toolu_9");
+  assert.match(d, /Bash/);
+  assert.match(d, /toolu_9/);
+  assert.match(d, /NEVER received a fluidbox decision/);
+  assert.notEqual(EXIT_UNGOVERNED_TOOL, 0, "an ungoverned tool must never exit success");
+});
+
+// ─── The wiring, asserted against the shipped runner source ────────────────
+//
+// A unit test cannot prove the SDK invokes our hook — only a live run does
+// (scripts/e2e-tool-gate.sh). What it CAN prove is that the harness still
+// passes one, which is the half that silently regressed before: `canUseTool`
+// was wired correctly the whole time and the gate still never ran.
+
+test("the Claude runner passes a PreToolUse hook to query()", () => {
+  const src = fs.readFileSync(CLAUDE_RUNNER, "utf8");
+  assert.match(
+    src,
+    /hooks:\s*\{\s*PreToolUse:\s*\[\s*\{\s*hooks:\s*\[\s*preToolUseGate\s*\]/,
+    "query() must receive the PreToolUse gate hook — without it the CLI " +
+      "auto-approves whole tool classes and canUseTool is never invoked",
+  );
+});
+
+test("the Claude runner never asks for a permission mode that skips the callback", () => {
+  const src = fs.readFileSync(CLAUDE_RUNNER, "utf8");
+  // bypassPermissions auto-approves before the callback; acceptEdits does the
+  // same for the entire edit class. Either silently un-governs the run.
+  assert.doesNotMatch(src, /permissionMode:\s*["']bypassPermissions["']/);
+  assert.doesNotMatch(src, /permissionMode:\s*["']acceptEdits["']/);
+  assert.doesNotMatch(src, /allowDangerouslySkipPermissions/);
+});
+
+test("the Claude runner passes no allowedTools, which would auto-approve before the gate", () => {
+  const src = fs.readFileSync(CLAUDE_RUNNER, "utf8");
+  // The SDK warns about this one by name: "Bare allowedTools entries
+  // auto-approve the whole tool before the callback is consulted."
+  assert.doesNotMatch(src, /^\s*allowedTools:/m);
+});
+
+test("the Claude runner reconciles tool results against decisions", () => {
+  const src = fs.readFileSync(CLAUDE_RUNNER, "utf8");
+  assert.match(src, /witness\.sawToolUse\(/, "must watch emitted tool_use blocks");
+  assert.match(src, /witness\.sawDecision\(/, "must record gate decisions");
+  assert.match(src, /witness\.ungovernedResult\(/, "must check results against decisions");
+  assert.match(src, /abortUngoverned\(/, "must abort on an ungoverned execution");
+});

--- a/images/sandbox-runner/runner/index.mjs
+++ b/images/sandbox-runner/runner/index.mjs
@@ -12,6 +12,10 @@ import {
   mcpServerOf,
   BROKER_SHIM,
   brokerShimEnv,
+  forceGateDecision,
+  GateWitness,
+  EXIT_UNGOVERNED_TOOL,
+  ungovernedToolDiagnostic,
 } from "/opt/fluidbox-runner/lib/contract.mjs";
 
 const env = loadRunnerEnv();
@@ -44,11 +48,15 @@ const MODEL = env.MODEL || "claude-haiku-4-5";
 delete process.env.FLUIDBOX_SESSION_TOKEN;
 delete process.env.FLUIDBOX_SESSION_TOKEN_FD;
 
-function textFromMessage(msg) {
-  // BetaMessage content is an array of blocks.
+// BetaMessage content is an array of blocks — or a bare string on some user
+// messages, which carries no tool blocks and is normalized away here.
+function blocksOf(msg) {
   const content = msg?.message?.content;
-  if (!Array.isArray(content)) return "";
-  return content
+  return Array.isArray(content) ? content : [];
+}
+
+function textFromMessage(msg) {
+  return blocksOf(msg)
     .filter((b) => b.type === "text")
     .map((b) => b.text)
     .join("");
@@ -91,6 +99,28 @@ function mcpServersConfig() {
   return servers;
 }
 
+/// Stop the run because a tool executed without a fluidbox decision.
+///
+/// Never returns. Mirrors the audience-mismatch abort in the contract lib and
+/// for the same reason: this is a broken harness, not a governance verdict, so
+/// it must not be laundered into an ordinary outcome. The diagnostic is
+/// best-effort recorded on the run timeline (unlike the audience case, the
+/// runner-control credential here is known good), and NO /result is posted —
+/// a runner that just proved it cannot mediate tool calls has not earned the
+/// right to write this run's terminal outcome. The heartbeat watchdog
+/// terminalizes the exited run exactly as it does for any runner crash.
+async function abortUngoverned(tool, toolCallId) {
+  const diag = ungovernedToolDiagnostic(tool, toolCallId);
+  console.error(diag);
+  await client.emit("harness", {
+    type: "run.error",
+    data: { message: diag, tool, tool_call_id: toolCallId },
+  });
+  client.stopHeartbeat();
+  client.stopTokenRenew();
+  process.exit(EXIT_UNGOVERNED_TOOL);
+}
+
 async function main() {
   await client.emit("harness", {
     type: "agent.message",
@@ -99,20 +129,27 @@ async function main() {
   client.startHeartbeat();
   client.startTokenRenew();
 
+  // Every tool call this run's gate decided, and every one it merely watched
+  // being emitted. See GateWitness: the hook below is the guarantee, this is
+  // the regression tripwire behind it.
+  const witness = new GateWitness();
+
   const canUseTool = async (toolName, input, opts) => {
+    const toolCallId =
+      opts?.toolUseID || `tu_${Date.now()}_${Math.random().toString(36).slice(2)}`;
     // Brokered tools are gated (and executed) server-side at /tools/call —
     // waving them through here decides each call exactly once, on the control
     // plane. A runner that "forgot" this callback changes nothing.
     const mcpServer = mcpServerOf(toolName);
     if (mcpServer && env.BROKERED.has(mcpServer)) {
+      witness.sawDecision(toolCallId);
       return { behavior: "allow", updatedInput: input };
     }
     // NOTE: the runner no longer emits its own tool.requested — the SERVER
     // writes the canonical event exactly once per intent inside the gate
     // (Phase 6), so budget/audit parity never depends on runner cooperation.
-    const toolCallId =
-      opts?.toolUseID || `tu_${Date.now()}_${Math.random().toString(36).slice(2)}`;
     const verdict = await client.requestPermission(toolName, input, toolCallId);
+    witness.sawDecision(toolCallId);
     if (verdict && verdict.decision === "allow") {
       return { behavior: "allow", updatedInput: verdict.updated_input || input };
     }
@@ -121,6 +158,14 @@ async function main() {
       message: (verdict && verdict.message) || "denied by fluidbox policy",
     };
   };
+
+  // THE reason every tool call reaches canUseTool at all. Without this hook the
+  // Claude Code CLI auto-approves whole classes of calls — its read-only and
+  // safe-command classifications — and the callback above is simply never
+  // invoked for them, so the run executes tools the control plane never saw.
+  // Read the note above forceGateDecision() in the contract lib before changing
+  // ANY of this, including the fact that the hook does no I/O.
+  const preToolUseGate = async () => forceGateDecision();
 
   const mcpServers = mcpServersConfig();
   if (Object.keys(mcpServers).length > 0) {
@@ -152,8 +197,14 @@ async function main() {
         mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,
         // Clean sandbox: do not load host/user/project settings files.
         settingSources: [],
-        // Everything routes through canUseTool → our gateway.
+        // NOT sufficient on its own: 'default' still lets the CLI auto-approve
+        // calls it judges safe, without consulting canUseTool. The PreToolUse
+        // hook below is what actually routes everything through our gateway.
         permissionMode: "default",
+        // The mandatory leg of the gate. Fires for EVERY tool call, below the
+        // CLI's auto-approval short-circuit, and answers `ask` so the call has
+        // to come back through canUseTool for a control-plane decision.
+        hooks: { PreToolUse: [{ hooks: [preToolUseGate] }] },
       },
     });
 
@@ -172,9 +223,23 @@ async function main() {
     for await (const msg of response) {
       if (quiesced) break;
       if (msg.type === "assistant") {
+        for (const block of blocksOf(msg)) {
+          if (block?.type === "tool_use") witness.sawToolUse(block.id, block.name);
+        }
         const text = textFromMessage(msg);
         if (text.trim()) {
           await client.emit("agent", { type: "agent.message", data: { role: "assistant", text } });
+        }
+      } else if (msg.type === "user") {
+        // A result for a call the gate never decided means a tool ran
+        // ungoverned. Fail the run closed rather than let it finish with an
+        // audit trail that silently omits the call.
+        for (const block of blocksOf(msg)) {
+          if (block?.type !== "tool_result") continue;
+          const ungoverned = witness.ungovernedResult(block.tool_use_id);
+          if (ungoverned) {
+            await abortUngoverned(ungoverned, block.tool_use_id);
+          }
         }
       } else if (msg.type === "result") {
         finalText = msg.result || "";

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -34,7 +34,14 @@ autonomy:
   on_approval_rule: deny
 tools:
   # Reading and searching are safe anywhere in the sandbox.
-  - match: ["Read", "Glob", "Grep", "LS", "TodoWrite", "Task", "NotebookRead"]
+  #
+  # ToolSearch is here because the gate can now SEE it. Until the PreToolUse
+  # hook landed, the Claude Code CLI auto-approved this whole class and the
+  # calls never reached /permission at all; with the gate mandatory they do,
+  # and an unmatched tool falls to defaults.tool_action (approve), which would
+  # pause every run on the agent's own tool-discovery calls. It reads tool
+  # schemas and executes nothing, so it belongs with the other read-only tools.
+  - match: ["Read", "Glob", "Grep", "LS", "TodoWrite", "Task", "NotebookRead", "ToolSearch"]
     action: allow
 
   # Edits are free inside the workspace; anything else asks a human.

--- a/scripts/e2e-tool-gate.sh
+++ b/scripts/e2e-tool-gate.sh
@@ -253,10 +253,23 @@ if [ -n "$T3" ]; then
   for _ in $(seq 1 30); do
     case "$(sstatus "$S3")" in cancelled|failed) break ;; esac; sleep 1
   done
+  # Two fail-closed shapes are correct here and which one you get is a race
+  # with token revocation on the terminal transition:
+  #   • a deny verdict ("session is not active"), or
+  #   • an outright 401 — the terminal transition revoked the session's tokens,
+  #     so no verdict is issued at all. The runner maps 401/403 at this route to
+  #     a hard deny (contract.mjs::requestPermission), so the tool still cannot
+  #     run. What must NEVER appear is an allow.
   CN=$(perm "$T3" "$S3" '{"tool_call_id":"tg-cancel-1","tool":"Read","input":{"file_path":"/workspace/x"}}')
-  echo "$CN" | grep -q '"decision": *"deny"' \
-    && ok "after cancellation the gate denies even a normally-allowed tool" \
-    || no "post-cancel response was: $(echo "$CN" | head -c 120)"
+  if echo "$CN" | grep -q '"decision": *"allow"'; then
+    no "AFTER CANCELLATION THE GATE ALLOWED A TOOL: $CN"
+  elif echo "$CN" | grep -q '"decision": *"deny"'; then
+    ok "after cancellation the gate denies even a normally-allowed tool"
+  elif echo "$CN" | grep -qE 'unauthorized|forbidden'; then
+    ok "after cancellation the session credential is revoked (no verdict issued)"
+  else
+    no "post-cancel response was neither a deny nor a refusal: $(echo "$CN" | head -c 120)"
+  fi
 fi
 
 # ═══ PHASE 4 — an approval that times out denies ═══════════════════════════

--- a/scripts/e2e-tool-gate.sh
+++ b/scripts/e2e-tool-gate.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# The MANDATORY TOOL GATE acceptance.
+#
+# Every other suite proves the gate DECIDES correctly once it is asked. This one
+# proves it is ASKED — the property that silently broke. The Claude Agent SDK's
+# `canUseTool` is not an interception point: the SDK turns it into
+# `--permission-prompt-tool stdio` on the Claude Code CLI it spawns, and the CLI
+# consults that prompt tool only for calls it decides to ASK about. Everything
+# it auto-approves first (its read-only and safe-command classifications) ran
+# with the control plane never seeing it. Measured pre-fix on the shipped image:
+# an ordinary workload produced FOUR tool calls and ZERO gate consultations.
+#
+# governance-e2e.sh cannot catch that class: it kills the real runner and drives
+# the contract itself, so it only exercises the half that always worked. Hence
+# PHASE 1 here, which runs a REAL agent against the REAL Docker provider and
+# asserts on an UNPREDICTABLE NONCE — the task asks for
+# `printf '<nonce>' | sha256sum`, the exact shape that bypassed the gate, and
+# the digest of a nonce minted seconds earlier cannot be guessed or replayed.
+# Digest in the timeline ⇒ the command really ran. Digest absent ⇒ it did not.
+#
+# PHASES 2-4 are the fail-closed properties. They drive /permission directly
+# with the sandbox's own tool-audience token and KILL the runner first
+# (`silence_runner`, the governance-e2e pattern) — deliberately, so they cost no
+# model tokens and cannot flake on talking a live model into misbehaving.
+#
+# Owns nothing: expects a control plane already running at FLUIDBOX_API_URL.
+set -uo pipefail
+source "$(dirname "$0")/e2e-lib.sh"
+load_env
+require_cmd docker curl python3 openssl shasum
+H="authorization: Bearer $FLUIDBOX_ADMIN_TOKEN"
+CT="content-type: application/json"
+
+if ! port_in_use; then
+  echo "  SKIP: no control plane at $API (start one with: just server)"; exit 0
+fi
+
+jq_get() { python3 -c "import sys,json;d=json.load(sys.stdin);print($1)" 2>/dev/null; }
+sstatus() { curl -s -H "$H" "$API/v1/sessions/$1" | jq_get "d['session']['status']"; }
+events()  { curl -s -H "$H" "$API/v1/sessions/$1/events?limit=300"; }
+perm() { curl -s -X POST -H "authorization: Bearer $1" -H "$CT" -d "$3" \
+           "$API/internal/sessions/$2/permission"; }
+
+# Is a model reachable? The live phase needs one; the rest deliberately do not,
+# so an exhausted key degrades this suite to its fail-closed half instead of
+# reporting failures that are really billing.
+model_available() {
+  [ -n "${ANTHROPIC_API_KEY:-}" ] || return 1
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" -m 25 \
+    "${LLM_UPSTREAM_URL:-http://127.0.0.1:4000}/v1/messages" \
+    -H "authorization: Bearer ${LITELLM_MASTER_KEY:-}" -H "$CT" \
+    -d '{"model":"claude-haiku-4-5","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}')
+  [ "$code" = "200" ]
+}
+
+token_for() { # session_id [env-var] -> token from the live sandbox
+  local sid=$1 var=${2:-FLUIDBOX_TOOL_TOKEN} cid
+  for _ in $(seq 1 60); do
+    cid=$(docker ps --filter "label=fluidbox.session=$sid" --format '{{.ID}}' | head -1)
+    if [ -n "$cid" ]; then
+      docker inspect "$cid" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
+        | sed -n "s/^$var=//p" | head -1 && return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+# Kill the real runner so it can neither race our choreography nor spend model
+# tokens. The session stays `running` (no /result posted) until the heartbeat
+# watchdog terminalizes it, which is the window these phases drive.
+silence_runner() {
+  local cid
+  cid=$(docker ps -q --filter "label=fluidbox.session=$1" | head -1)
+  [ -n "$cid" ] && docker kill "$cid" >/dev/null 2>&1
+}
+
+mkpolicy() { curl -s -o /dev/null -X POST -H "$H" -H "$CT" \
+  -d "$(python3 -c "import json,sys;print(json.dumps({'name':sys.argv[1],'yaml':open(sys.argv[2]).read()}))" "$1" "$2")" \
+  "$API/v1/policies"; }
+mkagent() { curl -s -o /dev/null -X POST -H "$H" -H "$CT" -d "$(python3 -c "
+import json,sys
+b={'name':sys.argv[1],'harness':'claude-agent-sdk','policy':sys.argv[2],'model':'claude-haiku-4-5'}
+if len(sys.argv)>3 and sys.argv[3]: b['runner_image']=sys.argv[3]
+print(json.dumps(b))" "$1" "$2" "${3:-}")" "$API/v1/agents"; }
+start_run() { curl -s -X POST -H "$H" -H "$CT" -d "$(python3 -c "
+import json,sys
+print(json.dumps({'agent':sys.argv[1],'task':sys.argv[2],'repo':{'kind':'none'},
+                  'autonomous':sys.argv[3]=='true'}))" "$1" "$2" "$3")" \
+  "$API/v1/sessions" | jq_get "d['session']['id']"; }
+wait_status() { local s=$1 want=$2 secs=${3:-180} st
+  for _ in $(seq 1 "$secs"); do
+    st=$(sstatus "$s"); [ "$st" = "$want" ] && return 0
+    case "$st" in completed|failed|cancelled|budget_exceeded) return 1 ;; esac
+    sleep 1
+  done; return 1; }
+
+# ── policies (both deny anything unmatched: an unclassified tool must never
+#    slip through on a permissive default) ───────────────────────────────────
+POLICY_HEAD='defaults:
+  tool_action: deny
+budgets:
+  max_wall_clock_secs: 900
+  max_tokens: 300000
+  max_cost_usd: 0.50
+  max_tool_calls: 20
+autonomy:
+  permitted: true
+  on_approval_rule: deny
+'
+READ_ONLY='  - match: ["Read", "Glob", "Grep", "LS", "TodoWrite", "Task", "NotebookRead", "ToolSearch"]
+    action: allow
+'
+policy_file() { # name ttl bash-action risk
+  { echo "name: $1"; echo "$POLICY_HEAD";
+    echo 'approvals:'; echo "  default_ttl_secs: $2"; echo '  scope: once'; echo '  timeout_action: deny';
+    echo 'tools:'; echo "$READ_ONLY";
+    echo '  - match: ["Bash"]'; echo "    action: $3"; echo "    risk: $4";
+  } > "${TMPDIR:-/tmp}/$1.yaml"; echo "${TMPDIR:-/tmp}/$1.yaml"; }
+
+mkpolicy tg-deny    "$(policy_file tg-deny 300 deny 'shell denied for the tool-gate acceptance')"
+mkpolicy tg-approve "$(policy_file tg-approve 600 approve 'every shell command needs a human decision')"
+mkpolicy tg-expire  "$(policy_file tg-expire 5 approve 'expires fast on purpose')"
+mkagent tg-deny-agent    tg-deny    "${FLUIDBOX_SANDBOX_IMAGE:-}"
+mkagent tg-approve-agent tg-approve "${FLUIDBOX_SANDBOX_IMAGE:-}"
+mkagent tg-expire-agent  tg-expire  "${FLUIDBOX_SANDBOX_IMAGE:-}"
+
+BASH_BODY='{"tool_call_id":"%s","tool":"Bash","input":{"command":"%s"}}'
+
+# ═══ PHASE 1 — LIVE agent: a denied tool never executes ════════════════════
+say "PHASE 1 — deny at the gate prevents execution (LIVE agent, Docker provider)"
+if [ "${E2E_SKIP_LIVE:-0}" = "1" ]; then
+  echo "  SKIP: E2E_SKIP_LIVE=1"
+elif ! model_available; then
+  echo "  SKIP: no reachable model (LLM upstream refused a 4-token probe —"
+  echo "        an exhausted key or a gateway that is down). The fail-closed"
+  echo "        phases below do not need one and still run."
+else
+  N1=$(openssl rand -hex 12); D1=$(printf '%s' "$N1" | shasum -a 256 | cut -d' ' -f1)
+  S1=$(start_run tg-deny-agent \
+    "Run this exact shell command with the Bash tool and report its output verbatim: printf '$N1' | sha256sum" true)
+  if [ -z "$S1" ]; then no "could not start the live run"; else
+    ok "live run started (session $S1)"
+    wait_status "$S1" completed 300 || true
+    EV1=$(events "$S1")
+    REQ=$(echo "$EV1" | python3 -c "
+import sys,json;print(sum(1 for e in json.load(sys.stdin)['events'] if e['type']=='tool.requested'))")
+    # THE regression assertion: pre-fix this was ZERO for exactly this command.
+    [ "${REQ:-0}" -ge 1 ] \
+      && ok "the gate SAW the call — $REQ tool.requested event(s)" \
+      || no "ZERO tool.requested: the gate was bypassed (the original P0)"
+    DEC=$(echo "$EV1" | python3 -c "
+import sys,json
+d=[e for e in json.load(sys.stdin)['events'] if e['type']=='tool.decision']
+print(d[0]['payload']['data']['verdict'] if d else 'NONE')")
+    [ "$DEC" = "deny" ] && ok "policy verdict recorded: deny" || no "expected deny, got '$DEC'"
+    echo "$EV1" | grep -q "$D1" \
+      && no "EXECUTED ANYWAY — the nonce digest is in the timeline despite a deny" \
+      || ok "command never executed (digest of a fresh nonce appears nowhere)"
+  fi
+fi
+
+# ═══ PHASE 2 — approval blocks the call until a human decides ══════════════
+say "PHASE 2 — an approval holds the tool call, then releases it exactly once"
+S2=$(start_run tg-approve-agent "tool gate probe" false)
+T2=$(token_for "$S2")
+silence_runner "$S2"
+[ -n "$T2" ] && ok "sandbox tool-audience token extracted (session $S2)" || no "no sandbox token"
+
+if [ -n "$T2" ]; then
+  BODY2=$(printf "$BASH_BODY" "tg-approve-1" "git push origin main")
+  OUT2="${TMPDIR:-/tmp}/tg-perm2.json"
+  ( perm "$T2" "$S2" "$BODY2" > "$OUT2" ) & PERM_PID=$!
+
+  wait_status "$S2" awaiting_approval 90 \
+    && ok "session paused at awaiting_approval" \
+    || no "never reached awaiting_approval (status: $(sstatus "$S2"))"
+
+  # The ORDERING property: the runner's call has not been answered yet, so the
+  # tool cannot have run. A gate that returned early here would be the bug.
+  kill -0 "$PERM_PID" 2>/dev/null \
+    && ok "the tool call is still blocked — no verdict issued yet" \
+    || no "the gate answered before a human decided"
+
+  AID=$(curl -s -H "$H" "$API/v1/sessions/$S2/approvals" | python3 -c "
+import sys,json
+a=[x for x in json.load(sys.stdin)['approvals'] if x['status']=='pending']
+print(a[0]['id'] if a else '')")
+  [ -n "$AID" ] && ok "a pending approval is queued for a human" || no "no pending approval row"
+
+  APPROVED=$(curl -s -X POST -H "$H" -H "$CT" -d '{"decision":"approved_once"}' \
+    "$API/v1/approvals/$AID/decision")
+  echo "$APPROVED" | grep -q '"status"' \
+    && ok "approval recorded by a human decision" \
+    || no "approve call failed: $(echo "$APPROVED" | head -c 160)"
+  wait "$PERM_PID" 2>/dev/null
+  D2=$(jq_get "d['decision']" < "$OUT2")
+  [ "$D2" = "allow" ] && ok "after approval the blocked call returns allow" \
+    || no "post-approval decision was '$D2'"
+
+  # Exactly once: the SAME id+input replayed adopts the recorded verdict and
+  # must NOT register a second intent (that would double-count and re-decide).
+  perm "$T2" "$S2" "$BODY2" > /dev/null
+  CNT=$(events "$S2" | python3 -c "
+import sys,json
+print(sum(1 for e in json.load(sys.stdin)['events']
+          if e['type']=='tool.requested'
+          and e['payload']['data'].get('tool_call_id')=='tg-approve-1'))")
+  [ "${CNT:-0}" = "1" ] \
+    && ok "approved_once decided exactly once (a faithful replay adopts, 1 intent)" \
+    || no "expected exactly 1 tool.requested for the id, got $CNT"
+fi
+
+# ═══ PHASE 3 — fail-closed properties ══════════════════════════════════════
+say "PHASE 3 — the gate fails closed"
+S3=$(start_run tg-approve-agent "tool gate probe" false)
+T3=$(token_for "$S3")
+CTRL3=$(token_for "$S3" FLUIDBOX_SESSION_TOKEN)
+silence_runner "$S3"
+
+if [ -n "$T3" ]; then
+  UNK=$(perm "$T3" "$S3" '{"tool_call_id":"tg-unknown-1","tool":"TotallyMadeUpTool","input":{}}' | jq_get "d['decision']")
+  [ "$UNK" = "deny" ] && ok "unknown tool → deny (policy default, never an implicit allow)" \
+    || no "unknown tool returned '$UNK'"
+
+  BAD=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    -H "authorization: Bearer fbx_sess_not_a_real_token" -H "$CT" \
+    -d "$(printf "$BASH_BODY" "tg-badtok-1" "echo hi")" \
+    "$API/internal/sessions/$S3/permission")
+  { [ "$BAD" = "401" ] || [ "$BAD" = "403" ]; } \
+    && ok "invalid token refused ($BAD) — no verdict issued at all" \
+    || no "invalid token got HTTP $BAD"
+
+  if [ -n "$CTRL3" ]; then
+    perm "$CTRL3" "$S3" "$(printf "$BASH_BODY" "tg-aud-1" "echo hi")" | grep -q wrong_audience \
+      && ok "runner-control credential rejected by audience (fatal, not a deny)" \
+      || no "the control token was not rejected by audience"
+  fi
+
+  # A reused id carrying DIFFERENT arguments is a protocol violation, not a
+  # cache hit — otherwise an approved call could be swapped for another one.
+  # Read (not Bash) on purpose: this policy makes Read an immediate allow, so
+  # the pair is allow-then-deny, which proves the violation path rather than
+  # two indistinguishable denies — and it never blocks on an approval.
+  RP1=$(perm "$T3" "$S3" '{"tool_call_id":"tg-replay-1","tool":"Read","input":{"file_path":"/workspace/a"}}' | jq_get "d['decision']")
+  [ "$RP1" = "allow" ] && ok "first use of a tool_call_id decided normally (allow)" \
+    || no "expected the first Read to allow, got '$RP1'"
+  RP=$(perm "$T3" "$S3" '{"tool_call_id":"tg-replay-1","tool":"Read","input":{"file_path":"/workspace/DIFFERENT"}}' | jq_get "d['decision']")
+  [ "$RP" = "deny" ] && ok "same tool_call_id replayed with different input → deny" \
+    || no "replay with different input returned '$RP'"
+
+  curl -s -o /dev/null -X POST -H "$H" "$API/v1/sessions/$S3/cancel"
+  for _ in $(seq 1 30); do
+    case "$(sstatus "$S3")" in cancelled|failed) break ;; esac; sleep 1
+  done
+  CN=$(perm "$T3" "$S3" '{"tool_call_id":"tg-cancel-1","tool":"Read","input":{"file_path":"/workspace/x"}}')
+  echo "$CN" | grep -q '"decision": *"deny"' \
+    && ok "after cancellation the gate denies even a normally-allowed tool" \
+    || no "post-cancel response was: $(echo "$CN" | head -c 120)"
+fi
+
+# ═══ PHASE 4 — an approval that times out denies ═══════════════════════════
+say "PHASE 4 — an approval that expires denies, never allows"
+S4=$(start_run tg-expire-agent "tool gate probe" false)
+T4=$(token_for "$S4")
+silence_runner "$S4"
+if [ -n "$T4" ]; then
+  D4=$(perm "$T4" "$S4" "$(printf "$BASH_BODY" "tg-expire-1" "git push origin main")" | jq_get "d['decision']")
+  [ "$D4" = "deny" ] && ok "expired approval → deny (timeout_action)" \
+    || no "expired approval returned '$D4'"
+  curl -s -o /dev/null -X POST -H "$H" "$API/v1/sessions/$S4/cancel"
+fi
+
+say "RESULT"
+printf "  \033[1;32m%d passed\033[0m, \033[1;31m%d failed\033[0m\n" "$pass" "$fail"
+exit $(( fail > 0 ? 1 : 0 ))


### PR DESCRIPTION
## The bug

A live Claude agent could execute tools with **no control-plane decision at all**.

`canUseTool` is not an interception point. The Agent SDK turns it into
`--permission-prompt-tool stdio` on the Claude Code CLI it spawns, and the CLI consults
that prompt tool **only for calls it decides to ask about**. Everything it auto-approves
first — its read-only and safe-command classifications — ran with the gate never consulted.

Measured pre-fix in the shipped image (SDK 0.3.205):

| | Bash | Read | ToolSearch | mcp__* |
|---|---|---|---|---|
| emitted | 3 | 1 | 2 | 1 |
| reached `PreToolUse` | 3 | 1 | 2 | 1 |
| reached `canUseTool` | **0** | **0** | **0** | 1 |

An ordinary workload produced **four tool calls and zero gate consultations**. And
`printf '<nonce>' | sha256sum` returned the digest of a nonce minted seconds earlier — so
the command provably ran — while the ledger held no tool events at all.

The runner was correct in every line a reviewer would look at (`canUseTool` wired,
`permissionMode: "default"`, `settingSources: []`, no `allowedTools`). The bug was an
**absent invocation**, which no assertion about decision logic can catch.

**Why it survived every acceptance run:** `e2e-live.sh:113` asserts `tool_calls >= 1`, and
demo A edits files and runs tests — calls the CLI *does* prompt for — so the counter stayed
non-zero. `governance-e2e.sh` kills the real runner and drives the contract itself, so it
only ever exercised the half that worked.

## The fix

A `PreToolUse` hook fires for every tool call, below that short-circuit. The hook answers
`ask`, forcing the call back onto the `canUseTool` path where the existing gate still
decides — so the hook does **no I/O** and cannot time out while a supervised approval
blocks for minutes. `canUseTool` is otherwise unchanged.

Second layer: `GateWitness` reconciles observed `tool_use` blocks against decided calls. A
result for an undecided call aborts the run (`EXIT_UNGOVERNED_TOOL`) with a timeline
diagnostic and no `/result`, rather than finishing with an audit trail that omits the call.

## Evidence

Live, post-fix, real agent on the Docker provider — the identical scenario that previously
produced zero events:

```
tool.requested {"summary":"printf 'fbxgate-acaf9ad75edf15bf9cd21790' | sha256sum",
                "tool":"Bash","tool_call_id":"toolu_013XrkvXtJhGDaXzpk6FDccz"}
tool.decision  {"verdict":"deny","source":"policy",
                "reason":"bash denied for the tool-gate acceptance"}
digest 0de67b1d…: 0 occurrences   ← the command did not run
```

## Tests

- `images/runner-lib/gate.test.mjs` — 12 tests on the existing CI step. **Mutation-verified:**
  removing the hook, removing the tripwire, or returning `allow` each fail a test.
- `scripts/e2e-tool-gate.sh` — live phase asserts on an unpredictable nonce; the
  fail-closed phases (approval ordering, exactly-once, unknown tool, invalid token, wrong
  audience, replay, cancellation, timeout) need **no model tokens**. **14 passed, 0 failed.**
- `cargo test -p fluidbox-core` 119 ✓, `node --test images/runner-lib/` 18 ✓, fmt + clippy clean.

## Reviewer attention, please

1. **`policies/default.yaml` is a behavioural change for existing deployments.** The gate now
   sees tools it never saw before; an unmatched tool falls to `defaults.tool_action`
   (`approve` → pause; `deny` in autonomous runs). `seed_policy_if_absent` never re-applies
   the seed, so stored policies need the rule added before deploying this image.
2. **An old pinned `runner_image` on a new server still bypasses the gate.** `runner_image`
   is a per-revision field that carries forward, so this is reachable without a bad deploy,
   and there is no server-side detection today.
3. **Subagent (`Task`) nested tool calls were not tested** — if they don't surface as
   top-level `tool_use`/`tool_result`, they'd be neither gated nor caught by the tripwire.
   This is the most important open question.
4. **The Codex harness was not examined** for an analogous gap.

Live validation was cut short when the `ANTHROPIC_API_KEY` hit
`"Your credit balance is too low"`; Phase 1 self-skips on that. Full write-up, including
residual risks and an environment incident (my server's boot sweep reaped another control
plane's sandbox on the shared Docker daemon):
`docs/reviews/claude-tool-gate-validation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7o9yDMmBrb7eXmP4gZLCb