### PR TITLE
fix(k8s): close the netpol admission race — bounded observation probe + per-sandbox netpol-gate

### DIFF
--- a/crates/fluidbox-core/src/traits.rs
+++ b/crates/fluidbox-core/src/traits.rs
@@ -56,6 +56,31 @@ pub struct SandboxSpec {
     /// compute if the control plane is down. None = installation default.
     pub active_deadline_secs: Option<u64>,
     pub network: NetworkMode,
+    /// Startup network-isolation admission (Kubernetes netpol race fix): when
+    /// set, the provider MUST prove — from inside the sandbox's own network
+    /// identity, BEFORE any untrusted runner code starts — that the positive
+    /// target is reachable AND the negative target is blocked, bounded by
+    /// `wait_secs` and failing closed on expiry. CNIs that program
+    /// NetworkPolicy asynchronously (AWS VPC CNI `standard` mode fails OPEN
+    /// for a new pod's first seconds) otherwise hand untrusted code an
+    /// unrestricted network at t=0. None = the deployment does not require
+    /// verified enforcement (dev posture) or the provider has no such race
+    /// (Docker's per-session bridge is synchronous with container start).
+    pub network_admission: Option<NetworkAdmission>,
+}
+
+/// The observable startup-isolation protocol's frozen targets: one address
+/// that MUST be reachable (proves the allow rule landed and the control plane
+/// is up) and one that MUST be blocked (proves the deny landed — the target
+/// is a live listener, so "blocked" is evidence of policy, not of a dead
+/// host). Both must hold in the SAME observation within `wait_secs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkAdmission {
+    pub positive_addr: String,
+    pub positive_port: u16,
+    pub negative_addr: String,
+    pub negative_port: u16,
+    pub wait_secs: u64,
 }
 
 /// How a provider hands the workspace to the sandbox. Host-dir providers bind

--- a/crates/fluidbox-provider-k8s/examples/netpol_fixtures.rs
+++ b/crates/fluidbox-provider-k8s/examples/netpol_fixtures.rs
@@ -1,0 +1,83 @@
+//! Validation fixture generator: prints the PRODUCTION netpol artifacts —
+//! the enforcement observation script, the certification probe Pod, and a
+//! sandbox Pod carrying the `netpol-gate` init container — so live-cluster
+//! validation (scripts/netpol-admission-validation.sh) exercises the real
+//! bytes this crate ships, not a hand-copied approximation that could drift.
+//!
+//! Never part of a release build (examples are dev-only targets).
+
+use fluidbox_core::traits::{NetworkAdmission, NetworkMode, SandboxSpec, SandboxTokens};
+use fluidbox_provider_k8s::config::K8sConfig;
+use fluidbox_provider_k8s::{manifest, netpol};
+
+fn usage() -> ! {
+    eprintln!(
+        "usage:\n  netpol_fixtures script <pos_addr> <pos_port> <neg_addr> <neg_port> <wait_secs>\n  \
+         netpol_fixtures probe-pod <name> <image> <pos_addr> <pos_port> <neg_addr> <neg_port> <wait_secs>\n  \
+         netpol_fixtures sandbox-pod <pos_addr> <pos_port> <neg_addr> <neg_port> <wait_secs>\n\
+         sandbox-pod reads the K8s knobs from the environment (FLUIDBOX_K8S_*, \
+         FLUIDBOX_NETPOL_PROBE_IMAGE, FLUIDBOX_COLLECTOR_IMAGE) and RUNNER_IMAGE."
+    );
+    std::process::exit(2);
+}
+
+fn admission(args: &[String]) -> NetworkAdmission {
+    NetworkAdmission {
+        positive_addr: args[0].clone(),
+        positive_port: args[1].parse().expect("positive port"),
+        negative_addr: args[2].clone(),
+        negative_port: args[3].parse().expect("negative port"),
+        wait_secs: args[4].parse().expect("wait secs"),
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(|s| s.as_str()) {
+        Some("script") if args.len() == 6 => {
+            let a = admission(&args[1..]);
+            println!(
+                "{}",
+                netpol::enforcement_script(
+                    (a.positive_addr.as_str(), a.positive_port),
+                    (a.negative_addr.as_str(), a.negative_port),
+                    a.wait_secs,
+                )
+            );
+        }
+        Some("probe-pod") if args.len() == 8 => {
+            let (name, image) = (&args[1], &args[2]);
+            let a = admission(&args[3..]);
+            let script = netpol::enforcement_script(
+                (a.positive_addr.as_str(), a.positive_port),
+                (a.negative_addr.as_str(), a.negative_port),
+                a.wait_secs,
+            );
+            let pod =
+                netpol::build_probe_pod(&K8sConfig::from_env(), name, image, &script, a.wait_secs);
+            println!("{}", serde_json::to_string_pretty(&pod).unwrap());
+        }
+        Some("sandbox-pod") if args.len() == 6 => {
+            let a = admission(&args[1..]);
+            let spec = SandboxSpec {
+                session_id: uuid::Uuid::nil(),
+                image: std::env::var("RUNNER_IMAGE").unwrap_or_else(|_| "busybox:1.36".into()),
+                env: vec![("FLUIDBOX_TASK".into(), "netpol-validation".into())],
+                tokens: SandboxTokens {
+                    control: "fbx_sess_stub_control".into(),
+                    tool: "fbx_sess_stub_tool".into(),
+                    llm: "fbx_sess_stub_llm".into(),
+                    workspace: "fbx_sess_stub_workspace".into(),
+                },
+                workspace_host_dir: None,
+                workspace_archive: None,
+                active_deadline_secs: Some(600),
+                network: NetworkMode::Hardened,
+                network_admission: Some(a),
+            };
+            let pod = manifest::build_pod(&spec, &K8sConfig::from_env());
+            println!("{}", serde_json::to_string_pretty(&pod).unwrap());
+        }
+        _ => usage(),
+    }
+}

--- a/crates/fluidbox-provider-k8s/src/config.rs
+++ b/crates/fluidbox-provider-k8s/src/config.rs
@@ -35,6 +35,16 @@ pub struct K8sConfig {
     /// `imagePullSecrets` names for private runner/collector/probe images in
     /// the sandbox namespace (the Secret must exist there).
     pub image_pull_secrets: Vec<String>,
+    /// The image the `netpol-gate` init container runs (needs sh + nc; the
+    /// same image the boot-time certification probe uses —
+    /// `FLUIDBOX_NETPOL_PROBE_IMAGE`, one knob for both).
+    pub netpol_probe_image: String,
+    /// Mirror of the server's `FLUIDBOX_REQUIRE_ENFORCED_NETPOL` (same env
+    /// var, same falsey parse, read in-process from the same environment).
+    /// Defense in depth: when enforcement is required, `provision` REFUSES a
+    /// spec that carries no `NetworkAdmission` — a server-side wiring bug can
+    /// then never silently skip the startup-isolation gate.
+    pub require_enforced_netpol: bool,
 }
 
 /// `deny_unknown_fields`: a misspelled field (e.g. `tolerationSecond`)
@@ -89,8 +99,19 @@ impl K8sConfig {
             tolerations: parse_tolerations(get("FLUIDBOX_K8S_TOLERATIONS")),
             priority_class_name: get("FLUIDBOX_K8S_PRIORITY_CLASS"),
             image_pull_secrets: parse_list(get("FLUIDBOX_K8S_IMAGE_PULL_SECRETS")),
+            netpol_probe_image: get("FLUIDBOX_NETPOL_PROBE_IMAGE")
+                .unwrap_or_else(|| "busybox:1.36".into()),
+            require_enforced_netpol: parse_enforced_flag(get("FLUIDBOX_REQUIRE_ENFORCED_NETPOL")),
         }
     }
+}
+
+/// The server's exact falsey parse for `FLUIDBOX_REQUIRE_ENFORCED_NETPOL`
+/// (`fluidbox-server::config`): anything but `false`/`0` is true, unset is
+/// true. The two readers see the same process environment, so agreeing on the
+/// parse is what keeps them the same knob.
+fn parse_enforced_flag(v: Option<String>) -> bool {
+    v.map(|v| v != "false" && v != "0").unwrap_or(true)
 }
 
 /// Parse `k1=v1,k2=v2` into pairs (node selector labels).
@@ -203,5 +224,18 @@ mod tests {
         assert_eq!(parse_list(Some("a, b ,c".into())), vec!["a", "b", "c"]);
         assert!(parse_list(Some(" , ".into())).is_empty());
         assert!(parse_list(None).is_empty());
+    }
+
+    /// Must match the server's parse of the SAME env var exactly — unset and
+    /// unrecognized values default to ENFORCING (fail closed), only the two
+    /// documented falsey spellings opt out.
+    #[test]
+    fn enforced_flag_parses_like_the_server() {
+        assert!(parse_enforced_flag(None));
+        assert!(parse_enforced_flag(Some("true".into())));
+        assert!(parse_enforced_flag(Some("1".into())));
+        assert!(parse_enforced_flag(Some("yes".into())));
+        assert!(!parse_enforced_flag(Some("false".into())));
+        assert!(!parse_enforced_flag(Some("0".into())));
     }
 }

--- a/crates/fluidbox-provider-k8s/src/lib.rs
+++ b/crates/fluidbox-provider-k8s/src/lib.rs
@@ -39,7 +39,11 @@ use manifest::{
 };
 use std::path::{Path, PathBuf};
 
-const RUNTIME: &str = "kubernetes";
+/// The provider's runtime name, public so the server can ask "is the active
+/// provider this one" (e.g. when deciding whether to freeze
+/// `NetworkAdmission` targets) without string-literal drift.
+pub const RUNTIME_NAME: &str = "kubernetes";
+const RUNTIME: &str = RUNTIME_NAME;
 /// Diff artifacts are bounded at this many bytes over exec (the collector
 /// already caps them; this is the receive-side ceiling).
 const MAX_DIFF_BYTES: usize = 16 * 1024 * 1024;
@@ -319,9 +323,28 @@ fn fatal_waiting(reason: Option<&str>) -> bool {
     )
 }
 
+/// Startup-isolation invariant (the netpol admission race): when this
+/// deployment REQUIRES verified enforcement, every sandbox must carry the
+/// admission targets its `netpol-gate` init container observes before the
+/// untrusted runner may start. A spec without them means a control-plane
+/// wiring bug (or a bypassed run gate) — refuse here rather than launch a
+/// pod whose first seconds ride the CNI's fail-open window unobserved.
+fn require_network_admission(cfg: &K8sConfig, spec: &SandboxSpec) -> Result<(), ProviderError> {
+    if cfg.require_enforced_netpol && spec.network_admission.is_none() {
+        return Err(ProviderError::Other(
+            "refusing to provision: FLUIDBOX_REQUIRE_ENFORCED_NETPOL is set but the run \
+             carries no network-admission targets (the enforcement gate has not verified \
+             this cluster, or the control plane failed to freeze the targets)"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl ExecutionProvider for KubernetesProvider {
     async fn provision(&self, spec: &SandboxSpec) -> Result<SandboxHandle, ProviderError> {
+        require_network_admission(&self.cfg, spec)?;
         let name = object_name(spec.session_id);
 
         // 1. Create the Pod referencing the not-yet-existing Secret. The
@@ -1183,6 +1206,49 @@ mod tests {
             parse_collected(b"garbage"),
             CollectedArtifacts::Missing { .. }
         ));
+    }
+
+    // ─── Startup network admission (netpol race fix) ───────────────────────
+
+    fn bare_spec(admission: Option<fluidbox_core::traits::NetworkAdmission>) -> SandboxSpec {
+        SandboxSpec {
+            session_id: Uuid::nil(),
+            image: "ghcr.io/x/runner:dev".into(),
+            env: vec![],
+            tokens: fluidbox_core::traits::SandboxTokens {
+                control: "c".into(),
+                tool: "t".into(),
+                llm: "l".into(),
+                workspace: "w".into(),
+            },
+            workspace_host_dir: None,
+            workspace_archive: None,
+            active_deadline_secs: None,
+            network: fluidbox_core::traits::NetworkMode::Hardened,
+            network_admission: admission,
+        }
+    }
+
+    /// Defense in depth for the admission gate: an enforcement-required
+    /// deployment REFUSES to launch a sandbox whose spec lost its admission
+    /// targets — the fail-open window must never be reachable through a
+    /// wiring bug upstream.
+    #[test]
+    fn provision_refuses_enforcement_required_spec_without_admission() {
+        let mut cfg = K8sConfig::from_env();
+        cfg.require_enforced_netpol = true;
+        assert!(require_network_admission(&cfg, &bare_spec(None)).is_err());
+        let adm = fluidbox_core::traits::NetworkAdmission {
+            positive_addr: "10.0.0.5".into(),
+            positive_port: 8788,
+            negative_addr: "10.0.0.6".into(),
+            negative_port: 8787,
+            wait_secs: 60,
+        };
+        assert!(require_network_admission(&cfg, &bare_spec(Some(adm))).is_ok());
+        // Dev posture (requireEnforced=false): no admission is legitimate.
+        cfg.require_enforced_netpol = false;
+        assert!(require_network_admission(&cfg, &bare_spec(None)).is_ok());
     }
 
     // ─── Gap 6 workload identity (Phase F) ─────────────────────────────────

--- a/crates/fluidbox-provider-k8s/src/manifest.rs
+++ b/crates/fluidbox-provider-k8s/src/manifest.rs
@@ -11,6 +11,13 @@ pub const LABEL_MANAGED: &str = "fluidbox.dev/managed";
 pub const RUNNER_CONTAINER: &str = "runner";
 pub const COLLECTOR_CONTAINER: &str = "workspace-collector";
 pub const INIT_CONTAINER: &str = "workspace-init";
+/// The startup network-admission gate: FIRST init container when the spec
+/// carries a `NetworkAdmission`. Init containers complete before app
+/// containers start (kubelet contract), so the untrusted runner cannot
+/// execute until this gate has OBSERVED the pod's own NetworkPolicy enforced
+/// — closing the CNI fail-open window (AWS VPC CNI `standard` mode) during
+/// which a fresh pod has unrestricted egress.
+pub const NETPOL_GATE_CONTAINER: &str = "netpol-gate";
 /// One Secret key per audience-scoped credential (Gap 10, invariant 19). The
 /// runner container references control/tool/llm; the INIT container references
 /// `workspace-token` and NOTHING else, so the archive-fetch credential never
@@ -125,6 +132,43 @@ pub fn build_pod(spec: &SandboxSpec, cfg: &K8sConfig) -> Value {
         { "name": "FLUIDBOX_BASE_COMMIT", "value": base_commit },
     ]);
 
+    // Init chain: the network-admission gate FIRST (when required), then the
+    // workspace fetch. Ordering is deliberate: nothing — not even the trusted
+    // archive fetch — runs until the pod's own network is proven enforced,
+    // and the kubelet's init-container contract then keeps the untrusted
+    // runner off the network for free.
+    let mut init_containers: Vec<Value> = Vec::new();
+    if let Some(adm) = &spec.network_admission {
+        let script = crate::netpol::enforcement_script(
+            (adm.positive_addr.as_str(), adm.positive_port),
+            (adm.negative_addr.as_str(), adm.negative_port),
+            adm.wait_secs,
+        );
+        init_containers.push(json!({
+            "name": NETPOL_GATE_CONTAINER,
+            "image": cfg.netpol_probe_image,
+            "command": ["/bin/sh", "-c", script],
+            "securityContext": container_sc,
+            // Tiny and explicit: the gate must never inflate the pod's
+            // effective request (quota) past the main containers.
+            "resources": {
+                "requests": { "cpu": "10m", "memory": "16Mi" },
+                "limits": { "cpu": "200m", "memory": "64Mi" },
+            },
+        }));
+    }
+    init_containers.push(json!({
+        "name": INIT_CONTAINER,
+        "image": cfg.collector_image,
+        "command": ["workspaced", "init"],
+        "env": init_env,
+        "securityContext": container_sc,
+        "volumeMounts": [
+            { "name": "workspace", "mountPath": "/workspace" },
+            { "name": "collector", "mountPath": "/collector" },
+        ],
+    }));
+
     let mut pod_spec = json!({
         "restartPolicy": "Never",
         "automountServiceAccountToken": false,
@@ -141,17 +185,7 @@ pub fn build_pod(spec: &SandboxSpec, cfg: &K8sConfig) -> Value {
             { "name": "workspace", "emptyDir": { "sizeLimit": cfg.volume_size_limit } },
             { "name": "collector", "emptyDir": { "sizeLimit": cfg.volume_size_limit } },
         ],
-        "initContainers": [{
-            "name": INIT_CONTAINER,
-            "image": cfg.collector_image,
-            "command": ["workspaced", "init"],
-            "env": init_env,
-            "securityContext": container_sc,
-            "volumeMounts": [
-                { "name": "workspace", "mountPath": "/workspace" },
-                { "name": "collector", "mountPath": "/collector" },
-            ],
-        }],
+        "initContainers": init_containers,
         "containers": [
             {
                 "name": RUNNER_CONTAINER,
@@ -315,6 +349,17 @@ mod tests {
             }),
             active_deadline_secs: Some(600),
             network: NetworkMode::Hardened,
+            network_admission: None,
+        }
+    }
+
+    fn admission() -> fluidbox_core::traits::NetworkAdmission {
+        fluidbox_core::traits::NetworkAdmission {
+            positive_addr: "10.96.0.10".into(),
+            positive_port: 8788,
+            negative_addr: "10.96.0.11".into(),
+            negative_port: 8787,
+            wait_secs: 60,
         }
     }
 
@@ -408,6 +453,55 @@ mod tests {
         // Three container roles: init + runner + collector.
         assert_eq!(pod["spec"]["initContainers"].as_array().unwrap().len(), 1);
         assert_eq!(pod["spec"]["containers"].as_array().unwrap().len(), 2);
+    }
+
+    /// The netpol admission race fix: with a `NetworkAdmission` frozen into
+    /// the spec, the gate init container runs FIRST — before the workspace
+    /// fetch and (by the kubelet's init-container contract) before the
+    /// untrusted runner — observing the pod's OWN network until enforcement
+    /// holds, bounded and fail-closed.
+    #[test]
+    fn network_admission_gate_is_the_first_init_container() {
+        let mut s = spec();
+        s.network_admission = Some(admission());
+        let pod = build_pod(&s, &cfg());
+        let inits = pod["spec"]["initContainers"].as_array().unwrap();
+        assert_eq!(inits.len(), 2, "gate + workspace-init");
+        let gate = &inits[0];
+        assert_eq!(gate["name"], NETPOL_GATE_CONTAINER);
+        assert_eq!(
+            inits[1]["name"], INIT_CONTAINER,
+            "workspace fetch must run AFTER the gate"
+        );
+        // The gate runs the shared observation script against the frozen
+        // targets — the same protocol the certification probe runs.
+        let script = gate["command"][2].as_str().unwrap();
+        assert!(script.contains("nc -z -w 2 10.96.0.10 8788"));
+        assert!(script.contains("nc -z -w 2 10.96.0.11 8787"));
+        assert!(script.contains("while :"), "the gate observes, not samples");
+        assert!(script.contains("exit 3"), "fail-closed on not-enforced");
+        // Restricted-PSS compliant like every other container.
+        assert_eq!(gate["securityContext"]["allowPrivilegeEscalation"], false);
+        assert_eq!(gate["securityContext"]["capabilities"]["drop"][0], "ALL");
+        // The gate image is the probe image knob (busybox by default).
+        assert_eq!(gate["image"], cfg().netpol_probe_image);
+        // Tiny explicit resources: never the LimitRange defaults, never a
+        // quota-relevant effective request.
+        assert_eq!(gate["resources"]["requests"]["cpu"], "10m");
+        // No volume mounts and no env: the gate needs the network only —
+        // it must never see tokens or the workspace.
+        assert!(gate.get("volumeMounts").is_none());
+        assert!(gate.get("env").is_none());
+    }
+
+    /// Without a `NetworkAdmission` (dev posture / Docker parity) the pod
+    /// shape is byte-identical to before the fix: one init container.
+    #[test]
+    fn no_admission_means_no_gate_container() {
+        let pod = build_pod(&spec(), &cfg());
+        let inits = pod["spec"]["initContainers"].as_array().unwrap();
+        assert_eq!(inits.len(), 1);
+        assert_eq!(inits[0]["name"], INIT_CONTAINER);
     }
 
     #[test]

--- a/crates/fluidbox-provider-k8s/src/netpol.rs
+++ b/crates/fluidbox-provider-k8s/src/netpol.rs
@@ -11,7 +11,7 @@
 
 use crate::config::K8sConfig;
 use k8s_openapi::api::core::v1::{Pod, Service};
-use kube::api::{Api, DeleteParams, PostParams};
+use kube::api::{Api, DeleteParams, LogParams, PostParams};
 use kube::Client;
 use std::time::Duration;
 
@@ -24,6 +24,56 @@ pub enum NetpolResult {
     Unschedulable,
     /// The probe itself errored (apiserver, RBAC) — treated as unverified.
     ProbeError,
+}
+
+/// Scheduling + image-pull slack added on top of the observation window for
+/// the probe Pod's own `activeDeadlineSeconds` (the script self-terminates at
+/// `wait_secs`; this bound only fires if the pod never got to run it).
+pub const PROBE_SCHEDULING_SLACK_SECS: u64 = 60;
+/// Extra slack the CALLER (the gate worker) waits beyond the pod's own
+/// deadline before concluding `Unschedulable` — covers apiserver lag between
+/// the kubelet killing the pod and the phase landing.
+pub const PROBE_CALLER_SLACK_SECS: u64 = 90;
+
+/// The bounded, observable enforcement-wait script (busybox sh). This is the
+/// SINGLE source of the admission protocol, shared verbatim by the boot-time
+/// certification probe and the per-sandbox `netpol-gate` init container.
+///
+/// Why a convergence LOOP and not one sample: CNIs may program NetworkPolicy
+/// for a new pod asynchronously (AWS VPC CNI `standard` mode fails OPEN for
+/// ~20s — measured 2026-07-28, docs/reviews/2026-07-27 §8c). A t=0 sample
+/// measures the unprogrammed network; a fixed sleep would encode a timing
+/// guess. This loop OBSERVES: each iteration tests the positive target (must
+/// be reachable — the allow rule) and the negative target (must be blocked —
+/// the deny), succeeding only when BOTH hold in the SAME observation.
+/// Enforcement is monotonic once programmed, so the first such observation is
+/// proof. On deadline it fails CLOSED with the original exit-code contract:
+///   0 = enforced; 3 = negative still reachable (NotEnforced);
+///   2 = positive still unreachable (Unschedulable / policy too tight).
+/// Every iteration prints an `obs …` line, so the pod log is a timestamped
+/// record of exactly what was measured — the observable half of the protocol.
+pub fn enforcement_script(positive: (&str, u16), negative: (&str, u16), wait_secs: u64) -> String {
+    format!(
+        "set -u; \
+         end=$(( $(date +%s) + {wait} )); i=0; \
+         while :; do \
+           i=$((i+1)); pos=fail; neg=blocked; \
+           nc -z -w 2 {pos_host} {pos_port} && pos=ok; \
+           nc -z -w 2 {neg_host} {neg_port} && neg=open; \
+           echo \"obs $i t=$(date +%s) pos=$pos neg=$neg\"; \
+           if [ \"$pos\" = ok ] && [ \"$neg\" = blocked ]; then echo enforced; exit 0; fi; \
+           if [ $(date +%s) -ge $end ]; then \
+             if [ \"$neg\" = open ]; then echo \"deadline: negative still reachable — NOT enforced\"; exit 3; fi; \
+             echo \"deadline: positive unreachable — policy too tight or server down\"; exit 2; \
+           fi; \
+           sleep 1; \
+         done",
+        wait = wait_secs,
+        pos_host = positive.0,
+        pos_port = positive.1,
+        neg_host = negative.0,
+        neg_port = negative.1,
+    )
 }
 
 /// Read a Service's ClusterIP (family-matched primary), for the runner's
@@ -52,11 +102,15 @@ pub fn build_probe_pod(
     name: &str,
     probe_image: &str,
     script: &str,
+    wait_secs: u64,
 ) -> serde_json::Value {
     let mut pod_spec = serde_json::json!({
         "restartPolicy": "Never",
         "automountServiceAccountToken": false,
-        "activeDeadlineSeconds": 60,
+        // The script self-terminates at `wait_secs`; the pod deadline only
+        // adds scheduling/pull slack on top — never a second, shorter clock
+        // that could kill a still-observing probe.
+        "activeDeadlineSeconds": wait_secs + PROBE_SCHEDULING_SLACK_SECS,
         "securityContext": { "runAsNonRoot": true, "runAsUser": cfg.run_as_user,
             "seccompProfile": { "type": "RuntimeDefault" } },
         "containers": [{
@@ -77,14 +131,19 @@ pub fn build_probe_pod(
 }
 
 /// Launch a probe Pod in the sandbox namespace (sandbox label so the egress
-/// policy applies) that MUST reach the internal Service :8788 and MUST NOT
-/// reach the public Service :8787, then map its terminal phase to a verdict.
-/// Cleans up the probe Pod on every path.
+/// policy applies) that runs the bounded observation loop: it must OBSERVE
+/// the internal Service :8788 reachable AND the public Service :8787 blocked
+/// within `wait_secs` (CNIs that program policy asynchronously converge
+/// inside the window instead of failing a t=0 sample). Terminal phase maps to
+/// the verdict; on failure the probe's own observation log is surfaced so the
+/// operator sees exactly what was measured. Cleans up the probe Pod on every
+/// path.
 pub async fn verify_netpol(
     cfg: &K8sConfig,
     probe_image: &str,
     internal_ip: &str,
     public_ip: &str,
+    wait_secs: u64,
 ) -> NetpolResult {
     let client = match Client::try_default().await {
         Ok(c) => c,
@@ -95,16 +154,9 @@ pub async fn verify_netpol(
     // Idempotent: clear a stale probe from a prior boot.
     let _ = pods.delete(name, &DeleteParams::default()).await;
 
-    let script = format!(
-        "set -u; \
-         if nc -z -w 4 {int} 8788; then echo pos-ok; else echo pos-fail; exit 2; fi; \
-         if nc -z -w 4 {pub} 8787; then echo neg-fail; exit 3; else echo neg-ok; fi; \
-         echo enforced",
-        int = internal_ip,
-        pub = public_ip,
-    );
+    let script = enforcement_script((internal_ip, 8788), (public_ip, 8787), wait_secs);
     let manifest: Pod =
-        match serde_json::from_value(build_probe_pod(cfg, name, probe_image, &script)) {
+        match serde_json::from_value(build_probe_pod(cfg, name, probe_image, &script, wait_secs)) {
             Ok(p) => p,
             Err(_) => return NetpolResult::ProbeError,
         };
@@ -117,7 +169,12 @@ pub async fn verify_netpol(
         return NetpolResult::ProbeError;
     }
 
-    let deadline = std::time::Instant::now() + Duration::from_secs(90);
+    // The pod runs the observation window itself; this outer clock only adds
+    // scheduling slack on top of the pod's own deadline. Derived, never a
+    // separate magic number — a caller clock shorter than the observation
+    // window would re-introduce the t=0 race it exists to fix.
+    let deadline = std::time::Instant::now()
+        + Duration::from_secs(wait_secs + PROBE_SCHEDULING_SLACK_SECS + PROBE_CALLER_SLACK_SECS);
     let verdict = loop {
         if std::time::Instant::now() > deadline {
             break NetpolResult::Unschedulable;
@@ -130,12 +187,14 @@ pub async fn verify_netpol(
                     .and_then(|s| s.phase.as_deref())
                     .unwrap_or("");
                 match phase {
-                    // Probe exited 0 → both assertions held → enforced.
+                    // Probe exited 0 → both assertions held in one
+                    // observation → enforced.
                     "Succeeded" => break NetpolResult::Enforced,
-                    // Non-zero: exit 3 = negative reachable (NOT enforced);
-                    // exit 2 = positive unreachable (policy too tight / server
-                    // down). Both mean "do not admit runs" — surface NotEnforced
-                    // vs Unschedulable by the terminated exit code.
+                    // Non-zero after the FULL observation window: exit 3 =
+                    // negative still reachable (NOT enforced); exit 2 =
+                    // positive still unreachable (policy too tight / server
+                    // down). Both mean "do not admit runs" — surface
+                    // NotEnforced vs Unschedulable by the terminated exit code.
                     "Failed" => {
                         let code = pod
                             .status
@@ -145,6 +204,12 @@ pub async fn verify_netpol(
                             .and_then(|c| c.state.as_ref())
                             .and_then(|st| st.terminated.as_ref())
                             .map(|t| t.exit_code);
+                        // The observation log is the evidence — surface its
+                        // tail rather than a bare exit code.
+                        let tail = probe_log_tail(&pods, name).await;
+                        tracing::warn!(
+                            "netpol probe failed (exit={code:?}); last observations:\n{tail}"
+                        );
                         break match code {
                             Some(3) => NetpolResult::NotEnforced,
                             _ => NetpolResult::Unschedulable,
@@ -161,6 +226,19 @@ pub async fn verify_netpol(
 
     let _ = pods.delete(name, &DeleteParams::default()).await;
     verdict
+}
+
+/// Last observation lines from the probe pod, best-effort (the verdict never
+/// depends on this — it is operator evidence only).
+async fn probe_log_tail(pods: &Api<Pod>, name: &str) -> String {
+    let lp = LogParams {
+        tail_lines: Some(12),
+        ..Default::default()
+    };
+    match pods.logs(name, &lp).await {
+        Ok(l) if !l.trim().is_empty() => l,
+        _ => "(no probe log available)".into(),
+    }
 }
 
 #[cfg(test)]
@@ -190,7 +268,7 @@ mod tests {
         }];
         c.image_pull_secrets = vec!["regcred".into()];
 
-        let pod = build_probe_pod(&c, "probe-x", "busybox:1.36", "echo hi");
+        let pod = build_probe_pod(&c, "probe-x", "busybox:1.36", "echo hi", 60);
         let spec = &pod["spec"];
         assert_eq!(spec["runtimeClassName"], "gvisor");
         assert_eq!(spec["priorityClassName"], "sandbox-low");
@@ -211,7 +289,7 @@ mod tests {
 
     #[test]
     fn probe_pod_omits_unset_placement() {
-        let pod = build_probe_pod(&cfg(), "probe-x", "busybox:1.36", "echo hi");
+        let pod = build_probe_pod(&cfg(), "probe-x", "busybox:1.36", "echo hi", 60);
         let spec = &pod["spec"];
         for key in [
             "runtimeClassName",
@@ -226,5 +304,53 @@ mod tests {
         assert_eq!(spec["restartPolicy"], "Never");
         assert_eq!(spec["automountServiceAccountToken"], false);
         assert_eq!(spec["securityContext"]["runAsNonRoot"], true);
+    }
+
+    /// The admission race regression (measured on EKS 2026-07-28,
+    /// docs/reviews/2026-07-27 §8c): the probe must OBSERVE convergence over a
+    /// bounded window, never sample once at t=0 and never sleep-then-assume.
+    #[test]
+    fn enforcement_script_is_a_bounded_convergence_loop() {
+        let s = enforcement_script(("10.0.0.5", 8788), ("10.0.0.6", 8787), 45);
+
+        // It loops — a single-sample script is exactly the bug.
+        assert!(s.contains("while :"), "script must poll, not sample once");
+        // Both assertions are re-tested EVERY iteration against the right
+        // targets.
+        assert!(s.contains("nc -z -w 2 10.0.0.5 8788"));
+        assert!(s.contains("nc -z -w 2 10.0.0.6 8787"));
+        // Success requires BOTH conditions in the SAME observation.
+        assert!(s.contains("[ \"$pos\" = ok ] && [ \"$neg\" = blocked ]"));
+        // The bound is the configured window, checked against observed time —
+        // not a blind `sleep 45`.
+        assert!(s.contains("end=$(( $(date +%s) + 45 ))"));
+        assert!(
+            !s.contains("sleep 45"),
+            "the window must be a deadline on observations, not one blind sleep"
+        );
+        // Every iteration emits an observation line (the observable half).
+        assert!(s.contains("echo \"obs $i t=$(date +%s) pos=$pos neg=$neg\""));
+        // Fail-closed verdicts keep the original exit-code contract:
+        // 3 = NotEnforced (negative still reachable), 2 = Unschedulable.
+        assert!(s.contains("exit 3"));
+        assert!(s.contains("exit 2"));
+        assert!(s.contains("exit 0"));
+        // The inter-observation pacing is a poll interval, not the bound.
+        assert!(s.contains("sleep 1"));
+    }
+
+    /// The pod's own clock must strictly contain the observation window: a
+    /// shorter activeDeadline would kill a still-observing probe and
+    /// re-introduce the race as a flake.
+    #[test]
+    fn probe_pod_deadline_contains_the_observation_window() {
+        let wait = 75u64;
+        let pod = build_probe_pod(&cfg(), "probe-x", "busybox:1.36", "echo hi", wait);
+        let deadline = pod["spec"]["activeDeadlineSeconds"].as_u64().unwrap();
+        assert!(
+            deadline > wait,
+            "activeDeadlineSeconds ({deadline}) must exceed the observation window ({wait})"
+        );
+        assert_eq!(deadline, wait + PROBE_SCHEDULING_SLACK_SECS);
     }
 }

--- a/crates/fluidbox-server/src/config.rs
+++ b/crates/fluidbox-server/src/config.rs
@@ -304,6 +304,13 @@ pub struct Config {
     pub require_enforced_netpol: bool,
     /// The probe image used by the boot-time netpol run-gate.
     pub netpol_probe_image: String,
+    /// The bounded observation window (seconds) for netpol enforcement: the
+    /// certification probe AND every sandbox's `netpol-gate` init container
+    /// poll (positive reachable AND negative blocked) until this deadline
+    /// before failing closed. Covers CNIs that program policy asynchronously
+    /// (AWS VPC CNI `standard` lands ~20s after pod start — measured);
+    /// NEVER a sleep: the first successful observation ends the wait.
+    pub netpol_wait_secs: u64,
     /// The server's own internal Service (name, namespace) — resolved to a
     /// ClusterIP at boot for the runner's no-DNS control URL under zeroEgress.
     pub internal_service: Option<String>,
@@ -423,6 +430,15 @@ pub const MAX_RUNNER_ENV_BYTES: usize = 512 * 1024;
 /// `facade`'s test derives its assertion from this constant, so raising the
 /// timeout past the TTL fails there instead of silently breaking the guarantee.
 pub const UPSTREAM_HTTP_TIMEOUT_SECS: u64 = 15 * 60;
+
+/// Default bounded observation window for netpol enforcement
+/// (`FLUIDBOX_NETPOL_WAIT_SECS`). Sized at 3× the measured AWS VPC CNI
+/// `standard`-mode programming latency (~20s for a fresh pod,
+/// docs/reviews/2026-07-27 §8c): enough headroom that a healthy cluster
+/// converges well inside it, short enough that a genuinely non-enforcing CNI
+/// (kindnet) is called out within a minute. The wait ENDS at the first
+/// successful observation — this is a deadline, not a delay.
+pub const DEFAULT_NETPOL_WAIT_SECS: u64 = 60;
 
 impl Config {
     pub fn from_env() -> anyhow::Result<Self> {
@@ -629,6 +645,10 @@ impl Config {
                 .unwrap_or(true),
             netpol_probe_image: get("FLUIDBOX_NETPOL_PROBE_IMAGE")
                 .unwrap_or_else(|_| "busybox:1.36".into()),
+            netpol_wait_secs: get("FLUIDBOX_NETPOL_WAIT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_NETPOL_WAIT_SECS),
             internal_service: get("FLUIDBOX_INTERNAL_SERVICE")
                 .ok()
                 .filter(|s| !s.is_empty()),

--- a/crates/fluidbox-server/src/governor.rs
+++ b/crates/fluidbox-server/src/governor.rs
@@ -1965,6 +1965,7 @@ mod tests {
             network_mode: fluidbox_core::traits::NetworkMode::HostDev,
             require_enforced_netpol: false,
             netpol_probe_image: String::new(),
+            netpol_wait_secs: crate::config::DEFAULT_NETPOL_WAIT_SECS,
             internal_service: None,
             internal_service_namespace: None,
             max_archive_bytes: 0,

--- a/crates/fluidbox-server/src/harness.rs
+++ b/crates/fluidbox-server/src/harness.rs
@@ -231,6 +231,7 @@ mod tests {
             network_mode: fluidbox_core::traits::NetworkMode::HostDev,
             require_enforced_netpol: false,
             netpol_probe_image: "busybox:1.36".into(),
+            netpol_wait_secs: crate::config::DEFAULT_NETPOL_WAIT_SECS,
             internal_service: None,
             internal_service_namespace: None,
             max_archive_bytes: 2 * 1024 * 1024 * 1024,

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -324,6 +324,9 @@ async fn main() -> anyhow::Result<()> {
         // Docker needs no netpol gate; Kubernetes starts unverified and the
         // worker below flips it once the CNI is proven to enforce policy.
         netpol_verified: std::sync::atomic::AtomicBool::new(!is_k8s),
+        // Filled by the gate worker before its first probe; the orchestrator
+        // freezes these into every sandbox's per-pod admission gate.
+        netpol_targets: std::sync::RwLock::new(None),
         oidc: Default::default(),
         // Phase D (#32) legacy→KMS re-seal: the singleton claim flag + live
         // progress, both in-memory (the job is restart-safe by construction).

--- a/crates/fluidbox-server/src/orchestrator.rs
+++ b/crates/fluidbox-server/src/orchestrator.rs
@@ -1307,6 +1307,7 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
         workspace_archive,
         active_deadline_secs: run_spec.budgets.max_wall_clock_secs,
         network: state.cfg.network_mode,
+        network_admission: network_admission(&state),
     };
 
     // Ownership re-check immediately before creating a sandbox: a finalizer
@@ -1444,6 +1445,36 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
     .await;
 
     Ok(())
+}
+
+/// The chart-fixed Service ports the netpol probe and the per-sandbox gate
+/// dial (`deploy/helm/fluidbox/templates/server.yaml`: public :8787, internal
+/// :8788 — the same literals `verify_netpol` scripts).
+const NETPOL_INTERNAL_SERVICE_PORT: u16 = 8788;
+const NETPOL_PUBLIC_SERVICE_PORT: u16 = 8787;
+
+/// Freeze the startup network-admission targets for this sandbox, when the
+/// deployment requires verified enforcement. The targets are the SAME pair
+/// the certification probe verified (stored by the gate worker before every
+/// probe), so the per-pod gate re-observes exactly the certified property
+/// from inside the pod's own network identity. None when enforcement is not
+/// required (dev posture / Docker) — and if targets are unexpectedly absent
+/// under enforcement, the k8s provider refuses to provision (fail closed)
+/// rather than launch an unobserved pod.
+fn network_admission(state: &AppState) -> Option<fluidbox_core::traits::NetworkAdmission> {
+    if !state.cfg.require_enforced_netpol
+        || state.provider.runtime_name() != fluidbox_provider_k8s::RUNTIME_NAME
+    {
+        return None;
+    }
+    let targets = state.netpol_targets.read().ok().and_then(|g| g.clone())?;
+    Some(fluidbox_core::traits::NetworkAdmission {
+        positive_addr: targets.internal_ip,
+        positive_port: NETPOL_INTERNAL_SERVICE_PORT,
+        negative_addr: targets.public_ip,
+        negative_port: NETPOL_PUBLIC_SERVICE_PORT,
+        wait_secs: state.cfg.netpol_wait_secs,
+    })
 }
 
 /// Assemble the RUNNER CONTAINER's env. The generic FLUIDBOX_* block is the

--- a/crates/fluidbox-server/src/state.rs
+++ b/crates/fluidbox-server/src/state.rs
@@ -238,6 +238,16 @@ pub struct AppStateInner {
     /// NetworkPolicy. `create_run` refuses while false + require_enforced_netpol
     /// (fails closed). Always true for Docker (a different isolation model).
     pub netpol_verified: std::sync::atomic::AtomicBool,
+    /// The netpol gate's resolved probe targets (internal/public Service
+    /// ClusterIPs), stored by the gate worker BEFORE each verification so a
+    /// `netpol_verified=true` gate implies targets are present. The
+    /// orchestrator freezes them into every sandbox's `NetworkAdmission` —
+    /// the per-pod startup-isolation gate observes the same two targets the
+    /// certification probe did. Never cleared once set (ClusterIPs are stable
+    /// for a Service's lifetime); on lock poisoning readers fail toward None,
+    /// which the k8s provider REFUSES fail-closed when enforcement is
+    /// required.
+    pub netpol_targets: std::sync::RwLock<Option<NetpolTargets>>,
     /// OIDC login runtime: the generation-keyed JWKS cache (singleflight
     /// refresh + negative-kid cache) and the fixed-window login rate counters.
     /// In-memory, single-replica (v1); a restart re-seeds from the DB caches.
@@ -266,3 +276,13 @@ pub struct AppStateInner {
 }
 
 pub type AppState = Arc<AppStateInner>;
+
+/// The two netpol probe targets, as resolved by the gate worker: the internal
+/// Service ClusterIP (positive — must be reachable from a sandbox) and the
+/// public Service ClusterIP (negative — must be blocked). Ports are the
+/// chart-fixed Service ports (8788/8787), applied where these are consumed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetpolTargets {
+    pub internal_ip: String,
+    pub public_ip: String,
+}

--- a/crates/fluidbox-server/src/workers.rs
+++ b/crates/fluidbox-server/src/workers.rs
@@ -816,18 +816,33 @@ pub fn spawn_netpol_gate(state: AppState) {
                     .flatten();
             match (internal_ip, public_ip) {
                 (Some(i), Some(p)) => {
+                    // Publish the targets BEFORE probing: a verified gate must
+                    // imply targets are present, because the orchestrator
+                    // freezes them into every sandbox's `NetworkAdmission`
+                    // (the per-pod startup-isolation gate observes the same
+                    // pair the certification probe does).
+                    if let Ok(mut t) = state.netpol_targets.write() {
+                        *t = Some(crate::state::NetpolTargets {
+                            internal_ip: i.clone(),
+                            public_ip: p.clone(),
+                        });
+                    }
                     let r = fluidbox_provider_k8s::netpol::verify_netpol(
                         &k8s_cfg,
                         &state.cfg.netpol_probe_image,
                         &i,
                         &p,
+                        state.cfg.netpol_wait_secs,
                     )
                     .await;
                     use fluidbox_provider_k8s::netpol::NetpolResult;
                     let ok = r == NetpolResult::Enforced;
                     state.netpol_verified.store(ok, Ordering::SeqCst);
                     if ok {
-                        tracing::info!("netpol gate: enforcement verified (+:8788 -:8787)");
+                        tracing::info!(
+                            "netpol gate: enforcement verified (+:8788 -:8787, observed within {}s)",
+                            state.cfg.netpol_wait_secs
+                        );
                     } else {
                         tracing::warn!("netpol gate: NOT verified ({r:?}) — runs blocked");
                     }

--- a/deploy/helm/fluidbox/templates/server.yaml
+++ b/deploy/helm/fluidbox/templates/server.yaml
@@ -184,6 +184,7 @@ spec:
             - { name: FLUIDBOX_NETWORK_MODE, value: "hardened" }
             - { name: FLUIDBOX_REQUIRE_ENFORCED_NETPOL, value: {{ .Values.netpol.requireEnforced | quote }} }
             - { name: FLUIDBOX_NETPOL_PROBE_IMAGE, value: {{ .Values.netpol.probeImage | quote }} }
+            - { name: FLUIDBOX_NETPOL_WAIT_SECS, value: {{ .Values.netpol.waitSeconds | quote }} }
             # Boot-resolve the internal Service ClusterIP → the runner's
             # control URL (no DNS under zeroEgress).
             - { name: FLUIDBOX_INTERNAL_SERVICE, value: {{ include "fluidbox.internalServiceName" . | quote }} }

--- a/deploy/helm/fluidbox/templates/tests/netpol-probe.yaml
+++ b/deploy/helm/fluidbox/templates/tests/netpol-probe.yaml
@@ -209,6 +209,9 @@ metadata:
 spec:
   restartPolicy: Never
   automountServiceAccountToken: false
+  # The script self-terminates at netpol.waitSeconds; this only adds
+  # scheduling/pull slack so a still-observing probe is never killed early.
+  activeDeadlineSeconds: {{ add .Values.netpol.waitSeconds 60 }}
   {{- with .Values.sandbox.runtimeClassName }}
   runtimeClassName: {{ . }}
   {{- end }}
@@ -245,22 +248,33 @@ spec:
           valueFrom: { configMapKeyRef: { name: {{ $targetsCm }}, key: publicIp } }
       command: ["/bin/sh", "-c"]
       args:
+        # The bounded observation loop (same protocol as the server's boot
+        # probe and the per-sandbox netpol-gate init container): a fresh pod's
+        # policy may land ASYNCHRONOUSLY (AWS VPC CNI `standard` mode fails
+        # open for its first seconds), so a t=0 sample measures the
+        # unprogrammed network and false-fails a healthy cluster. Poll until
+        # BOTH assertions hold in the SAME observation; fail closed at the
+        # deadline with the reason last observed.
         - |
           set -u
           if [ -z "$INT_IP" ] || [ -z "$PUB_IP" ]; then
             echo "FAIL: probe targets unresolved (resolver Job did not publish)"; exit 1
           fi
-          echo "probe: internal=$INT_IP:8788  public=$PUB_IP:8787"
-          # POSITIVE: the internal listener must be reachable.
-          if nc -z -w 4 "$INT_IP" 8788; then
-            echo "OK positive: internal :8788 reachable"
-          else
-            echo "FAIL positive: internal :8788 UNREACHABLE (egress policy too tight, or server down)"; exit 1
-          fi
-          # NEGATIVE: the public listener must be BLOCKED by NetworkPolicy.
-          if nc -z -w 4 "$PUB_IP" 8787; then
-            echo "FAIL negative: public :8787 REACHABLE — the CNI is NOT enforcing NetworkPolicy"; exit 1
-          else
-            echo "OK negative: public :8787 blocked (policy enforced)"
-          fi
-          echo "PASS: NetworkPolicy enforced (+:8788 -:8787)"
+          echo "probe: internal=$INT_IP:8788  public=$PUB_IP:8787 (observing up to {{ .Values.netpol.waitSeconds }}s)"
+          end=$(( $(date +%s) + {{ .Values.netpol.waitSeconds }} )); i=0
+          while :; do
+            i=$((i+1)); pos=fail; neg=blocked
+            nc -z -w 2 "$INT_IP" 8788 && pos=ok
+            nc -z -w 2 "$PUB_IP" 8787 && neg=open
+            echo "obs $i t=$(date +%s) pos=$pos neg=$neg"
+            if [ "$pos" = ok ] && [ "$neg" = blocked ]; then
+              echo "PASS: NetworkPolicy enforced (+:8788 -:8787, observation $i)"; exit 0
+            fi
+            if [ $(date +%s) -ge $end ]; then
+              if [ "$neg" = open ]; then
+                echo "FAIL negative: public :8787 still REACHABLE after {{ .Values.netpol.waitSeconds }}s — the CNI is NOT enforcing NetworkPolicy"; exit 1
+              fi
+              echo "FAIL positive: internal :8788 still UNREACHABLE after {{ .Values.netpol.waitSeconds }}s (egress policy too tight, or server down)"; exit 1
+            fi
+            sleep 1
+          done

--- a/deploy/helm/fluidbox/values.yaml
+++ b/deploy/helm/fluidbox/values.yaml
@@ -313,6 +313,16 @@ sandbox:
 # cluster without the VPC CNI network-policy agent) blocks runs by design.
 netpol:
   requireEnforced: true
+  # Bounded observation window (seconds) for enforcement: the boot probe, the
+  # helm-test probe and every sandbox's netpol-gate init container POLL
+  # "internal :8788 reachable AND public :8787 blocked" until this deadline
+  # before failing closed. Needed because some CNIs program NetworkPolicy for
+  # a new pod asynchronously and fail OPEN meanwhile (AWS VPC CNI `standard`
+  # mode: ~20s measured) — a t=0 sample measures the unprogrammed network.
+  # The wait ends at the first successful observation; this is a deadline on
+  # observations, not a delay. Must stay well under sandbox init grace
+  # (FLUIDBOX_K8S_INIT_GRACE_SECS, default 300).
+  waitSeconds: 60
   # The probe image (needs a TCP client; busybox has nc/wget).
   probeImage: busybox:1.36
   # The helm-test resolver image (needs curl + a shell): reads the two Service

--- a/docs/reviews/k8s-network-admission-validation.md
+++ b/docs/reviews/k8s-network-admission-validation.md
@@ -1,0 +1,289 @@
+# Kubernetes network-enforcement admission race — fix + two-environment validation
+
+**Date:** 2026-07-29 · **Branch:** `feat/k8s-network-admission-gate`
+**Commits:** `f81aae7` (fix + unit regressions); validation harness + this
+report land as the branch's second commit.
+**Author:** validation run driven by Claude (Fable 5), evidence inline.
+
+## 1. The defect
+
+Measured on a real EKS 1.33 cluster on 2026-07-28 (`docs/reviews/2026-07-27-pr92-two-environment-validation.md` §8c)
+and root-caused in code this run:
+
+1. **The certification probe raced and always lost.** `verify_netpol`
+   (`crates/fluidbox-provider-k8s/src/netpol.rs`) created a probe pod whose
+   script sampled its two assertions exactly once, at container t=0. The AWS
+   VPC CNI in `standard` enforcing mode programs NetworkPolicy for a NEW pod
+   asynchronously (~20 s measured) and **fails open** meanwhile. Every gate
+   worker retry created a *fresh* pod that re-entered the same window, so the
+   boot gate could never pass on `scripts/eks-cluster.yaml` and every
+   `POST /v1/sessions` answered 503 — no run could ever be created on EKS.
+2. **Real sandbox workloads were exposed, not just the probe.** A sandbox pod
+   is also a fresh pod: its containers start inside the same fail-open window,
+   which means the untrusted `runner` container could execute with
+   **unrestricted egress for its first seconds** — the exact property the
+   boot gate exists to certify was not delivered per-pod. (Confirmed natively
+   in this run, §5 N1.)
+
+Nothing was misconfigured: the policies are correct, the nodeagent enforces.
+The probe simply did not wait, and nothing made the runner wait.
+
+## 2. The fix — a bounded, observable admission protocol
+
+No fixed sleeps anywhere; `netpol.requireEnforced` semantics untouched
+(default `true`, fails closed, `false` remains dev-only).
+
+**One shared protocol** (`netpol::enforcement_script`): poll once per second —
+positive target (internal Service `:8788`) must be **reachable** and negative
+target (public Service `:8787`) must be **blocked** — and succeed only when
+*both hold in the same observation*. Enforcement is monotonic once programmed,
+so the first such observation is proof. At the deadline
+(`FLUIDBOX_NETPOL_WAIT_SECS` / `netpol.waitSeconds`, default 60 s) it fails
+**closed** with the original exit-code contract: `3` = negative still
+reachable (`NotEnforced`), `2` = positive still unreachable
+(`Unschedulable`). Every iteration prints an `obs i t=<epoch> pos=… neg=…`
+line, so the pod log is a timestamped record of exactly what was measured.
+Both targets back the same live listener, so "blocked" is evidence of policy,
+never of a dead host.
+
+Three consumers:
+
+1. **Certification probe** (`verify_netpol`) — runs the loop instead of the
+   t=0 sample; the pod's `activeDeadlineSeconds` and the worker's wait are
+   *derived* from the window (`wait + PROBE_SCHEDULING_SLACK_SECS(60)`,
+   `+ PROBE_CALLER_SLACK_SECS(90)`) so no second, shorter clock can kill a
+   still-observing probe. On failure the probe's observation log tail is
+   surfaced in the server log.
+2. **Per-sandbox admission gate** — a new `netpol-gate` init container,
+   **first** in every sandbox pod when the deployment requires enforcement.
+   By the kubelet's init-container ordering the untrusted `runner` (and even
+   the trusted workspace fetch) cannot start until the pod's *own* network is
+   observed enforced. Targets are frozen per run
+   (`SandboxSpec.network_admission: Option<NetworkAdmission>`) from the same
+   ClusterIP pair the certification probe verified — stored by the gate
+   worker *before* each probe, so a verified gate implies targets exist. On
+   deadline the init container exits non-zero → the pod fails →
+   `runner_status` maps it to a terminated sandbox (`init:` reason) → the run
+   fails closed at zero model spend.
+3. **`helm test` probe** — same loop (it had the same t=0 race, previously
+   noted as "helm-test probe false-negatives on standard-mode fail-open").
+
+**Defense in depth:** the provider itself refuses to provision an
+enforcement-required spec that carries no admission targets
+(`require_network_admission` in `crates/fluidbox-provider-k8s/src/lib.rs`),
+so a control-plane wiring bug cannot silently skip the gate. The provider
+reads the same `FLUIDBOX_REQUIRE_ENFORCED_NETPOL` env the server does, with a
+pinned-equal falsey parse.
+
+**What still gates runs:** `create_run` continues to 503 until the
+certification probe passes (unchanged); the per-pod gate closes the residual
+per-pod window that certification could never speak for.
+
+### Files touched
+
+| Area | Change |
+|---|---|
+| `fluidbox-core/src/traits.rs` | `NetworkAdmission` + `SandboxSpec.network_admission` |
+| `fluidbox-provider-k8s/src/netpol.rs` | `enforcement_script`, convergence probe, derived deadlines, log-tail surfacing |
+| `fluidbox-provider-k8s/src/manifest.rs` | `netpol-gate` first init container (conditional) |
+| `fluidbox-provider-k8s/src/lib.rs` | provision refusal without admission targets |
+| `fluidbox-provider-k8s/src/config.rs` | `netpol_probe_image`, mirrored `require_enforced_netpol` |
+| `fluidbox-server/src/{config,state,workers,orchestrator,main}.rs` | `FLUIDBOX_NETPOL_WAIT_SECS`, target storage, freezing `NetworkAdmission` |
+| `deploy/helm/fluidbox/{values.yaml,templates/server.yaml,templates/tests/netpol-probe.yaml}` | `netpol.waitSeconds`, env wiring, helm-test convergence |
+| `crates/fluidbox-provider-k8s/examples/netpol_fixtures.rs` | fixture generator: validation runs the production bytes |
+| `scripts/netpol-admission-validation.sh` | kind + Calico regression harness |
+| `scripts/netpol-admission-eks-validation.sh` | EKS native-race validation + teardown/audit |
+
+### Regression tests (unit)
+
+- `netpol::tests::enforcement_script_is_a_bounded_convergence_loop` — pins
+  loop-not-sample, same-observation success, deadline-not-sleep, observation
+  lines, exit codes.
+- `netpol::tests::probe_pod_deadline_contains_the_observation_window` — the
+  pod clock strictly contains the window (derived, not magic).
+- `manifest::tests::network_admission_gate_is_the_first_init_container` —
+  placement before `workspace-init`, real script against frozen targets,
+  restricted-PSS compliance, no tokens/volumes/env in the gate.
+- `manifest::tests::no_admission_means_no_gate_container` — dev-posture pod
+  shape byte-stable.
+- `lib::tests::provision_refuses_enforcement_required_spec_without_admission`.
+- `config::tests::enforced_flag_parses_like_the_server`.
+
+All 576 unit tests in the three touched crates pass; `cargo clippy
+--workspace --all-targets` clean; chart `helm lint` clean.
+
+## 3. Validation topology (both environments)
+
+The network layer is validated in isolation from the fluidbox control plane —
+what EKS/kind add over unit tests is *CNI behavior*, so the stand-ins keep
+everything else constant:
+
+- Namespace `fbxval` — a stand-in "server" pod carrying the chart's exact
+  Service selector labels (`app.kubernetes.io/name: fluidbox`,
+  `component: server`) with busybox `httpd` listeners on **both** 8787 and
+  8788, fronted by two ClusterIP Services. Reachability of both ports is
+  therefore known independently of policy.
+- Namespace `fbxval-sandboxes` — created from the **chart-rendered**
+  `templates/sandbox.yaml` (`helm template … -s templates/sandbox.yaml`), so
+  `fluidbox-sandbox-default-deny` + `fluidbox-sandbox-egress` are the
+  production policy bytes (restricted PSA labels included; quota off as
+  orthogonal).
+- Sandbox pods are generated by
+  `cargo run -p fluidbox-provider-k8s --example netpol_fixtures sandbox-pod`,
+  i.e. the production `build_pod` output (gate placement, env routing,
+  security baseline). Stubbed for the harness: non-gate images/commands →
+  busybox scripts, runner resources shrunk; the `netpol-gate` container is
+  byte-identical to production. The runner stub is the adversary: its **first
+  instruction** attempts the forbidden egress a hostile agent would.
+- Probe pods likewise via `… netpol_fixtures probe-pod` (production
+  `build_probe_pod`).
+
+## 4. kind + Calico (enforcing CNI) — results
+
+Cluster: `fbx-netadm-val`, kind v1.36.1 node, Calico v3.28.0, colima/docker
+(arm64). Calico programs policy for new pods fast and fails **closed**, so
+the EKS race does not occur natively — phases B/C/D *simulate* it by creating
+pods while the two NetworkPolicies are deleted (an unpoliced namespace is the
+fail-open analog) and applying them seconds later.
+
+**ALL 12 ASSERTIONS PASSED** (`SCRIPT_EXIT=0`). Wall time ≈ 9 min including
+cluster create + delete. Targets: internal `10.96.12.177:8788`, public
+`10.96.108.16:8787`.
+
+| # | Assertion | Result |
+|---|---|---|
+| A1–A5 | Steady state ×5: gate admits, forbidden blocked, allowed works | PASS ×5 — 12–13 s pod end-to-end, gate passed on its **first** observation every time; runner reported `public:8787=blocked internet:443=blocked internal:8788=ok` |
+| B0 | Vulnerability reproduced: pre-fix pod (no gate) in the unpoliced window | PASS — runner's first instruction reported `public:8787=OPEN internet:443=OPEN` |
+| B1–B3 | Race ×3: pod created before policy; gate must hold the runner | PASS ×3 — gate observed the open network 8× each run, runner stayed `PodInitializing`, `startedAt ≥ policy-apply` (e.g. 1785303999 ≥ 1785303995), then all egress blocked |
+| C-old | Pre-fix probe under late policy | PASS — `Failed`/exit 3, the measured EKS-503 cause reproduced on kind |
+| C-new | Shipped probe, identical conditions | PASS — converged in 14 s after observing the open network 10× |
+| D | Bound: policy never applied | PASS — exit 3 at the 15 s test window (18 s total), no hang, no runner start |
+
+The B1 gate log — the observable protocol end to end (policies applied at
+epoch `…995`):
+
+```
+obs 8 t=1785303994 pos=ok neg=open      ← still fail-open
+obs 9 t=1785303997 pos=ok neg=blocked   ← enforcement observed (≤2 s after apply)
+enforced
+runner startedAt epoch: 1785303999 (policies applied: 1785303995)
+runner: forbidden public:8787=blocked internet:443=blocked allowed internal:8788=ok
+```
+
+## 5. EKS + VPC CNI standard mode (native race) — results
+
+Two ephemeral clusters, both uniquely named/tagged
+(`fluidbox-ephemeral=true`, `fluidbox-validation=k8s-network-admission`,
+`fluidbox-run-id=<id>`), account `471112572248`, `us-east-1`, EKS 1.33,
+AL2023 arm64 node, vpc-cni addon with `enableNetworkPolicy: "true"`
+(`aws-eks-nodeagent` verified present), default `standard` enforcing mode.
+The account had **zero** pre-existing EKS clusters; identity was inspected
+read-only before any mutation, and the scripts touch only their own cluster.
+
+- **Run 1** `fbx-netadm-07290046` (~01:00–01:45 UTC-5): all phases failed on
+  `FailedScheduling: Insufficient memory` — a **harness sizing defect**, not a
+  protocol result: the chart's LimitRange assigned its 1 Gi default request to
+  the un-stubbed containers, which cannot fit a t4g.small (kind's 12 Gi node
+  had hidden this). The run still proved the teardown machinery: trap fired,
+  cluster deleted, audit clean.
+- **Run 2** `fbx-netadm-07290125` (~01:25–02:00): harness fixed (explicit tiny
+  resources on stubs + probe pods; t4g.medium). **ALL 9 ASSERTIONS PASSED**,
+  `EKS_SCRIPT_EXIT=0`.
+
+| # | Assertion | Result |
+|---|---|---|
+| N1 ×2 | **Determination**: does the native fail-open window expose a real (pre-fix-shaped) sandbox workload? | PASS ×2 — **yes**: the runner's own first instruction saw `public:8787=OPEN internet:443=OPEN` at its t=0 sample, blocked ~1 s later |
+| N2 ×3 | The fix on the native race: production gated pod | PASS ×3 — gate observed the open network (obs 1–2 `neg=open`), enforcement at obs 3 (~4 s), runner then found all forbidden egress blocked and the allowed path working |
+| N3 ×2 | Certification, old vs new | PASS — the pre-fix probe **failed exit 3 natively both times** (`pos-ok` then `neg-fail`; the deterministic cause of "every `POST /v1/sessions` is 503"), while the shipped probe certified in 11 s over 3 observations |
+
+The N2.1 gate log — the native VPC CNI fail-open, observed and closed:
+
+```
+obs 1 t=1785307414 pos=ok neg=open      ← fail-open window, live
+obs 2 t=1785307415 pos=ok neg=open
+obs 3 t=1785307418 pos=ok neg=blocked   ← policy programmed
+enforced
+runner: forbidden public:8787=blocked internet:443=blocked allowed internal:8788=ok
+```
+
+**On window length:** 2026-07-28's measurement saw ~20 s; this idle
+single-node cluster showed ~1–4 s. The duration varies with node/nodeagent
+state and policy count — AWS's contract is only "applied eventually", with no
+bound. That is precisely why the fix is an *observation* protocol rather than
+any timing assumption: the gate converts an exposure of unbounded-by-contract
+duration into a bounded, evidenced admission, and stays correct at 1 s or 20 s.
+
+## 6. Limitations, residuals, honesty
+
+- **kind simulates the race** (policy applied late) rather than exhibiting
+  VPC CNI's asynchronous programming; the EKS phases cover the native
+  behavior. Calico's own new-pod window is fail-closed, which the gate
+  tolerates by design (positive-unreachable observations until programmed).
+- **The gate observes the Service VIP path** (ClusterIP DNAT → server pod),
+  the same path the runner uses; it does not observe arbitrary destinations.
+  The negative external canary (1.1.1.1:443) is asserted from the runner
+  stub in validation, not by the shipped gate — the shipped negative target
+  (live listener, port-scoped deny) is chosen precisely so "blocked" cannot
+  be explained by a dead host.
+- **A pod-restart of the runner container does not re-run init containers**
+  (`restartPolicy: Never` makes this moot for sandbox pods — the pod never
+  restarts containers).
+- **`requireEnforced=false` deployments get no gate**, exactly as before —
+  the flag remains the documented dev-only escape and is not weakened; the
+  EKS values keep `requireEnforced: true` and the 2026-07-28 workaround note
+  (`netpol.requireEnforced=false`) is now obsolete.
+- **Window length is environment-dependent**: 60 s default covers the ~20 s
+  measured EKS window 3×; a pathological CNI slower than the window fails
+  closed (correct direction) and the knob is per-deployment.
+- **Cross-knob bound not machine-checked**: `netpol.waitSeconds` must stay
+  under `FLUIDBOX_K8S_INIT_GRACE_SECS` (default 300); documented in
+  values.yaml, not asserted at boot.
+- **The N1 winprobe samples at 1 Hz**, so a sub-second window would be
+  under-sampled; the observed `OPEN` samples are a floor on exposure, not a
+  precise duration. (Old-probe exit-3s in N3 independently confirm the window
+  from a second vantage.)
+- **In-flight sandbox pods** launched before this change carry no gate; the
+  gate applies from the next provisioned run onward (RunSpec immutability is
+  untouched — admission targets are frozen per new run).
+- **The runner-shape validation stubs images/commands** of the non-gate
+  containers (documented in §3); placement, env routing, security context and
+  the gate container itself are the production bytes.
+
+## 7. Teardown verification
+
+Both clusters torn down by the script's EXIT trap (run 1's fired after a
+deliberate failure — proving teardown-on-failure), then audited:
+
+- `eksctl` CloudFormation stacks (`…-cluster`, `…-nodegroup-ng-1`):
+  **DELETE_COMPLETE** both runs; no `DELETE_FAILED` retries needed — the two
+  known EKS leak sweeps (detached VPC-CNI ENIs; the out-of-CFN
+  `eks-cluster-sg-*`) found nothing to sweep this time but remain in the trap.
+- VPCs `vpc-0503d5e9f21f81fbb` / `vpc-0ed306a9441f321f3`: **gone** (describe
+  returns nothing); zero ENIs remained in either.
+- NAT gateways `nat-0a5d6a754cc4f0d74` / `nat-0f3af12ddfb486bc0`: state
+  **deleted**; their EIPs released (zero unattached EIPs account-wide).
+- Nodes/volumes: instances **terminated**, volumes **InvalidVolume.NotFound**.
+- Resource Groups Tagging API listed 4 ARNs per run post-delete
+  (instance/ENI/volume/NAT); each was directly verified
+  terminated/NotFound/deleted — **eventual-consistency index ghosts, zero
+  live residue**.
+- Final account-wide sweep: `aws eks list-clusters` **empty**; no
+  `fbx-netadm*` stacks in any live status; no `fluidbox-ephemeral`-tagged
+  VPCs; no unattached EIPs.
+
+**Cost**: ≈1.4 cluster-hours total across both runs ≈ **$0.35** (control
+plane $0.14, NAT ~$0.11, nodes ~$0.05, EIP/data cents) — against the $40 cap.
+
+## 8. Reproduction commands
+
+```bash
+# unit + shape regressions
+cargo test -p fluidbox-provider-k8s -p fluidbox-core -p fluidbox-server
+
+# kind (enforcing CNI) — creates/deletes cluster fbx-netadm-val
+scripts/netpol-admission-validation.sh          # --keep to retain
+
+# EKS (native VPC CNI race) — creates a uniquely-tagged ephemeral cluster,
+# validates, then tears down + audits to empty. ≈$0.20/h while up.
+scripts/netpol-admission-eks-validation.sh
+```

--- a/scripts/netpol-admission-eks-validation.sh
+++ b/scripts/netpol-admission-eks-validation.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# EKS validation of the netpol startup-admission protocol against the REAL
+# AWS VPC CNI `standard`-mode fail-open behavior (the race is NATIVE here —
+# no simulation: every fresh pod's policy is programmed asynchronously).
+#
+# Phases (stand-in topology, chart-rendered policies, production fixtures —
+# same as scripts/netpol-admission-validation.sh):
+#   N1 (determination): a PRE-FIX-shaped pod (no gate) whose runner samples
+#      forbidden egress once per second from its own t=0 — measuring whether
+#      the fail-open window exposes REAL sandbox workloads (not just the
+#      certification probe) and how long it lasts.
+#   N2 (fix): the production gated pod — the netpol-gate must observe the
+#      open network, hold the runner, release only after enforcement; the
+#      runner's first instruction must find egress blocked.
+#   N3 (certification): the OLD one-sample probe fails closed (the measured
+#      cause of "every POST /v1/sessions is 503 on EKS"); the NEW bounded
+#      observation probe converges and Succeeds.
+#
+# Safety: everything lives in ONE uniquely-named eksctl cluster tagged
+# fluidbox-ephemeral=true + fluidbox-validation=k8s-network-admission.
+# Teardown runs on EXIT (even on failure): eksctl delete + the two known
+# EKS leak sweeps (detached VPC-CNI ENIs; the EKS-created cluster SG that is
+# created OUTSIDE CloudFormation and otherwise holds the VPC), then an audit
+# that must come back empty.
+#
+# Cost envelope: control plane $0.10/h + 1× t4g.small $0.0168/h + single NAT
+# $0.045/h ⇒ ≈$0.17/h; a full run is ~1h ⇒ well under $1 (hard cap $40).
+set -euo pipefail
+
+REGION="${REGION:-us-east-1}"
+RUN_ID="${RUN_ID:-$(date +%m%d%H%M)}"
+CLUSTER="fbx-netadm-${RUN_ID}"
+NS_CTRL=fbxval
+NS_SANDBOX=fbxval-sandboxes
+BUSYBOX=busybox:1.36
+WAIT_SECS=60
+LOG_DIR="${NETPOL_VAL_LOG_DIR:-$(mktemp -d /tmp/netpol-eks.XXXXXX)}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0; declare -a RESULTS=()
+SKIP_TEARDOWN="${SKIP_TEARDOWN:-0}"
+
+say()  { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+pass() { PASS=$((PASS+1)); RESULTS+=("PASS  $1"); printf '  \033[1;32mPASS\033[0m %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); RESULTS+=("FAIL  $1"); printf '  \033[1;31mFAIL\033[0m %s\n' "$1"; }
+
+for tool in aws eksctl kubectl helm jq cargo python3; do
+  command -v "$tool" >/dev/null || { echo "missing: $tool"; exit 1; }
+done
+
+say "preflight: identity + existing clusters (read-only)"
+aws sts get-caller-identity --output json | tee "$LOG_DIR/identity.json"
+EXISTING=$(aws eks list-clusters --region "$REGION" --query 'clusters' --output text)
+echo "existing clusters in $REGION: ${EXISTING:-<none>} (this run creates '$CLUSTER' and touches ONLY it)"
+
+say "building production fixtures"
+cargo build -q -p fluidbox-provider-k8s --example netpol_fixtures
+FIX="$ROOT/target/debug/examples/netpol_fixtures"
+
+# ── teardown + audit, guaranteed on exit ────────────────────────────────────
+VPC_ID=""
+teardown() {
+  local rc=$?
+  set +e
+  if [ "$SKIP_TEARDOWN" = 1 ]; then
+    echo "SKIP_TEARDOWN=1 — cluster '$CLUSTER' LEFT RUNNING (delete with: eksctl delete cluster --name $CLUSTER --region $REGION)"
+    exit $rc
+  fi
+  say "TEARDOWN (always runs; exit code was $rc)"
+  # No kubectl pre-clean: this validation creates no Services of type LB and
+  # no PVCs, so nothing in the namespaces holds cloud resources — and a bare
+  # kubectl here would hit whatever the CURRENT context is, which is unsafe
+  # if another validation run switched it. The cluster delete removes it all.
+  eksctl delete cluster --name "$CLUSTER" --region "$REGION" --disable-nodegroup-eviction --wait 2>&1 | tail -8
+
+  # Known leak #1: detached VPC-CNI ENIs (GC race) hold subnets → DELETE_FAILED.
+  if [ -n "$VPC_ID" ]; then
+    for eni in $(aws ec2 describe-network-interfaces --region "$REGION" \
+        --filters "Name=vpc-id,Values=$VPC_ID" "Name=status,Values=available" \
+        --query 'NetworkInterfaces[].NetworkInterfaceId' --output text 2>/dev/null); do
+      echo "sweeping detached ENI $eni"
+      aws ec2 delete-network-interface --region "$REGION" --network-interface-id "$eni"
+    done
+    # Known leak #2: the EKS-created cluster SG (created outside CFN, holds the VPC).
+    for sg in $(aws ec2 describe-security-groups --region "$REGION" \
+        --filters "Name=vpc-id,Values=$VPC_ID" "Name=group-name,Values=eks-cluster-sg-${CLUSTER}-*" \
+        --query 'SecurityGroups[].GroupId' --output text 2>/dev/null); do
+      echo "sweeping cluster SG $sg"
+      aws ec2 delete-security-group --region "$REGION" --group-id "$sg"
+    done
+    # If the VPC stack went DELETE_FAILED because of the above, retry it.
+    for st in $(aws cloudformation list-stacks --region "$REGION" \
+        --stack-status-filter DELETE_FAILED \
+        --query "StackSummaries[?contains(StackName,'$CLUSTER')].StackName" --output text 2>/dev/null); do
+      echo "retrying DELETE_FAILED stack $st"
+      aws cloudformation delete-stack --region "$REGION" --stack-name "$st"
+      aws cloudformation wait stack-delete-complete --region "$REGION" --stack-name "$st"
+    done
+  fi
+
+  say "AUDIT — every line below must be empty"
+  {
+    echo "-- resources tagged fluidbox-run-id=$RUN_ID:"
+    aws resourcegroupstaggingapi get-resources --region "$REGION" \
+      --tag-filters "Key=fluidbox-run-id,Values=$RUN_ID" \
+      --query 'ResourceTagMappingList[].ResourceARN' --output text
+    echo "-- CFN stacks *$CLUSTER* (any status but DELETE_COMPLETE):"
+    aws cloudformation list-stacks --region "$REGION" \
+      --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE DELETE_FAILED DELETE_IN_PROGRESS ROLLBACK_COMPLETE \
+      --query "StackSummaries[?contains(StackName,'$CLUSTER')].[StackName,StackStatus]" --output text
+    if [ -n "$VPC_ID" ]; then
+      echo "-- VPC $VPC_ID (must be gone):"
+      aws ec2 describe-vpcs --region "$REGION" --vpc-ids "$VPC_ID" \
+        --query 'Vpcs[].VpcId' --output text 2>/dev/null
+      echo "-- ENIs in $VPC_ID:"
+      aws ec2 describe-network-interfaces --region "$REGION" \
+        --filters "Name=vpc-id,Values=$VPC_ID" \
+        --query 'NetworkInterfaces[].NetworkInterfaceId' --output text 2>/dev/null
+    fi
+    echo "-- NAT gateways for the cluster:"
+    aws ec2 describe-nat-gateways --region "$REGION" \
+      --filter "Name=state,Values=available,pending" \
+      --query "NatGateways[?Tags[?Key=='fluidbox-run-id'&&Value=='$RUN_ID']].NatGatewayId" --output text
+    echo "-- unattached EIPs tagged with the run:"
+    aws ec2 describe-addresses --region "$REGION" \
+      --query "Addresses[?AssociationId==null] | [?Tags[?Key=='fluidbox-run-id'&&Value=='$RUN_ID']].AllocationId" --output text
+    echo "-- EKS clusters remaining:"
+    aws eks list-clusters --region "$REGION" --query 'clusters[?contains(@,`fbx-netadm`)]' --output text
+  } | tee "$LOG_DIR/teardown-audit.txt"
+  exit $rc
+}
+trap teardown EXIT
+
+say "creating ephemeral cluster '$CLUSTER' (~15 min; every resource tagged fluidbox-run-id=$RUN_ID)"
+cat > "$LOG_DIR/cluster.yaml" <<YAML
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: $CLUSTER
+  region: $REGION
+  version: "1.33"
+  tags:
+    fluidbox-ephemeral: "true"
+    fluidbox-validation: k8s-network-admission
+    fluidbox-run-id: "$RUN_ID"
+availabilityZones: [us-east-1b, us-east-1c]
+vpc:
+  nat: { gateway: Single }
+addons:
+  - name: vpc-cni
+    configurationValues: |-
+      enableNetworkPolicy: "true"
+  - name: kube-proxy
+  - name: coredns
+managedNodeGroups:
+  - name: ng-1
+    amiFamily: AmazonLinux2023
+    # t4g.medium: the validation pods are tiny, but ~1.3Gi allocatable on
+    # t4g.small left no headroom over the EKS daemonsets + addons.
+    instanceType: t4g.medium
+    availabilityZones: [us-east-1b]
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 1
+    volumeSize: 20
+    volumeType: gp3
+    tags:
+      fluidbox-ephemeral: "true"
+      fluidbox-run-id: "$RUN_ID"
+YAML
+eksctl create cluster -f "$LOG_DIR/cluster.yaml" 2>&1 | tail -12
+
+say "resource inventory (post-create)"
+VPC_ID=$(aws eks describe-cluster --region "$REGION" --name "$CLUSTER" \
+  --query 'cluster.resourcesVpcConfig.vpcId' --output text)
+{
+  echo "run-id: $RUN_ID  cluster: $CLUSTER  vpc: $VPC_ID  region: $REGION"
+  echo "-- CFN stacks:"
+  aws cloudformation list-stacks --region "$REGION" --stack-status-filter CREATE_COMPLETE \
+    --query "StackSummaries[?contains(StackName,'$CLUSTER')].StackName" --output text
+  echo "-- tagged resources:"
+  aws resourcegroupstaggingapi get-resources --region "$REGION" \
+    --tag-filters "Key=fluidbox-run-id,Values=$RUN_ID" \
+    --query 'ResourceTagMappingList[].ResourceARN' --output text
+  echo "-- NAT:"
+  aws ec2 describe-nat-gateways --region "$REGION" \
+    --filter "Name=vpc-id,Values=$VPC_ID" --query 'NatGateways[].NatGatewayId' --output text
+  echo "-- nodes:"
+  kubectl get nodes -o wide | sed 's/^/   /'
+} | tee "$LOG_DIR/inventory.txt"
+
+say "verifying the netpol nodeagent is enforcing (standard mode)"
+kubectl -n kube-system get ds aws-node -o jsonpath='{.spec.template.spec.containers[*].name}' | tr ' ' '\n' | sed 's/^/  ds container: /'
+kubectl -n kube-system get pods -l k8s-app=aws-node -o name | head -3
+
+say "topology: stand-in server + chart-rendered policies"
+kubectl create namespace "$NS_CTRL" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+helm template fluidbox "$ROOT/deploy/helm/fluidbox" -n "$NS_CTRL" \
+  -s templates/sandbox.yaml \
+  --set sandbox.namespace="$NS_SANDBOX" \
+  --set sandbox.quota.enabled=false > "$LOG_DIR/rendered-sandbox.yaml"
+kubectl apply -f "$LOG_DIR/rendered-sandbox.yaml" >/dev/null
+kubectl -n "$NS_CTRL" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fbxval-server
+  labels: { app.kubernetes.io/name: fluidbox, app.kubernetes.io/component: server }
+spec:
+  securityContext: { runAsNonRoot: true, runAsUser: 10001, seccompProfile: { type: RuntimeDefault } }
+  containers:
+    - name: listeners
+      image: $BUSYBOX
+      command: ["/bin/sh","-c","httpd -p 8787; httpd -p 8788; exec tail -f /dev/null"]
+      securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: ["ALL"] } }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: fbxval-internal }
+spec:
+  selector: { app.kubernetes.io/name: fluidbox, app.kubernetes.io/component: server }
+  ports: [ { port: 8788, targetPort: 8788 } ]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: fbxval-public }
+spec:
+  selector: { app.kubernetes.io/name: fluidbox, app.kubernetes.io/component: server }
+  ports: [ { port: 8787, targetPort: 8787 } ]
+YAML
+kubectl -n "$NS_CTRL" wait --for=condition=Ready pod/fbxval-server --timeout=180s >/dev/null
+INT_IP=$(kubectl -n "$NS_CTRL" get svc fbxval-internal -o jsonpath='{.spec.clusterIP}')
+PUB_IP=$(kubectl -n "$NS_CTRL" get svc fbxval-public -o jsonpath='{.spec.clusterIP}')
+echo "  internal=$INT_IP:8788 public=$PUB_IP:8787  (logs: $LOG_DIR)"
+
+# Sandbox-shaped pod builder (see the kind script for the stubbing contract).
+WINDOW_PROBE='echo "winprobe: runner started t=$(date +%s)"; end=$(( $(date +%s) + 120 )); openseen=0; while :; do t=$(date +%s); p=blocked; nc -z -w 1 PUBIP 8787 && p=OPEN; w=blocked; nc -z -w 1 1.1.1.1 443 && w=OPEN; echo "winprobe t=$t public=$p internet=$w"; if [ "$p" = OPEN ] || [ "$w" = OPEN ]; then openseen=1; fi; if [ "$p" = blocked ] && [ "$w" = blocked ]; then echo "winprobe: converged t=$t openseen=$openseen"; break; fi; if [ "$t" -ge "$end" ]; then echo "winprobe: DEADLINE still-open openseen=$openseen"; break; fi; sleep 1; done; sleep 2'
+RUNNER_PROBE='echo "runner: started t=$(date +%s)"; p=blocked; nc -z -w 2 PUBIP 8787 && p=OPEN; w=blocked; nc -z -w 2 1.1.1.1 443 && w=OPEN; a=fail; nc -z -w 2 INTIP 8788 && a=ok; echo "runner: forbidden public:8787=$p internet:443=$w allowed internal:8788=$a"; sleep 2'
+sandbox_pod_json() { # $1 name, $2 with_gate (1|0), $3 runner script
+  local rs=${3//PUBIP/$PUB_IP}; rs=${rs//INTIP/$INT_IP}
+  FLUIDBOX_COLLECTOR_IMAGE="$BUSYBOX" FLUIDBOX_NETPOL_PROBE_IMAGE="$BUSYBOX" \
+    "$FIX" sandbox-pod "$INT_IP" 8788 "$PUB_IP" 8787 "$WAIT_SECS" \
+    | jq --arg name "$1" --arg rs "$rs" --arg img "$BUSYBOX" '
+        .metadata.name = $name
+        | .spec.initContainers[-1].image = $img
+        | .spec.initContainers[-1].command = ["/bin/sh","-c","echo workspace-init: stub"]
+        | .spec.initContainers[-1].env = []
+        | .spec.initContainers[-1].resources = {"requests":{"cpu":"10m","memory":"16Mi"},"limits":{"cpu":"200m","memory":"64Mi"}}
+        | .spec.containers[0].image = $img
+        | .spec.containers[0].command = ["/bin/sh","-c",$rs]
+        | .spec.containers[0].resources = {"requests":{"cpu":"50m","memory":"64Mi"},"limits":{"cpu":"500m","memory":"256Mi"}}
+        | .spec.containers[1].image = $img
+        | .spec.containers[1].command = ["/bin/sh","-c","sleep 15"]
+      ' \
+    | if [ "$2" = 1 ]; then cat; else jq 'del(.spec.initContainers[0])'; fi
+}
+wait_runner_done() { # $1 pod, $2 timeout_s
+  local end=$(( $(date +%s) + $2 ))
+  while [ "$(date +%s)" -lt "$end" ]; do
+    local st
+    st=$(kubectl -n "$NS_SANDBOX" get pod "$1" -o jsonpath='{.status.containerStatuses[?(@.name=="runner")].state.terminated.exitCode}' 2>/dev/null || true)
+    [ -n "$st" ] && return 0
+    sleep 2
+  done
+  return 1
+}
+
+say "phase N1 ×2: DETERMINATION — does the native fail-open window expose a real (pre-fix) sandbox workload?"
+for i in 1 2; do
+  POD="fbxval-n1-$i"
+  sandbox_pod_json "$POD" 0 "$WINDOW_PROBE" | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+  wait_runner_done "$POD" 200 || true
+  LOG=$(kubectl -n "$NS_SANDBOX" logs "$POD" -c runner 2>/dev/null || true)
+  echo "$LOG" > "$LOG_DIR/n1-$i.log"
+  echo "$LOG" | sed 's/^/    /' | head -30
+  OPEN_SAMPLES=$(echo "$LOG" | grep -c '=OPEN' || true)
+  if echo "$LOG" | grep -q 'converged.*openseen=1'; then
+    FIRST=$(echo "$LOG" | grep -m1 'winprobe: runner started' | sed 's/.*t=//')
+    CONV=$(echo "$LOG" | grep -m1 'winprobe: converged' | sed 's/.*t=\([0-9]*\).*/\1/')
+    pass "[N1.$i] REAL WORKLOADS AFFECTED: runner saw open egress ($OPEN_SAMPLES open sample(s)) for $((CONV-FIRST))s before policy landed"
+  elif echo "$LOG" | grep -q 'converged.*openseen=0'; then
+    pass "[N1.$i] window not observed from this pod (policy landed before runner start) — samples: $OPEN_SAMPLES open"
+  else
+    fail "[N1.$i] runner never converged: $(echo "$LOG" | tail -2 | tr '\n' ' ')"
+  fi
+  kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+done
+
+say "phase N2 ×3: THE FIX — gated production pod on the native race"
+for i in 1 2 3; do
+  POD="fbxval-n2-$i"
+  sandbox_pod_json "$POD" 1 "$RUNNER_PROBE" | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+  if ! wait_runner_done "$POD" 200; then
+    fail "[N2.$i] runner never completed"
+    kubectl -n "$NS_SANDBOX" describe pod "$POD" | tail -15
+    kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+    continue
+  fi
+  GATE_LOG=$(kubectl -n "$NS_SANDBOX" logs "$POD" -c netpol-gate 2>/dev/null || true)
+  REPORT=$(kubectl -n "$NS_SANDBOX" logs "$POD" -c runner 2>/dev/null | grep '^runner: forbidden' || true)
+  { echo "$GATE_LOG"; echo "$REPORT"; } > "$LOG_DIR/n2-$i.log"
+  OPEN_OBS=$(echo "$GATE_LOG" | grep -c 'neg=open' || true)
+  OBS=$(echo "$GATE_LOG" | grep -c '^obs' || true)
+  if echo "$GATE_LOG" | grep -q '^enforced' \
+     && echo "$REPORT" | grep -q 'public:8787=blocked' \
+     && echo "$REPORT" | grep -q 'internet:443=blocked' \
+     && echo "$REPORT" | grep -q 'internal:8788=ok'; then
+    pass "[N2.$i] gate held through $OBS observation(s) ($OPEN_OBS saw the open net), then runner egress blocked — $REPORT"
+  else
+    fail "[N2.$i] gate: $(echo "$GATE_LOG" | tail -2 | tr '\n' ' ') runner: $REPORT"
+  fi
+  kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+done
+
+say "phase N3 ×2: CERTIFICATION — old one-sample probe vs the shipped observation probe, natively"
+OLD_SCRIPT="set -u; if nc -z -w 4 $INT_IP 8788; then echo pos-ok; else echo pos-fail; exit 2; fi; if nc -z -w 4 $PUB_IP 8787; then echo neg-fail; exit 3; else echo neg-ok; fi; echo enforced"
+for i in 1 2; do
+  # old
+  POD="fbxval-n3-old-$i"
+  FLUIDBOX_NETPOL_PROBE_IMAGE="$BUSYBOX" "$FIX" probe-pod "$POD" "$BUSYBOX" "$INT_IP" 8788 "$PUB_IP" 8787 "$WAIT_SECS" \
+    | jq --arg s "$OLD_SCRIPT" --arg n "$POD" '.metadata.name=$n | .spec.containers[0].command=["/bin/sh","-c",$s] | .spec.containers[0].resources = {"requests":{"cpu":"10m","memory":"16Mi"},"limits":{"cpu":"200m","memory":"64Mi"}}' \
+    | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+  for _ in $(seq 1 60); do
+    PHASE=$(kubectl -n "$NS_SANDBOX" get pod "$POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    [ "$PHASE" = "Failed" ] || [ "$PHASE" = "Succeeded" ] && break
+    sleep 2
+  done
+  CODE=$(kubectl -n "$NS_SANDBOX" get pod "$POD" -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || true)
+  kubectl -n "$NS_SANDBOX" logs "$POD" > "$LOG_DIR/n3-old-$i.log" 2>/dev/null || true
+  if [ "$PHASE" = "Failed" ] && { [ "$CODE" = "3" ] || [ "$CODE" = "2" ]; }; then
+    pass "[N3.$i-old] pre-fix probe races and loses natively: phase=$PHASE exit=$CODE (the 503 cause)"
+  elif [ "$PHASE" = "Succeeded" ]; then
+    pass "[N3.$i-old] pre-fix probe got lucky this round (policy landed first) — phase=$PHASE (race, not determinism)"
+  else
+    fail "[N3.$i-old] unexpected: phase=$PHASE exit=$CODE"
+  fi
+  kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+
+  # new
+  POD="fbxval-n3-new-$i"
+  T0=$(date +%s)
+  FLUIDBOX_NETPOL_PROBE_IMAGE="$BUSYBOX" "$FIX" probe-pod "$POD" "$BUSYBOX" "$INT_IP" 8788 "$PUB_IP" 8787 "$WAIT_SECS" \
+    | jq --arg n "$POD" '.metadata.name=$n | .spec.containers[0].resources = {"requests":{"cpu":"10m","memory":"16Mi"},"limits":{"cpu":"200m","memory":"64Mi"}}' \
+    | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+  for _ in $(seq 1 80); do
+    PHASE=$(kubectl -n "$NS_SANDBOX" get pod "$POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    [ "$PHASE" = "Failed" ] || [ "$PHASE" = "Succeeded" ] && break
+    sleep 2
+  done
+  T1=$(date +%s)
+  LOGS=$(kubectl -n "$NS_SANDBOX" logs "$POD" 2>/dev/null || true); echo "$LOGS" > "$LOG_DIR/n3-new-$i.log"
+  OBS=$(echo "$LOGS" | grep -c '^obs' || true)
+  if [ "$PHASE" = "Succeeded" ] && echo "$LOGS" | grep -q '^enforced'; then
+    pass "[N3.$i-new] shipped probe certifies in $((T1-T0))s over $OBS observation(s) — the gate can now pass on EKS"
+  else
+    fail "[N3.$i-new] expected Succeeded, got phase=$PHASE ($(echo "$LOGS" | tail -1))"
+  fi
+  kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+done
+
+say "summary"
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+echo "  logs: $LOG_DIR"
+[ "$FAIL" -eq 0 ] && echo "  ALL $PASS ASSERTIONS PASSED" || echo "  $FAIL FAILED / $PASS passed"
+# teardown + audit run via the EXIT trap
+[ "$FAIL" -eq 0 ]

--- a/scripts/netpol-admission-validation.sh
+++ b/scripts/netpol-admission-validation.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# Live validation of the netpol startup-admission protocol on a kind cluster
+# with an ENFORCING CNI (Calico — kind's default kindnet does not enforce
+# NetworkPolicy at all).
+#
+# What it proves, with the PRODUCTION bytes (script + pod shapes come from
+# `cargo run -p fluidbox-provider-k8s --example netpol_fixtures`, policies
+# from `helm template … -s templates/sandbox.yaml`):
+#
+#   A  (×N) steady state, repeatedly: a gated sandbox-shaped pod starts, the
+#      netpol-gate observes enforcement immediately, and the runner's FIRST
+#      instruction finds forbidden egress (public :8787, internet 1.1.1.1:443)
+#      BLOCKED while allowed traffic (internal :8788) works.
+#   B  (×N) the admission RACE, simulated: the pod is created while the
+#      namespace has NO NetworkPolicies (the fail-open analog of AWS VPC CNI
+#      `standard` mode programming policy asynchronously); policies are
+#      applied seconds later. The gate must OBSERVE the open network (neg=open
+#      in its log), HOLD the runner, then release only after enforcement — and
+#      the runner's first instruction must find egress blocked. Runner
+#      startedAt must be AFTER the policy-apply timestamp.
+#   B0 the vulnerability, reproduced: the same pod WITHOUT the gate (pre-fix
+#      shape) created in the same window reports FORBIDDEN EGRESS OPEN from
+#      the runner — the reason the gate exists.
+#   C  the certification probe: the OLD single-t=0-sample script fails closed
+#      (exit 3) under late-applied policy — the measured cause of "every
+#      POST /v1/sessions is 503 on EKS" — while the NEW bounded observation
+#      probe converges and Succeeds under identical conditions.
+#   D  the bound: with policies never applied, the gate fails CLOSED with
+#      exit 3 at its deadline (no runner start, no hang).
+#
+# Usage: scripts/netpol-admission-validation.sh [--keep] [--iterations N]
+# Requires: kind, kubectl, helm, jq, docker (colima or Docker Desktop), cargo.
+set -euo pipefail
+
+KEEP=0
+ITER=5
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep) KEEP=1 ;;
+    --iterations) ITER="$2"; shift ;;
+    *) echo "unknown arg: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLUSTER="${KIND_CLUSTER:-fbx-netadm-val}"
+NS_CTRL=fbxval
+NS_SANDBOX=fbxval-sandboxes
+BUSYBOX=busybox:1.36
+RACE_ITER=3
+WAIT_SECS=60
+LOG_DIR="${NETPOL_VAL_LOG_DIR:-$(mktemp -d /tmp/netpol-val.XXXXXX)}"
+PASS=0; FAIL=0; declare -a RESULTS=()
+
+say()  { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+pass() { PASS=$((PASS+1)); RESULTS+=("PASS  $1"); printf '  \033[1;32mPASS\033[0m %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); RESULTS+=("FAIL  $1"); printf '  \033[1;31mFAIL\033[0m %s\n' "$1"; }
+
+for tool in kind kubectl helm jq docker cargo python3; do
+  command -v "$tool" >/dev/null || { echo "missing: $tool"; exit 1; }
+done
+
+# Prefer colima's socket if the default daemon is unreachable (macOS setups
+# where Docker Desktop owns /var/run/docker.sock but is not running).
+if ! docker info >/dev/null 2>&1; then
+  if [ -S "$HOME/.colima/default/docker.sock" ]; then
+    export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
+  fi
+fi
+docker info >/dev/null 2>&1 || { echo "no reachable docker daemon"; exit 1; }
+
+say "building the production fixture generator"
+cargo build -q -p fluidbox-provider-k8s --example netpol_fixtures
+FIX="$ROOT/target/debug/examples/netpol_fixtures"
+
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+  say "creating kind cluster '$CLUSTER' (disableDefaultCNI → Calico)"
+  # No --wait: with disableDefaultCNI the node cannot go Ready until the CNI
+  # below is applied, so a readiness wait here would always time out.
+  cat <<KIND | kind create cluster --name "$CLUSTER" --config -
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: "192.168.0.0/16"
+KIND
+fi
+kubectl config use-context "kind-$CLUSTER" >/dev/null
+# Idempotent on rerun: apply is a no-op when Calico is already installed.
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml >/dev/null
+kubectl -n kube-system rollout status ds/calico-node --timeout=240s
+# Preload busybox via a docker-save archive: `kind load docker-image` trips on
+# containerd-snapshotter multi-platform manifests ("content digest … not
+# found"), while a saved archive carries only the local platform. Best-effort
+# — on failure the node pulls the tiny image from the registry itself.
+docker image inspect "$BUSYBOX" >/dev/null 2>&1 || docker pull "$BUSYBOX" >/dev/null
+BBTAR=$(mktemp /tmp/busybox.XXXXXX.tar)
+if docker save "$BUSYBOX" -o "$BBTAR" && kind load image-archive "$BBTAR" --name "$CLUSTER" >/dev/null 2>&1; then
+  echo "  preloaded $BUSYBOX onto the node"
+else
+  echo "  preload failed; the node will pull $BUSYBOX from the registry"
+fi
+rm -f "$BBTAR"
+
+say "topology: control-plane stand-in ($NS_CTRL) + sandbox namespace ($NS_SANDBOX) with the chart's rendered policies"
+kubectl create namespace "$NS_CTRL" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+# The REAL policy bytes: rendered from the chart with the release namespace
+# this validation uses, so the namespaceSelector/podSelector pairs are exactly
+# what production applies. Quota off — orthogonal to netpol.
+render_policies() {
+  helm template fluidbox "$ROOT/deploy/helm/fluidbox" -n "$NS_CTRL" \
+    -s templates/sandbox.yaml \
+    --set sandbox.namespace="$NS_SANDBOX" \
+    --set sandbox.quota.enabled=false
+}
+render_policies > "$LOG_DIR/rendered-sandbox.yaml"
+kubectl apply -f "$LOG_DIR/rendered-sandbox.yaml" >/dev/null
+
+# Stand-in "server": the chart's Service selector labels, two busybox httpd
+# listeners on the real ports. Reachability of BOTH ports is therefore known
+# independently of policy — "blocked" is evidence of policy, not a dead host.
+kubectl -n "$NS_CTRL" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fbxval-server
+  labels:
+    app.kubernetes.io/name: fluidbox
+    app.kubernetes.io/component: server
+spec:
+  securityContext: { runAsNonRoot: true, runAsUser: 10001, seccompProfile: { type: RuntimeDefault } }
+  containers:
+    - name: listeners
+      image: $BUSYBOX
+      command: ["/bin/sh","-c","httpd -p 8787; httpd -p 8788; exec tail -f /dev/null"]
+      securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: ["ALL"] } }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: fbxval-internal }
+spec:
+  selector: { app.kubernetes.io/name: fluidbox, app.kubernetes.io/component: server }
+  ports: [ { port: 8788, targetPort: 8788 } ]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: fbxval-public }
+spec:
+  selector: { app.kubernetes.io/name: fluidbox, app.kubernetes.io/component: server }
+  ports: [ { port: 8787, targetPort: 8787 } ]
+YAML
+kubectl -n "$NS_CTRL" wait --for=condition=Ready pod/fbxval-server --timeout=120s >/dev/null
+INT_IP=$(kubectl -n "$NS_CTRL" get svc fbxval-internal -o jsonpath='{.spec.clusterIP}')
+PUB_IP=$(kubectl -n "$NS_CTRL" get svc fbxval-public -o jsonpath='{.spec.clusterIP}')
+echo "  internal=$INT_IP:8788 public=$PUB_IP:8787  (logs: $LOG_DIR)"
+
+# The two NetworkPolicy objects the race phases remove/apply.
+yq_policies() { # extract just the NetworkPolicies from the rendered file
+  python3 - "$LOG_DIR/rendered-sandbox.yaml" <<'PY'
+import sys
+docs = open(sys.argv[1]).read().split("\n---")
+for d in docs:
+    if "kind: NetworkPolicy" in d:
+        print(d.strip("\n"))
+        print("---")
+PY
+}
+yq_policies > "$LOG_DIR/policies.yaml"
+
+policies_delete() {
+  kubectl -n "$NS_SANDBOX" delete networkpolicy fluidbox-sandbox-default-deny fluidbox-sandbox-egress --ignore-not-found >/dev/null
+}
+policies_apply() { kubectl apply -f "$LOG_DIR/policies.yaml" >/dev/null; }
+
+# Production sandbox pod (gate + workspace-init + runner + collector) with the
+# non-gate workloads stubbed to busybox (images/commands only — placement,
+# ordering, env routing and securityContext stay exactly as build_pod emits).
+# The runner's stub is the ADVERSARY: its very first instruction attempts the
+# forbidden egress a hostile agent would.
+RUNNER_PROBE='echo "runner: started t=$(date +%s)"; p=blocked; nc -z -w 2 PUBIP 8787 && p=OPEN; w=blocked; nc -z -w 2 1.1.1.1 443 && w=OPEN; a=fail; nc -z -w 2 INTIP 8788 && a=ok; echo "runner: forbidden public:8787=$p internet:443=$w allowed internal:8788=$a"; sleep 2'
+sandbox_pod_json() { # $1 = pod name, $2 = with_gate (1|0)
+  local name="$1" with_gate="$2"
+  local runner_script=${RUNNER_PROBE//PUBIP/$PUB_IP}
+  runner_script=${runner_script//INTIP/$INT_IP}
+  FLUIDBOX_COLLECTOR_IMAGE="$BUSYBOX" FLUIDBOX_NETPOL_PROBE_IMAGE="$BUSYBOX" \
+    "$FIX" sandbox-pod "$INT_IP" 8788 "$PUB_IP" 8787 "$WAIT_SECS" \
+    | jq --arg name "$name" --arg rs "$runner_script" --arg img "$BUSYBOX" '
+        .metadata.name = $name
+        | .spec.initContainers[-1].image = $img
+        | .spec.initContainers[-1].command = ["/bin/sh","-c","echo workspace-init: stub fetch; sleep 1"]
+        | .spec.initContainers[-1].env = []
+        | .spec.containers[0].image = $img
+        | .spec.containers[0].command = ["/bin/sh","-c",$rs]
+        | .spec.containers[0].resources = {"requests":{"cpu":"50m","memory":"64Mi"},"limits":{"cpu":"500m","memory":"256Mi"}}
+        | .spec.containers[1].image = $img
+        | .spec.containers[1].command = ["/bin/sh","-c","sleep 15"]
+      ' \
+    | if [ "$with_gate" = 1 ]; then cat; else jq 'del(.spec.initContainers[0])'; fi
+}
+
+runner_report() { # $1 pod — the runner's first-instruction egress report line
+  kubectl -n "$NS_SANDBOX" logs "$1" -c runner 2>/dev/null | grep '^runner: forbidden' || true
+}
+runner_started_epoch() { # $1 pod
+  local t
+  t=$(kubectl -n "$NS_SANDBOX" get pod "$1" -o jsonpath='{.status.containerStatuses[?(@.name=="runner")].state.running.startedAt}' 2>/dev/null)
+  [ -z "$t" ] && t=$(kubectl -n "$NS_SANDBOX" get pod "$1" -o jsonpath='{.status.containerStatuses[?(@.name=="runner")].state.terminated.startedAt}' 2>/dev/null)
+  [ -z "$t" ] && { echo 0; return; }
+  python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$t"
+}
+wait_runner_done() { # $1 pod, $2 timeout_s — until the runner container terminated
+  local end=$(( $(date +%s) + $2 ))
+  while [ "$(date +%s)" -lt "$end" ]; do
+    local st
+    st=$(kubectl -n "$NS_SANDBOX" get pod "$1" -o jsonpath='{.status.containerStatuses[?(@.name=="runner")].state.terminated.exitCode}' 2>/dev/null || true)
+    [ -n "$st" ] && return 0
+    sleep 2
+  done
+  return 1
+}
+
+say "phase A: steady state ×$ITER — gate admits immediately, forbidden egress blocked, allowed traffic works"
+for i in $(seq 1 "$ITER"); do
+  POD="fbxval-a$i"
+  T0=$(date +%s)
+  sandbox_pod_json "$POD" 1 | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+  if ! wait_runner_done "$POD" 120; then
+    fail "[A$i] runner never completed"; kubectl -n "$NS_SANDBOX" describe pod "$POD" | tail -20; continue
+  fi
+  T1=$(date +%s)
+  GATE_LOG=$(kubectl -n "$NS_SANDBOX" logs "$POD" -c netpol-gate 2>/dev/null || true)
+  REPORT=$(runner_report "$POD")
+  echo "$GATE_LOG" > "$LOG_DIR/a$i-gate.log"; echo "$REPORT" >> "$LOG_DIR/a$i-gate.log"
+  if echo "$GATE_LOG" | grep -q '^enforced' \
+     && echo "$REPORT" | grep -q 'public:8787=blocked' \
+     && echo "$REPORT" | grep -q 'internet:443=blocked' \
+     && echo "$REPORT" | grep -q 'internal:8788=ok'; then
+    pass "[A$i] $((T1-T0))s end-to-end; $(echo "$GATE_LOG" | grep -c '^obs') gate observation(s); $REPORT"
+  else
+    fail "[A$i] gate/log mismatch — gate: $(echo "$GATE_LOG" | tail -2 | tr '\n' ' ') runner: $REPORT"
+  fi
+  kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+done
+
+say "phase B0: the VULNERABILITY, reproduced — pre-fix pod (no gate) created while policies are absent"
+policies_delete
+sleep 2
+POD=fbxval-b0
+sandbox_pod_json "$POD" 0 | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+wait_runner_done "$POD" 90 || true
+REPORT=$(runner_report "$POD"); echo "$REPORT" > "$LOG_DIR/b0-runner.log"
+if echo "$REPORT" | grep -q 'public:8787=OPEN'; then
+  pass "[B0] pre-fix shape leaks: runner's first instruction reached forbidden targets — $REPORT"
+else
+  fail "[B0] expected the unprotected runner to see an open network, got: $REPORT"
+fi
+kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+
+say "phase B: the RACE ×$RACE_ITER — pod created before policy exists; gate must hold the runner until enforcement"
+for i in $(seq 1 "$RACE_ITER"); do
+  POD="fbxval-b$i"
+  policies_delete
+  sleep 2
+  sandbox_pod_json "$POD" 1 | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+  sleep 8   # let the gate observe the open network for a few iterations
+  MID=$(kubectl -n "$NS_SANDBOX" get pod "$POD" -o jsonpath='{.status.containerStatuses[?(@.name=="runner")].state.waiting.reason}' 2>/dev/null || true)
+  APPLY_TS=$(date +%s)
+  policies_apply
+  if ! wait_runner_done "$POD" 120; then
+    fail "[B$i] runner never completed after policies applied"; continue
+  fi
+  GATE_LOG=$(kubectl -n "$NS_SANDBOX" logs "$POD" -c netpol-gate 2>/dev/null || true)
+  REPORT=$(runner_report "$POD")
+  STARTED=$(runner_started_epoch "$POD")
+  { echo "$GATE_LOG"; echo "runner startedAt epoch: $STARTED (policies applied: $APPLY_TS)"; echo "$REPORT"; } > "$LOG_DIR/b$i-gate.log"
+  OPEN_OBS=$(echo "$GATE_LOG" | grep -c 'neg=open' || true)
+  if [ "$OPEN_OBS" -ge 1 ] \
+     && echo "$GATE_LOG" | grep -q '^enforced' \
+     && [ -n "$MID" ] \
+     && [ "$STARTED" -ge "$APPLY_TS" ] \
+     && echo "$REPORT" | grep -q 'public:8787=blocked' \
+     && echo "$REPORT" | grep -q 'internet:443=blocked' \
+     && echo "$REPORT" | grep -q 'internal:8788=ok'; then
+    pass "[B$i] gate observed open net ${OPEN_OBS}×, runner held (waiting=$MID), started ${STARTED}s ≥ apply ${APPLY_TS}s, then egress blocked"
+  else
+    fail "[B$i] open_obs=$OPEN_OBS mid_waiting='$MID' started=$STARTED apply=$APPLY_TS report='$REPORT'"
+  fi
+  kubectl -n "$NS_SANDBOX" delete pod "$POD" --ignore-not-found >/dev/null
+done
+
+say "phase C: certification probe — old t=0 sample fails closed; new bounded observation converges (policy applied late)"
+# C-old: the exact pre-fix script (one sample per assertion at t=0).
+policies_delete
+sleep 2
+OLD_SCRIPT="set -u; if nc -z -w 4 $INT_IP 8788; then echo pos-ok; else echo pos-fail; exit 2; fi; if nc -z -w 4 $PUB_IP 8787; then echo neg-fail; exit 3; else echo neg-ok; fi; echo enforced"
+FLUIDBOX_NETPOL_PROBE_IMAGE="$BUSYBOX" "$FIX" probe-pod fbxval-c-old "$BUSYBOX" "$INT_IP" 8788 "$PUB_IP" 8787 "$WAIT_SECS" \
+  | jq --arg s "$OLD_SCRIPT" '.metadata.name="fbxval-c-old" | .spec.containers[0].command=["/bin/sh","-c",$s]' \
+  | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+( sleep 10; policies_apply ) &
+LATE_APPLY_PID=$!
+for _ in $(seq 1 45); do
+  PHASE=$(kubectl -n "$NS_SANDBOX" get pod fbxval-c-old -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  [ "$PHASE" = "Failed" ] || [ "$PHASE" = "Succeeded" ] && break
+  sleep 2
+done
+CODE=$(kubectl -n "$NS_SANDBOX" get pod fbxval-c-old -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || true)
+kubectl -n "$NS_SANDBOX" logs fbxval-c-old > "$LOG_DIR/c-old.log" 2>/dev/null || true
+if [ "$PHASE" = "Failed" ] && [ "$CODE" = "3" ]; then
+  pass "[C-old] pre-fix probe under late policy: phase=$PHASE exit=$CODE (the measured EKS 503 cause, reproduced)"
+else
+  fail "[C-old] expected Failed/exit 3, got phase=$PHASE exit=$CODE"
+fi
+wait "$LATE_APPLY_PID" 2>/dev/null || true
+kubectl -n "$NS_SANDBOX" delete pod fbxval-c-old --ignore-not-found >/dev/null
+
+# C-new: identical late-policy conditions, the SHIPPED observation script.
+policies_delete
+sleep 2
+T0=$(date +%s)
+FLUIDBOX_NETPOL_PROBE_IMAGE="$BUSYBOX" "$FIX" probe-pod fbxval-c-new "$BUSYBOX" "$INT_IP" 8788 "$PUB_IP" 8787 "$WAIT_SECS" \
+  | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+( sleep 10; policies_apply ) &
+LATE_APPLY_PID=$!
+for _ in $(seq 1 60); do
+  PHASE=$(kubectl -n "$NS_SANDBOX" get pod fbxval-c-new -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  [ "$PHASE" = "Failed" ] || [ "$PHASE" = "Succeeded" ] && break
+  sleep 2
+done
+T1=$(date +%s)
+LOGS=$(kubectl -n "$NS_SANDBOX" logs fbxval-c-new 2>/dev/null || true); echo "$LOGS" > "$LOG_DIR/c-new.log"
+OPEN_OBS=$(echo "$LOGS" | grep -c 'neg=open' || true)
+if [ "$PHASE" = "Succeeded" ] && [ "$OPEN_OBS" -ge 1 ] && echo "$LOGS" | grep -q '^enforced'; then
+  pass "[C-new] shipped probe converged in $((T1-T0))s after observing the open network ${OPEN_OBS}× — certification now passes where the old probe 503'd"
+else
+  fail "[C-new] expected Succeeded with observed transition, got phase=$PHASE open_obs=$OPEN_OBS"
+fi
+wait "$LATE_APPLY_PID" 2>/dev/null || true
+kubectl -n "$NS_SANDBOX" delete pod fbxval-c-new --ignore-not-found >/dev/null
+
+say "phase D: the bound — policies never applied; gate must fail CLOSED with exit 3 at its deadline"
+policies_delete
+sleep 2
+T0=$(date +%s)
+FLUIDBOX_NETPOL_PROBE_IMAGE="$BUSYBOX" "$FIX" probe-pod fbxval-d "$BUSYBOX" "$INT_IP" 8788 "$PUB_IP" 8787 15 \
+  | kubectl -n "$NS_SANDBOX" apply -f - >/dev/null
+for _ in $(seq 1 40); do
+  PHASE=$(kubectl -n "$NS_SANDBOX" get pod fbxval-d -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  [ "$PHASE" = "Failed" ] || [ "$PHASE" = "Succeeded" ] && break
+  sleep 2
+done
+T1=$(date +%s)
+CODE=$(kubectl -n "$NS_SANDBOX" get pod fbxval-d -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || true)
+kubectl -n "$NS_SANDBOX" logs fbxval-d > "$LOG_DIR/d.log" 2>/dev/null || true
+if [ "$PHASE" = "Failed" ] && [ "$CODE" = "3" ] && [ $((T1-T0)) -lt 60 ]; then
+  pass "[D] unenforced cluster fails closed: exit 3 after ~15s window ($((T1-T0))s total)"
+else
+  fail "[D] expected Failed/exit 3 within a minute, got phase=$PHASE exit=$CODE in $((T1-T0))s"
+fi
+kubectl -n "$NS_SANDBOX" delete pod fbxval-d --ignore-not-found >/dev/null
+policies_apply   # leave the namespace in its enforced state
+
+say "summary"
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+echo "  logs: $LOG_DIR"
+if [ "$FAIL" -eq 0 ]; then
+  echo "  ALL $PASS ASSERTIONS PASSED"
+  if [ "$KEEP" = 0 ]; then
+    say "teardown (pass --keep to retain the cluster)"
+    kind delete cluster --name "$CLUSTER"
+  fi
+  exit 0
+else
+  echo "  $FAIL FAILED / $PASS passed — cluster '$CLUSTER' kept for forensics (kind delete cluster --name $CLUSTER)"
+  exit 1
+fi


### PR DESCRIPTION
## What

Closes the Kubernetes network-enforcement **admission race** (measured on EKS 2026-07-28, §8c of the 2026-07-27 validation): the netpol certification probe sampled its two assertions once at container t=0 — inside AWS VPC CNI `standard` mode's asynchronous, **fail-open** policy-programming window that every *fresh pod* re-enters. Consequences:

1. the boot gate could never pass on EKS ⇒ every `POST /v1/sessions` was 503 (each worker retry made a new probe pod that raced again), and
2. **sandbox pods themselves** start inside the same window ⇒ the untrusted runner could execute with unrestricted egress for its first seconds.

No blind sleeps anywhere; `netpol.requireEnforced` semantics untouched (default-on, fail-closed, `false` stays dev-only).

## How

One shared bounded observation protocol (`netpol::enforcement_script`): poll once per second until **positive (internal :8788) reachable AND negative (public :8787) blocked hold in the same observation** — enforcement is monotonic, so the first such observation is proof. Fail closed at `FLUIDBOX_NETPOL_WAIT_SECS` / `netpol.waitSeconds` (default 60 s) with the original exit codes (3 = NotEnforced, 2 = Unschedulable). Every iteration logs `obs i t=… pos=… neg=…`.

Three consumers:
1. **Certification probe** (`verify_netpol`) — converges instead of racing; pod/caller deadlines derived from the window; failures surface the observation log tail.
2. **`netpol-gate` init container** (new) — first init container of every sandbox pod when enforcement is required, so by kubelet init ordering the untrusted runner cannot start until the pod's *own* network is observed enforced. Targets frozen per run (`SandboxSpec.network_admission`) from the same ClusterIP pair the certification probe verified; the provider **refuses** to provision an enforcement-required spec without them (defense in depth, mirrored env parse pinned by test).
3. **helm-test probe** — same loop (it had the same t=0 race / known false-negative).

## Validation — `docs/reviews/k8s-network-admission-validation.md`

- **Unit/shape regressions**: script-is-a-loop-not-a-sample, deadline derivation, gate placement + restricted-PSS + no-tokens-in-gate, provision refusal, flag-parse parity. 576 tests green in touched crates; workspace clippy clean; `helm lint` clean.
- **kind + Calico** (`scripts/netpol-admission-validation.sh`): **12/12** — steady state ×5; the pre-fix leak *reproduced* (runner's first instruction reached forbidden targets in the unpoliced window); the race ×3 (gate observed the open network 8×, held the runner, released after policy apply, `startedAt ≥ apply`); old probe exit-3 vs shipped probe converging; fail-closed deadline.
- **EKS, native VPC CNI race** (`scripts/netpol-admission-eks-validation.sh`, ephemeral tagged cluster): **9/9** — **determination: real workloads ARE exposed** (a pre-fix-shaped runner saw `public=OPEN internet=OPEN` at its own t=0, natively); the gate held through the native fail-open (obs 1–2 `neg=open`, enforced at obs 3) ×3; the old probe failed exit-3 deterministically (the 503 cause) while the shipped probe certified in 11 s. Window length varies (~1–4 s that day vs ~20 s on 2026-07-28) and is unbounded by AWS contract — hence observation, not timing.
- **Teardown**: trap-guaranteed (proven on a deliberately failed run), swept + audited to **zero orphans** account-wide across two ephemeral clusters (~$0.35 total).

## Notes for review

- `SandboxSpec` gains `network_admission: Option<NetworkAdmission>`; Docker provider ignores it (its per-session bridge has no such race).
- The gate worker publishes resolved ClusterIPs *before* probing, so a verified gate implies targets exist; ports are the chart-fixed Service ports (8787/8788).
- Known follow-ups deliberately out of scope: machine-checking `waitSeconds < init grace`; surfacing gate observations on the run timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBctaHC9EbFtSEqUEYVSa8
