### PR TITLE
feat: durable automation API contract, PATCH /v1/triggers/{id}, self-explanatory template box

### DIFF
--- a/apps/web/app/automations/[id]/page.tsx
+++ b/apps/web/app/automations/[id]/page.tsx
@@ -6,14 +6,21 @@ import {
   Agent,
   apiGet,
   apiGetCached,
+  apiPatch,
   apiPost,
   TriggerDetail,
   TriggerSubscription,
 } from "../../lib/api";
-import { AutomationContract } from "../../components/AutomationContract";
+import { AutomationContract, CopyBlock, TemplateChips } from "../../components/AutomationContract";
 import { AutomationActivity } from "../../components/AutomationPanel";
 import { MintedAutomation, ShowAutomationSecrets } from "../../components/RunComposer";
+import { ScheduleBuilder } from "../../components/ScheduleBuilder";
 import { LoadingRows } from "../../components/bits";
+
+/** Verbatim message from an apiPatch rejection (server body for 4xx/409). */
+function errText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 export default function AutomationDetail({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -141,6 +148,16 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
       </section>
 
       <section className="automation-detail-section">
+        <h2>Configuration</h2>
+        <SettingsSection detail={detail} onSaved={load} />
+      </section>
+
+      <section className="automation-detail-section">
+        <h2>Task template</h2>
+        <TemplateSection detail={detail} onSaved={load} />
+      </section>
+
+      <section className="automation-detail-section">
         <h2>Activity</h2>
         <AutomationActivity id={sub.id} />
       </section>
@@ -153,6 +170,336 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
           }}
         />
       )}
+    </div>
+  );
+}
+
+const CONCURRENCY_LABELS: Record<string, string> = {
+  allow: "Allow runs to overlap",
+  skip_if_running: "Skip and record the invocation",
+  replace: "Cancel the active run and start the new one",
+};
+const MISSED_LABELS: Record<string, string> = {
+  skip: "Record the gap and resume the cadence",
+  catch_up: "Start exactly one make-up run",
+};
+
+function signedCallbackUrl(sub: TriggerSubscription): string {
+  return sub.result_destinations.find((d) => d.kind === "signed_webhook")?.url ?? "";
+}
+
+function SettingsSection({
+  detail,
+  onSaved,
+}: {
+  detail: TriggerDetail;
+  onSaved: () => Promise<void>;
+}) {
+  const sub = detail.subscription;
+  const schedule = detail.schedule;
+  const initialCallbackUrl = signedCallbackUrl(sub);
+
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState("");
+  const [newSecret, setNewSecret] = useState<string | null>(null);
+
+  const [name, setName] = useState(sub.name);
+  const [allowTask, setAllowTask] = useState(sub.allow_task_override);
+  const [allowWorkspace, setAllowWorkspace] = useState(sub.allow_workspace_override);
+  const [concurrency, setConcurrency] = useState(sub.concurrency_policy);
+  const [callbackUrl, setCallbackUrl] = useState(initialCallbackUrl);
+  const [cron, setCron] = useState(schedule?.cron ?? "");
+  const [timezone, setTimezone] = useState(schedule?.timezone ?? "");
+  const [missed, setMissed] = useState(schedule?.missed_run_policy ?? "skip");
+
+  const startEditing = () => {
+    // Seed the draft from the current server truth every time, so a reopened
+    // editor never carries stale values from a previous, saved edit.
+    setName(sub.name);
+    setAllowTask(sub.allow_task_override);
+    setAllowWorkspace(sub.allow_workspace_override);
+    setConcurrency(sub.concurrency_policy);
+    setCallbackUrl(initialCallbackUrl);
+    setCron(schedule?.cron ?? "");
+    setTimezone(schedule?.timezone ?? "");
+    setMissed(schedule?.missed_run_policy ?? "skip");
+    setErr("");
+    setEditing(true);
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setErr("");
+    try {
+      // Only touched fields ride the PATCH; the schedule object carries only its
+      // own touched keys (the wire contract is partial by design).
+      const body: Record<string, unknown> = {};
+      if (name !== sub.name) body.name = name;
+      if (allowTask !== sub.allow_task_override) body.allow_task_override = allowTask;
+      if (allowWorkspace !== sub.allow_workspace_override) body.allow_workspace_override = allowWorkspace;
+      if (concurrency !== sub.concurrency_policy) body.concurrency_policy = concurrency;
+      if (callbackUrl !== initialCallbackUrl) body.callback_url = callbackUrl; // "" clears
+      if (sub.trigger_kind === "schedule" && schedule) {
+        const scheduleBody: Record<string, string> = {};
+        if (cron !== schedule.cron) scheduleBody.cron = cron;
+        if (timezone !== schedule.timezone) scheduleBody.timezone = timezone;
+        if (missed !== schedule.missed_run_policy) scheduleBody.missed_run_policy = missed;
+        if (Object.keys(scheduleBody).length > 0) body.schedule = scheduleBody;
+      }
+      if (Object.keys(body).length === 0) {
+        setEditing(false);
+        return; // nothing touched — do not send an empty PATCH
+      }
+      const response = await apiPatch<{ callback_secret: string | null }>(
+        `/triggers/${sub.id}`,
+        body
+      );
+      if (response.callback_secret) setNewSecret(response.callback_secret);
+      setEditing(false);
+      await onSaved();
+    } catch (error) {
+      // A 409 means a concurrent edit — the server's message (reload and retry)
+      // is surfaced verbatim.
+      setErr(errText(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      {newSecret && (
+        <div className="note">
+          <p>New callback signing secret — copy it now, it will not be shown again.</p>
+          <CopyBlock label="Signing secret" value={newSecret} />
+          <button className="btn ghost sm" type="button" onClick={() => setNewSecret(null)}>
+            Dismiss
+          </button>
+        </div>
+      )}
+      {!editing ? (
+        <div>
+          <div className="rows">
+            <div className="row contract-var">
+              <span>Name</span>
+              <span className="faint">{sub.name}</span>
+            </div>
+            <div className="row contract-var">
+              <span>Autonomy</span>
+              <span className="faint">{sub.autonomy ?? "policy default"}</span>
+            </div>
+            <div className="row contract-var">
+              <span>When another run is active</span>
+              <span className="faint">
+                {CONCURRENCY_LABELS[sub.concurrency_policy] ?? sub.concurrency_policy}
+              </span>
+            </div>
+            <div className="row contract-var">
+              <span>Task override</span>
+              <span className="faint">{sub.allow_task_override ? "allowed" : "refused"}</span>
+            </div>
+            <div className="row contract-var">
+              <span>Workspace override</span>
+              <span className="faint">{sub.allow_workspace_override ? "allowed" : "refused"}</span>
+            </div>
+            <div className="row contract-var">
+              <span>Signed callback</span>
+              <span className="faint">{initialCallbackUrl || "none"}</span>
+            </div>
+            {sub.trigger_kind === "schedule" && schedule && (
+              <>
+                <div className="row contract-var">
+                  <span>Schedule</span>
+                  <span className="faint mono">{schedule.cron}</span>
+                </div>
+                <div className="row contract-var">
+                  <span>Timezone</span>
+                  <span className="faint">{schedule.timezone}</span>
+                </div>
+                <div className="row contract-var">
+                  <span>If a scheduled time was missed</span>
+                  <span className="faint">
+                    {MISSED_LABELS[schedule.missed_run_policy] ?? schedule.missed_run_policy}
+                  </span>
+                </div>
+                <div className="row contract-var">
+                  <span>Next run</span>
+                  <span className="faint">
+                    {schedule.next_fire_at
+                      ? new Date(schedule.next_fire_at).toLocaleString()
+                      : "—"}
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+          <button className="btn ghost sm" type="button" onClick={startEditing}>
+            Edit configuration
+          </button>
+        </div>
+      ) : (
+        <div className="field">
+          <label className="field">
+            <span className="lab">Name</span>
+            <input className="inp" value={name} onChange={(event) => setName(event.target.value)} />
+          </label>
+          <label className="check">
+            <input
+              type="checkbox"
+              checked={allowTask}
+              onChange={(event) => setAllowTask(event.target.checked)}
+            />
+            Allow the caller to override the task
+          </label>
+          <label className="check">
+            <input
+              type="checkbox"
+              checked={allowWorkspace}
+              onChange={(event) => setAllowWorkspace(event.target.checked)}
+            />
+            Allow a narrower workspace override within this automation&apos;s authority
+          </label>
+          <label className="field">
+            <span className="lab">When another run is already active</span>
+            <select
+              className="inp"
+              value={concurrency}
+              onChange={(event) => setConcurrency(event.target.value)}
+            >
+              <option value="allow">Allow runs to overlap</option>
+              <option value="skip_if_running">Skip and record the invocation</option>
+              <option value="replace">Cancel the active run and start the new one</option>
+            </select>
+          </label>
+          <label className="field">
+            <span className="lab">
+              Signed callback URL <span className="optional-label">optional</span>
+            </span>
+            <input
+              className="inp"
+              value={callbackUrl}
+              onChange={(event) => setCallbackUrl(event.target.value)}
+              placeholder="https://your-service.example/fluidbox/callback"
+            />
+            <span className="field-hint">
+              Clearing removes the signed callback; changing it mints a NEW signing secret shown once
+            </span>
+          </label>
+          {sub.trigger_kind === "schedule" && schedule && (
+            <>
+              <ScheduleBuilder
+                cron={cron}
+                timezone={timezone}
+                onCron={setCron}
+                onTimezone={setTimezone}
+              />
+              <label className="field">
+                <span className="lab">If a scheduled time was missed</span>
+                <select
+                  className="inp"
+                  value={missed}
+                  onChange={(event) => setMissed(event.target.value)}
+                >
+                  <option value="skip">Record the gap and resume the cadence</option>
+                  <option value="catch_up">Start exactly one make-up run</option>
+                </select>
+              </label>
+            </>
+          )}
+          {err && <div className="err">{err}</div>}
+          <div className="automation-actions">
+            <button
+              className="btn primary sm"
+              type="button"
+              disabled={saving}
+              onClick={() => void save()}
+            >
+              {saving ? "Saving…" : "Save configuration"}
+            </button>
+            <button
+              className="btn ghost sm"
+              type="button"
+              disabled={saving}
+              onClick={() => setEditing(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TemplateSection({ detail, onSaved }: { detail: TriggerDetail; onSaved: () => Promise<void> }) {
+  const sub = detail.subscription;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(sub.task_template ?? "");
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState("");
+
+  const save = async () => {
+    setSaving(true);
+    setErr("");
+    try {
+      await apiPatch(`/triggers/${sub.id}`, { task_template: draft });
+      setEditing(false);
+      await onSaved();
+    } catch (error) {
+      setErr(String(error)); // server names the missing placeholder/context
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!editing) {
+    return (
+      <div>
+        {sub.task_template ? (
+          <>
+            <pre className="token">{sub.task_template}</pre>
+            <TemplateChips kind={sub.trigger_kind} template={sub.task_template} />
+          </>
+        ) : (
+          <p className="contract-note">
+            No template — every invocation must supply its own task (task override is on).
+          </p>
+        )}
+        <button
+          className="btn ghost sm"
+          type="button"
+          onClick={() => {
+            setDraft(sub.task_template ?? "");
+            setEditing(true);
+          }}
+        >
+          Edit template
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="field">
+      <textarea
+        className="inp run-task-input"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      <TemplateChips kind={sub.trigger_kind} template={draft} />
+      <span className="field-hint">
+        Future firings use the new template immediately; runs already in flight keep the
+        configuration they started with.
+      </span>
+      {err && <div className="err">{err}</div>}
+      <div className="automation-actions">
+        <button className="btn primary sm" type="button" disabled={saving} onClick={() => void save()}>
+          {saving ? "Saving…" : "Save template"}
+        </button>
+        <button className="btn ghost sm" type="button" disabled={saving} onClick={() => setEditing(false)}>
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/automations/[id]/page.tsx
+++ b/apps/web/app/automations/[id]/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { use, useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Agent,
+  apiGet,
+  apiGetCached,
+  apiPost,
+  TriggerDetail,
+  TriggerSubscription,
+} from "../../lib/api";
+import { AutomationContract } from "../../components/AutomationContract";
+import { AutomationActivity } from "../../components/AutomationPanel";
+import { MintedAutomation, ShowAutomationSecrets } from "../../components/RunComposer";
+import { LoadingRows } from "../../components/bits";
+
+export default function AutomationDetail({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [detail, setDetail] = useState<TriggerDetail | null>(null);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loadErr, setLoadErr] = useState("");
+  const [actionErr, setActionErr] = useState("");
+  const [minted, setMinted] = useState<MintedAutomation | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [detailResponse, agentResponse] = await Promise.all([
+        apiGet<TriggerDetail>(`/triggers/${id}`),
+        apiGetCached<{ agents: Agent[] }>("/agents", { maxAgeMs: 15_000 }),
+      ]);
+      setDetail(detailResponse);
+      setAgents(agentResponse.agents);
+      setLoadErr("");
+    } catch (error) {
+      // Keep the last good snapshot; surface the failure without blanking.
+      setLoadErr(String(error));
+    }
+  }, [id]);
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = async (subscription: TriggerSubscription) => {
+    setActionErr("");
+    try {
+      await apiPost(`/triggers/${id}/${subscription.enabled ? "disable" : "enable"}`, {});
+      await load();
+    } catch (error) {
+      setActionErr(String(error));
+    }
+  };
+
+  const rotate = async (subscription: TriggerSubscription) => {
+    setActionErr("");
+    try {
+      const response = await apiPost<{
+        token: string;
+        base_url: string | null;
+        invoke_url: string | null;
+        poll_url_template: string | null;
+        ingress_url?: string | null;
+      }>(`/triggers/${id}/rotate_token`, {});
+      setMinted({
+        subscription,
+        token: response.token,
+        callback_secret: null,
+        rotated: true,
+        base_url: response.base_url,
+        invoke_url: response.invoke_url,
+        poll_url_template: response.poll_url_template,
+        ingress_url: response.ingress_url ?? null,
+      });
+    } catch (error) {
+      setActionErr(String(error));
+    }
+  };
+
+  if (!detail) {
+    return (
+      <div className="automation-detail">
+        {loadErr ? <div className="err">{loadErr}</div> : <LoadingRows />}
+      </div>
+    );
+  }
+  const sub = detail.subscription;
+  const agentName = agents.find((agent) => agent.id === sub.agent_id)?.name ?? null;
+  return (
+    <div className="automation-detail">
+      <header className="automation-detail-head">
+        <div>
+          <div className="automation-title-line">
+            <span className="automation-kind">
+              {sub.trigger_kind === "schedule" ? "Schedule" : sub.trigger_kind === "event" ? "Event" : "API"}
+            </span>
+            <h1>{sub.name}</h1>
+            <span className={`badge ${sub.enabled ? "ok" : ""}`}>
+              {sub.enabled ? "enabled" : "disabled"}
+            </span>
+          </div>
+          <p className="automation-intro">
+            Runs{" "}
+            {agentName ? (
+              <Link className="link" href="/agents">
+                <b>{agentName}</b>
+              </Link>
+            ) : (
+              <span className="mono">{sub.agent_id.slice(0, 8)}</span>
+            )}
+            {detail.schedule?.next_fire_at && (
+              <> · next run {new Date(detail.schedule.next_fire_at).toLocaleString()}</>
+            )}
+            {" · "}
+            <Link className="link" href="/?view=automations">
+              All automations
+            </Link>
+          </p>
+        </div>
+        <div className="automation-actions">
+          <button className="btn ghost sm" type="button" onClick={() => void rotate(sub)}>
+            Rotate token
+          </button>
+          <button className="btn sm" type="button" onClick={() => void toggle(sub)}>
+            {sub.enabled ? "Disable" : "Enable"}
+          </button>
+        </div>
+      </header>
+      {loadErr && <div className="note">Refresh failed — showing the last loaded state. {loadErr}</div>}
+      {actionErr && <div className="err">{actionErr}</div>}
+
+      <section className="automation-detail-section">
+        <h2>API</h2>
+        <AutomationContract
+          subscription={sub}
+          invokeUrl={detail.invoke_url}
+          pollUrl={detail.poll_url_template}
+          ingressUrl={detail.ingress_url}
+          token={null}
+          updatedAt={sub.updated_at}
+        />
+      </section>
+
+      <section className="automation-detail-section">
+        <h2>Activity</h2>
+        <AutomationActivity id={sub.id} />
+      </section>
+      {minted && (
+        <ShowAutomationSecrets
+          minted={minted}
+          onClose={() => {
+            setMinted(null);
+            void load();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/automations/[id]/page.tsx
+++ b/apps/web/app/automations/[id]/page.tsx
@@ -383,7 +383,7 @@ function SettingsSection({
               placeholder="https://your-service.example/fluidbox/callback"
             />
             <span className="field-hint">
-              Clearing removes the signed callback; changing it mints a NEW signing secret shown once
+              Clearing removes the signed callback; changing it mints a NEW signing secret shown once. Either change abandons deliveries still pending for earlier runs.
             </span>
           </label>
           {sub.trigger_kind === "schedule" && schedule && (

--- a/apps/web/app/components/AutomationContract.tsx
+++ b/apps/web/app/components/AutomationContract.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState } from "react";
+import { TriggerSubscription } from "../lib/api";
+import { buildCurl, classifyVariables } from "../lib/automation-contract";
+
+/* ─── Automation integration contract ─────────────────────────────────────
+   What a caller needs to actually integrate, in one copyable place: the real
+   endpoint (absolute, from the control plane — never a `<placeholder>` host),
+   the variables this automation declares, and the responses to expect. This
+   is the shared body rendered by the one-time secrets modal's pointer target
+   (the durable /automations/{id} page) and the composer preview, so all
+   surfaces show the SAME contract without drifting. */
+
+export function CopyBlock({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      /* clipboard unavailable — the text is selectable either way */
+    }
+  };
+  return (
+    <div className="field">
+      <div className="contract-head">
+        <span className="lab">{label}</span>
+        <button type="button" className="btn ghost sm" onClick={copy}>
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre className="token">{value}</pre>
+      {hint && <span className="field-hint">{hint}</span>}
+    </div>
+  );
+}
+
+export function AutomationContract({
+  subscription,
+  invokeUrl,
+  pollUrl,
+  ingressUrl,
+  token,
+  updatedAt,
+}: {
+  subscription: TriggerSubscription;
+  invokeUrl: string;
+  pollUrl: string;
+  ingressUrl: string | null;
+  token: string | null;
+  updatedAt: string | null;
+}) {
+  const kind = subscription.trigger_kind;
+  const { caller: callerVars, system: systemVars, invalid: invalidVars } = classifyVariables(
+    kind,
+    subscription.task_template
+  );
+  const declared = [...callerVars, ...systemVars, ...invalidVars];
+
+  const curl = buildCurl({
+    invokeUrl,
+    token,
+    caller: callerVars,
+    hasTemplate: !!subscription.task_template,
+  });
+
+  const responseExample = [
+    "200 OK",
+    JSON.stringify(
+      {
+        session_id: "019f…",
+        status: "queued",
+        replay: false,
+        poll_url: `/v1/triggers/${subscription.id}/runs/{session_id}`,
+      },
+      null,
+      2
+    ),
+  ].join("\n");
+
+  const hasSignedWebhook = subscription.result_destinations.some(
+    (d) => d.kind === "signed_webhook"
+  );
+
+  return (
+    <div className="contract">
+      {kind === "api" && (
+        <section className="contract-section">
+          <h4>Endpoint</h4>
+          <CopyBlock label="Invoke" value={`POST ${invokeUrl}`} />
+          <CopyBlock
+            label="Poll a run"
+            value={`GET ${pollUrl}`}
+            hint="Substitute the session_id returned by invoke."
+          />
+        </section>
+      )}
+
+      {kind === "event" && (
+        <section className="contract-section">
+          <h4>Endpoint</h4>
+          {ingressUrl && (
+            <CopyBlock
+              label="Webhook ingress"
+              value={ingressUrl}
+              hint="Deliveries are authenticated by their signature, so this URL needs no token."
+            />
+          )}
+          <p className="contract-note">
+            Runs start from repository events — there is no API caller to authenticate.
+          </p>
+        </section>
+      )}
+
+      {kind === "schedule" && (
+        <section className="contract-section">
+          <h4>Endpoint</h4>
+          <p className="contract-note">
+            Runs start on the clock — there is no API caller.
+          </p>
+        </section>
+      )}
+
+      <section className="contract-section">
+        <h4>Variables</h4>
+        {declared.length === 0 ? (
+          <p className="contract-note">
+            This automation&apos;s task has no placeholders, so callers send an empty body.
+            Add <code>{"{{name}}"}</code> to the task template to accept values.
+          </p>
+        ) : (
+          <div className="rows">
+            {callerVars.map((name) => (
+              <div key={name} className="row contract-var">
+                <span className="mono">{`{{${name}}}`}</span>
+                <span className="faint">
+                  you supply it in <code>context</code>
+                </span>
+              </div>
+            ))}
+            {systemVars.map((name) => (
+              <div key={name} className="row contract-var">
+                <span className="mono">{`{{${name}}}`}</span>
+                <span className="faint">filled in by fluidbox</span>
+              </div>
+            ))}
+            {invalidVars.map((name) => (
+              <div key={name} className="row contract-var">
+                <span className="mono invalid">{`{{${name}}}`}</span>
+                <span className="faint invalid">
+                  not available — save refuses this placeholder
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+        <p className="contract-note">
+          <strong>{subscription.allow_task_override ? "Task override allowed" : "Task override refused"}</strong> ·{" "}
+          <strong>{subscription.allow_workspace_override ? "workspace override allowed" : "workspace override refused"}</strong>.
+          Sending a refused field returns 400. Context values must be flat strings.
+        </p>
+      </section>
+
+      {kind === "api" && (
+        <section className="contract-section">
+          <h4>Request</h4>
+          <CopyBlock
+            label="Example"
+            value={curl}
+            hint="Idempotency-Key is optional but strongly recommended: replaying the same key returns the original run instead of starting a second one."
+          />
+        </section>
+      )}
+
+      <section className="contract-section">
+        <h4>Responses</h4>
+        <CopyBlock label="Success" value={responseExample} />
+        <div className="rows">
+          <div className="row contract-var">
+            <span className="mono">409</span>
+            <span className="faint">
+              a run is already active and this automation is set to{" "}
+              <code>{subscription.concurrency_policy}</code>
+            </span>
+          </div>
+          <div className="row contract-var">
+            <span className="mono">422</span>
+            <span className="faint">
+              the Idempotency-Key was already used with a different request body
+            </span>
+          </div>
+          <div className="row contract-var">
+            <span className="mono">400</span>
+            <span className="faint">an override this subscription does not allow</span>
+          </div>
+          <div className="row contract-var">
+            <span className="mono">401</span>
+            <span className="faint">wrong token, or the token was revoked</span>
+          </div>
+        </div>
+      </section>
+
+      {hasSignedWebhook && (
+        <section className="contract-section">
+          <h4>Result delivery</h4>
+          <p className="contract-note">
+            When the run finishes, fluidbox POSTs the result to your callback URL and retries
+            with backoff over roughly an hour. Delivery is at-least-once — deduplicate on{" "}
+            <code>x-fluidbox-delivery</code>.
+          </p>
+          <CopyBlock
+            label="Signature"
+            value={'x-fluidbox-signature: v1=hmac-sha256(secret, "{timestamp}.{body}")'}
+            hint="Also sent: x-fluidbox-delivery (unique id) and x-fluidbox-timestamp. Verify before trusting the payload."
+          />
+        </section>
+      )}
+
+      {updatedAt && (
+        <p className="contract-stamp">
+          Reflects the configuration as of {new Date(updatedAt).toLocaleString()}.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Live placeholder read-back under a template textarea: which {{names}}
+ *  the caller supplies, which the platform fills, and which a no-caller
+ *  kind can never fill (save will refuse those). */
+export function TemplateChips({ kind, template }: { kind: string; template: string }) {
+  const { caller, system, invalid } = classifyVariables(kind, template || null);
+  if (caller.length === 0 && system.length === 0 && invalid.length === 0) return null;
+  return (
+    <div className="tpl-chips">
+      {caller.map((name) => (
+        <span key={name} className="tpl-chip caller" title="Caller supplies this in `context`">
+          {`{{${name}}}`} · caller
+        </span>
+      ))}
+      {system.map((name) => (
+        <span key={name} className="tpl-chip system" title="Filled in by fluidbox">
+          {`{{${name}}}`} · fluidbox
+        </span>
+      ))}
+      {invalid.map((name) => (
+        <span key={name} className="tpl-chip invalid" title="This trigger has no caller and fluidbox does not fill this name — saving will be refused">
+          {`{{${name}}}`} · unknown
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/components/AutomationContract.tsx
+++ b/apps/web/app/components/AutomationContract.tsx
@@ -59,13 +59,6 @@ export function AutomationContract({
   );
   const declared = [...callerVars, ...systemVars, ...invalidVars];
 
-  const curl = buildCurl({
-    invokeUrl,
-    token,
-    caller: callerVars,
-    hasTemplate: !!subscription.task_template,
-  });
-
   const responseExample = [
     "200 OK",
     JSON.stringify(
@@ -168,7 +161,12 @@ export function AutomationContract({
           <h4>Request</h4>
           <CopyBlock
             label="Example"
-            value={curl}
+            value={buildCurl({
+              invokeUrl,
+              token,
+              caller: callerVars,
+              hasTemplate: !!subscription.task_template,
+            })}
             hint="Idempotency-Key is optional but strongly recommended: replaying the same key returns the original run instead of starting a second one."
           />
         </section>

--- a/apps/web/app/components/AutomationPanel.tsx
+++ b/apps/web/app/components/AutomationPanel.tsx
@@ -212,7 +212,9 @@ function AutomationRow({
         <KindIcon kind={subscription.trigger_kind} />
         <div className="automation-copy">
           <div className="automation-title-line">
-            <strong>{subscription.name}</strong>
+            <Link className="link" href={`/automations/${subscription.id}`}>
+              <strong>{subscription.name}</strong>
+            </Link>
             <span className={`badge ${subscription.enabled ? "ok" : ""}`}>
               {subscription.enabled ? "enabled" : "disabled"}
             </span>
@@ -233,6 +235,9 @@ function AutomationRow({
           <button className="btn ghost sm" type="button" onClick={() => setOpen((current) => !current)}>
             {open ? "Hide activity" : "Activity"}
           </button>
+          <Link className="btn ghost sm" href={`/automations/${subscription.id}`}>
+            Open →
+          </Link>
           <button className="btn ghost sm" type="button" onClick={() => onRotate(subscription)}>
             Rotate token
           </button>
@@ -250,7 +255,7 @@ function AutomationRow({
   );
 }
 
-function AutomationActivity({ id }: { id: string }) {
+export function AutomationActivity({ id }: { id: string }) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [deliveries, setDeliveries] = useState<ResultDelivery[]>([]);
   const [invocations, setInvocations] = useState<TriggerInvocation[]>([]);

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -18,6 +18,7 @@ import {
 } from "../lib/api";
 import { AddServerWizard } from "../capabilities/AddServerWizard";
 import { defaultModelFor, modelsFor, useHarnesses } from "../lib/harnesses";
+import { buildCurl, classifyVariables } from "../lib/automation-contract";
 import { useAuthMe } from "../lib/useAuthMe";
 import { AppPicker } from "./AppPicker";
 import { HarnessPicker } from "./HarnessPicker";
@@ -1704,23 +1705,6 @@ function SpecRow({
    the secrets that exist only in this response, the variables this automation
    declares, and the responses to expect. */
 
-/** Placeholders the platform fills in itself, per trigger kind. Anything else
- *  in the template is the caller's to supply in `context`. */
-const SYSTEM_VARIABLES: Record<string, string[]> = {
-  schedule: ["fire_time"],
-  event: ["repository", "pr_number", "pr_title"],
-  api: [],
-};
-
-function templateVariables(template: string | null): string[] {
-  if (!template) return [];
-  const found = new Set<string>();
-  for (const match of template.matchAll(/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g)) {
-    found.add(match[1]);
-  }
-  return [...found];
-}
-
 function CopyBlock({ label, value, hint }: { label: string; value: string; hint?: string }) {
   const [copied, setCopied] = useState(false);
   const copy = async () => {
@@ -1760,23 +1744,14 @@ export function ShowAutomationSecrets({
   const invokeUrl = minted.invoke_url || `<control-plane>/v1/triggers/${sub.id}/invoke`;
   const pollUrl = minted.poll_url_template || `<control-plane>/v1/triggers/${sub.id}/runs/{session_id}`;
 
-  const system = SYSTEM_VARIABLES[kind] ?? [];
-  const declared = templateVariables(sub.task_template);
-  const callerVars = declared.filter((name) => !system.includes(name));
-  const systemVars = declared.filter((name) => system.includes(name));
-
-  const contextExample =
-    callerVars.length > 0
-      ? `{"context": {${callerVars.map((name) => `"${name}": "…"`).join(", ")}}}`
-      : `{}`;
-
-  const curl = [
-    `curl -X POST '${invokeUrl}' \\`,
-    `  -H 'Authorization: Bearer ${minted.token}' \\`,
-    `  -H 'Content-Type: application/json' \\`,
-    `  -H 'Idempotency-Key: <your-unique-key>' \\`,
-    `  -d '${contextExample}'`,
-  ].join("\n");
+  const { caller: callerVars, system: systemVars } = classifyVariables(kind, sub.task_template);
+  const declared = [...callerVars, ...systemVars];
+  const curl = buildCurl({
+    invokeUrl,
+    token: minted.token,
+    caller: callerVars,
+    hasTemplate: !!sub.task_template,
+  });
 
   const responseExample = [
     "200 OK",

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -18,7 +18,8 @@ import {
 } from "../lib/api";
 import { AddServerWizard } from "../capabilities/AddServerWizard";
 import { defaultModelFor, modelsFor, useHarnesses } from "../lib/harnesses";
-import { CopyBlock } from "./AutomationContract";
+import { CopyBlock, TemplateChips } from "./AutomationContract";
+import { buildCurl, classifyVariables } from "../lib/automation-contract";
 import { useAuthMe } from "../lib/useAuthMe";
 import { AppPicker } from "./AppPicker";
 import { HarnessPicker } from "./HarnessPicker";
@@ -615,6 +616,9 @@ export function RunComposer({
       if (mode === "automation" && !task.trim() && !allowTask) {
         return "Describe the task, or allow the caller to provide one (under advanced controls).";
       }
+      if (mode === "automation" && (kind === "schedule" || kind === "event") && !task.trim()) {
+        return "This trigger fires without a caller — write the task template it should run.";
+      }
     }
     if (agentsLoading || revisionLoading) return "Loading the agent configuration…";
     if (agentChoice === "existing" && !selectedAgentName) return "Choose an agent or create one here.";
@@ -758,10 +762,10 @@ export function RunComposer({
 
   const templateHint =
     kind === "schedule"
-      ? "You can use {{fire_time}} in these instructions."
+      ? "Saved with the automation. {{fire_time}} is filled in at each firing; any other {{name}} is refused at save (a schedule has no caller to supply it)."
       : kind === "event"
-        ? "Pull request values such as {{repository}}, {{pr_number}}, and {{pr_title}} are available."
-        : "API callers can supply values for placeholders such as {{ticket}}.";
+        ? "Saved with the automation. Pull-request values ({{repository}}, {{pr_number}}, {{pr_title}}, {{pr_url}}, {{pr_author}}, …) are filled from the event; any other {{name}} is refused at save."
+        : "Saved with the automation. Every {{name}} you add becomes a required context value the API caller sends on invoke.";
 
   const agentDisplayName = agentChoice === "new" ? newAgentName.trim() || "New agent" : selectedAgentName;
   const finalAction = agentOnly ? "Create Agent" : mode === "once" ? "Start Run" : "Save Automation";
@@ -954,15 +958,32 @@ export function RunComposer({
 
             <label className="field">
               <span className="lab">
-                {mode === "once" ? "What should the agent accomplish?" : "What should happen each time?"}
-                {mode === "automation" && <span className="optional-label"> optional template</span>}
+                {mode === "once"
+                  ? "What should the agent accomplish?"
+                  : kind === "api"
+                    ? "Task template — rendered for every API invocation"
+                    : kind === "schedule"
+                      ? "Task template — rendered at every scheduled firing"
+                      : "Task template — rendered for every matching PR event"}
+                {mode === "automation" && kind === "api" && allowTask && (
+                  <span className="optional-label"> optional — callers may send their own task</span>
+                )}
               </span>
               <textarea
                 className="inp run-task-input"
                 value={task}
                 onChange={(event) => setTask(event.target.value)}
-                placeholder={mode === "once" ? "Review the latest changes, identify regressions, and prepare a safe patch…" : "Investigate {{ticket}} and report the root cause…"}
+                placeholder={
+                  mode === "once"
+                    ? "Review the latest changes, identify regressions, and prepare a safe patch…"
+                    : kind === "schedule"
+                      ? "Sweep the queue as of {{fire_time}} and file a summary…"
+                      : kind === "event"
+                        ? "Review {{repository}} PR #{{pr_number}}: {{pr_title}}…"
+                        : "Investigate {{ticket}} and report the root cause…"
+                }
               />
+              {mode === "automation" && <TemplateChips kind={kind} template={task} />}
               {mode === "automation" && <span className="field-hint">{templateHint}</span>}
             </label>
           </ComposerSection>
@@ -1619,6 +1640,10 @@ export function RunComposer({
               />
             )}
 
+            {!agentOnly && mode === "automation" && kind === "api" && !blockingIssue && (
+              <ApiPreview task={task} allowTask={allowTask} />
+            )}
+
             {agentChoice === "existing" && revisionTouched && (
               <p className="rc-note">
                 One new revision will be appended to {selectedAgentName}. Active runs keep the
@@ -1695,6 +1720,59 @@ function SpecRow({
       <span className="rc-row-label">{label}</span>
       <span className={`rc-row-value ${clamp ? "rc-clamp" : ""}`}>{value}</span>
       {sub && <span className="rc-row-sub">{sub}</span>}
+    </div>
+  );
+}
+
+/** Pre-save preview of the integration contract. Deliberately labeled a
+ *  preview: the id and token exist only after save, so those two are
+ *  placeholders — but the base URL is the server's real answer. */
+function ApiPreview({ task, allowTask }: { task: string; allowTask: boolean }) {
+  const [copied, setCopied] = useState(false);
+  const [baseUrl, setBaseUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    apiGetCached<{ base_url?: string }>("/triggers", { maxAgeMs: 60_000 })
+      .then((response) => {
+        if (!cancelled && response.base_url) setBaseUrl(response.base_url);
+      })
+      .catch(() => {
+        /* preview keeps the {base_url} placeholder */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const { caller } = classifyVariables("api", task || null);
+  const hasTemplate = task.trim().length > 0;
+  const curl = buildCurl({
+    invokeUrl: `${baseUrl ?? "{base_url}"}/v1/triggers/{id-assigned-on-save}/invoke`,
+    token: "<minted-on-save>",
+    caller,
+    hasTemplate: hasTemplate || !allowTask,
+  });
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(curl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      /* clipboard unavailable — the text is selectable either way */
+    }
+  };
+  return (
+    <div className="rc-api-preview">
+      <div className="contract-head">
+        <span className="rc-row-label">API preview</span>
+        <button type="button" className="btn ghost sm" onClick={copy}>
+          {copied ? "Copied" : "Copy preview"}
+        </button>
+      </div>
+      <pre className="token rc-api-preview-curl">{curl}</pre>
+      <span className="field-hint">
+        The id and one-time token are minted when you save; the full contract then lives on
+        the automation&apos;s page.
+      </span>
     </div>
   );
 }

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -18,7 +18,7 @@ import {
 } from "../lib/api";
 import { AddServerWizard } from "../capabilities/AddServerWizard";
 import { defaultModelFor, modelsFor, useHarnesses } from "../lib/harnesses";
-import { buildCurl, classifyVariables } from "../lib/automation-contract";
+import { CopyBlock } from "./AutomationContract";
 import { useAuthMe } from "../lib/useAuthMe";
 import { AppPicker } from "./AppPicker";
 import { HarnessPicker } from "./HarnessPicker";
@@ -1699,36 +1699,12 @@ function SpecRow({
   );
 }
 
-/* ─── Automation integration contract ─────────────────────────────────────
-   What a caller needs to actually integrate, in one copyable place: the real
-   endpoint (absolute, from the control plane — never a `<placeholder>` host),
-   the secrets that exist only in this response, the variables this automation
-   declares, and the responses to expect. */
-
-function CopyBlock({ label, value, hint }: { label: string; value: string; hint?: string }) {
-  const [copied, setCopied] = useState(false);
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1600);
-    } catch {
-      /* clipboard unavailable — the text is selectable either way */
-    }
-  };
-  return (
-    <div className="field">
-      <div className="contract-head">
-        <span className="lab">{label}</span>
-        <button type="button" className="btn ghost sm" onClick={copy}>
-          {copied ? "Copied" : "Copy"}
-        </button>
-      </div>
-      <pre className="token">{value}</pre>
-      {hint && <span className="field-hint">{hint}</span>}
-    </div>
-  );
-}
+/* ─── One-time secrets modal ───────────────────────────────────────────────
+   Shown once after minting or rotating an automation's credentials. The token
+   and signing secret are stored hashed/sealed and can never be re-displayed,
+   so this panel exists solely to hand them over. Everything else about the
+   automation (endpoint, request shape, variables, responses) lives on the
+   durable /automations/{id} page via <AutomationContract>. */
 
 export function ShowAutomationSecrets({
   minted,
@@ -1738,39 +1714,11 @@ export function ShowAutomationSecrets({
   onClose: () => void;
 }) {
   const sub = minted.subscription;
-  const kind = sub.trigger_kind;
-  // Fall back to a relative path only if an older control plane omitted the
-  // absolute URLs; the placeholder is then honest about being one.
-  const invokeUrl = minted.invoke_url || `<control-plane>/v1/triggers/${sub.id}/invoke`;
-  const pollUrl = minted.poll_url_template || `<control-plane>/v1/triggers/${sub.id}/runs/{session_id}`;
-
-  const { caller: callerVars, system: systemVars } = classifyVariables(kind, sub.task_template);
-  const declared = [...callerVars, ...systemVars];
-  const curl = buildCurl({
-    invokeUrl,
-    token: minted.token,
-    caller: callerVars,
-    hasTemplate: !!sub.task_template,
-  });
-
-  const responseExample = [
-    "200 OK",
-    JSON.stringify(
-      {
-        session_id: "019f…",
-        status: "queued",
-        replay: false,
-        poll_url: `/v1/triggers/${sub.id}/runs/{session_id}`,
-      },
-      null,
-      2
-    ),
-  ].join("\n");
 
   return (
     <ModalShell
       title={minted.rotated ? "Token rotated" : `“${sub.name}” is live`}
-      sub="The token and signing secret exist only in this response — they are stored hashed and sealed and can never be shown again."
+      sub="The token and signing secret exist only in this response — they are stored hashed and sealed and can never be shown again. Everything else stays available on the automation's page."
       onClose={onClose}
       maxWidth="min(760px, 96vw)"
       dirty
@@ -1795,100 +1743,16 @@ export function ShowAutomationSecrets({
         </section>
 
         <section className="contract-section">
-          <h4>Endpoint</h4>
-          <CopyBlock label="Invoke" value={`POST ${invokeUrl}`} />
-          <CopyBlock
-            label="Poll a run"
-            value={`GET ${pollUrl}`}
-            hint="Substitute the session_id returned by invoke."
-          />
-          {minted.ingress_url && (
-            <CopyBlock
-              label="Webhook ingress"
-              value={minted.ingress_url}
-              hint="Deliveries are authenticated by their signature, so this URL needs no token."
-            />
-          )}
-        </section>
-
-        <section className="contract-section">
-          <h4>Variables</h4>
-          {declared.length === 0 ? (
-            <p className="contract-note">
-              This automation&apos;s task has no placeholders, so callers send an empty body.
-              Add <code>{"{{name}}"}</code> to the task template to accept values.
-            </p>
-          ) : (
-            <div className="rows">
-              {callerVars.map((name) => (
-                <div key={name} className="row contract-var">
-                  <span className="mono">{`{{${name}}}`}</span>
-                  <span className="faint">
-                    you supply it in <code>context</code>
-                  </span>
-                </div>
-              ))}
-              {systemVars.map((name) => (
-                <div key={name} className="row contract-var">
-                  <span className="mono">{`{{${name}}}`}</span>
-                  <span className="faint">filled in by fluidbox</span>
-                </div>
-              ))}
-            </div>
-          )}
+          <h4>Where everything else lives</h4>
           <p className="contract-note">
-            <strong>{sub.allow_task_override ? "Task override allowed" : "Task override refused"}</strong> ·{" "}
-            <strong>{sub.allow_workspace_override ? "workspace override allowed" : "workspace override refused"}</strong>.
-            Sending a refused field returns 400. Context values must be flat strings.
+            The endpoint, request shape, variables, and response contract are always
+            available at{" "}
+            <Link className="link" href={`/automations/${sub.id}`} onClick={onClose}>
+              Automations → {sub.name} → API
+            </Link>
+            {" "}— only the secrets above are shown once. Lost token? Rotate it there.
           </p>
         </section>
-
-        <section className="contract-section">
-          <h4>Request</h4>
-          <CopyBlock
-            label="Example"
-            value={curl}
-            hint="Idempotency-Key is optional but strongly recommended: replaying the same key returns the original run instead of starting a second one."
-          />
-        </section>
-
-        <section className="contract-section">
-          <h4>Responses</h4>
-          <pre className="token">{responseExample}</pre>
-          <div className="rows">
-            <div className="row contract-var">
-              <span className="mono">409</span>
-              <span className="faint">
-                a run is already active and this automation is set to{" "}
-                <code>{sub.concurrency_policy}</code>, or the key was reused with a different body
-              </span>
-            </div>
-            <div className="row contract-var">
-              <span className="mono">400</span>
-              <span className="faint">an override this subscription does not allow</span>
-            </div>
-            <div className="row contract-var">
-              <span className="mono">401</span>
-              <span className="faint">wrong token, or the token was revoked</span>
-            </div>
-          </div>
-        </section>
-
-        {minted.callback_secret && (
-          <section className="contract-section">
-            <h4>Result delivery</h4>
-            <p className="contract-note">
-              When the run finishes, fluidbox POSTs the result to your callback URL and retries
-              with backoff over roughly an hour. Delivery is at-least-once — deduplicate on{" "}
-              <code>x-fluidbox-delivery</code>.
-            </p>
-            <CopyBlock
-              label="Signature"
-              value={'x-fluidbox-signature: v1=hmac-sha256(secret, "{timestamp}.{body}")'}
-              hint="Also sent: x-fluidbox-delivery (unique id) and x-fluidbox-timestamp. Verify before trusting the payload."
-            />
-          </section>
-        )}
       </div>
 
       <div className="modal-footer secret-footer">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4609,6 +4609,35 @@ select.inp {
   font-size: 11.5px;
   line-height: 1.45;
 }
+.contract-var .mono.invalid,
+.contract-var .faint.invalid {
+  color: var(--red);
+}
+.contract-stamp {
+  font-size: 12px;
+  color: var(--ink-3);
+  margin: 4px 0 0;
+}
+.tpl-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+.tpl-chip {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+.tpl-chip.system {
+  opacity: 0.7;
+}
+.tpl-chip.invalid {
+  border-color: var(--red);
+  color: var(--red);
+}
 
 /* A pinned bundle that Phase C refuses at run creation. Kept visible so a
    legacy revision can be fixed, marked so it is not mistaken for usable. */

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4389,6 +4389,8 @@ select.inp {
   letter-spacing: 0.07em;
   color: var(--ink-3);
 }
+.rc-api-preview { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border); }
+.rc-api-preview-curl { font-size: 11px; max-height: 140px; overflow: auto; }
 .rc-row-value {
   font-size: 13px;
   color: var(--ink);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1401,6 +1401,11 @@ h1.title {
   color: var(--ink-3);
   font-size: 11.5px;
 }
+.automation-detail { max-width: 880px; margin: 0 auto; padding: 24px 16px 64px; }
+.automation-detail-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 8px; }
+.automation-detail-head h1 { font-size: 20px; margin: 0; }
+.automation-detail-section { margin-top: 28px; }
+.automation-detail-section > h2 { font-size: 15px; margin: 0 0 10px; }
 .activity-line {
   min-height: 28px;
   display: flex;

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -702,6 +702,7 @@ export interface TriggerSubscription {
   /** Capability keep-list (§3.5 narrowing); null = keep all attached. */
   capability_bundles: string[] | null;
   created_at: string;
+  updated_at: string;
 }
 
 /** The clock on a subscription (schedules table). */
@@ -736,6 +737,20 @@ export interface ResultDelivery {
   last_error: string | null;
   delivered_at: string | null;
   created_at: string;
+}
+
+/** GET /v1/triggers/{id} — subscription + activity + the caller-facing URLs
+ *  (server-derived from FLUIDBOX_PUBLIC_URL; the dashboard never builds hosts). */
+export interface TriggerDetail {
+  subscription: TriggerSubscription;
+  schedule: Schedule | null;
+  sessions: Session[];
+  deliveries: ResultDelivery[];
+  invocations: TriggerInvocation[];
+  base_url: string;
+  invoke_url: string;
+  poll_url_template: string;
+  ingress_url: string | null;
 }
 
 export interface Approval {

--- a/apps/web/app/lib/automation-contract.test.ts
+++ b/apps/web/app/lib/automation-contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCurl,
+  classifyVariables,
+  contextExample,
+  SYSTEM_VARIABLES,
+  templateVariables,
+} from "./automation-contract";
+
+describe("templateVariables", () => {
+  it("extracts unique placeholder names", () => {
+    expect(templateVariables("do {{ticket}} for {{ team }} re {{ticket}}")).toEqual([
+      "ticket",
+      "team",
+    ]);
+    expect(templateVariables(null)).toEqual([]);
+  });
+});
+
+describe("classifyVariables", () => {
+  it("api kind: everything is caller-supplied, nothing invalid", () => {
+    const r = classifyVariables("api", "do {{ticket}}");
+    expect(r).toEqual({ caller: ["ticket"], system: [], invalid: [] });
+  });
+  it("schedule kind: fire_time is system, anything else is invalid (no caller exists)", () => {
+    const r = classifyVariables("schedule", "sweep {{fire_time}} for {{team}}");
+    expect(r.system).toEqual(["fire_time"]);
+    expect(r.caller).toEqual([]);
+    expect(r.invalid).toEqual(["team"]);
+  });
+  it("event kind knows the full GitHub context, not just three names", () => {
+    // Mirrors connectors/github.rs sample_context() — 12 variables.
+    expect(SYSTEM_VARIABLES.event).toEqual([
+      "repository", "pr_number", "pr_title", "pr_url", "pr_author",
+      "head_sha", "head_ref", "base_sha", "base_ref", "action", "event", "fork",
+    ]);
+    const r = classifyVariables("event", "review {{pr_url}} by {{pr_author}} ({{oops}})");
+    expect(r.system).toEqual(["pr_url", "pr_author"]);
+    expect(r.invalid).toEqual(["oops"]);
+  });
+});
+
+describe("buildCurl", () => {
+  const url = "https://fb.example/v1/triggers/x/invoke";
+  it("real token rides in single quotes", () => {
+    expect(
+      buildCurl({ invokeUrl: url, token: "fbx_trig_abc", caller: [], hasTemplate: true })
+    ).toContain("-H 'Authorization: Bearer fbx_trig_abc'");
+  });
+  it("durable form uses DOUBLE quotes so the shell expands the variable", () => {
+    const durable = buildCurl({ invokeUrl: url, token: null, caller: ["ticket"], hasTemplate: true });
+    expect(durable).toContain('-H "Authorization: Bearer ${FLUIDBOX_TRIGGER_TOKEN}"');
+    expect(durable).toContain('"ticket": "…"');
+  });
+  it("template-less automation sends a task, not {} (invoke would 400)", () => {
+    const c = buildCurl({ invokeUrl: url, token: null, caller: [], hasTemplate: false });
+    expect(c).toContain('"task"');
+    expect(c).not.toContain("-d '{}'");
+  });
+});
+
+describe("contextExample", () => {
+  it("is {} with no caller variables", () => {
+    expect(contextExample([])).toBe("{}");
+    expect(contextExample(["a", "b"])).toBe('{"context": {"a": "…", "b": "…"}}');
+  });
+});

--- a/apps/web/app/lib/automation-contract.ts
+++ b/apps/web/app/lib/automation-contract.ts
@@ -1,0 +1,75 @@
+/** Pure integration-contract helpers shared by the composer preview, the
+ *  one-time secrets modal, and the durable automation detail page. Keeping
+ *  them here (tested, presentation-free) is what lets three surfaces render
+ *  the SAME contract without drifting. */
+
+/** Placeholders the platform fills in itself, per trigger kind. Anything
+ *  else is the caller's (api kind) or refused at save (schedule/event fire
+ *  with no caller). The event list mirrors connectors/github.rs
+ *  sample_context() — keep them in lockstep. */
+export const SYSTEM_VARIABLES: Record<string, string[]> = {
+  schedule: ["fire_time"],
+  event: [
+    "repository", "pr_number", "pr_title", "pr_url", "pr_author",
+    "head_sha", "head_ref", "base_sha", "base_ref", "action", "event", "fork",
+  ],
+  api: [],
+};
+
+export function templateVariables(template: string | null): string[] {
+  if (!template) return [];
+  const found = new Set<string>();
+  for (const match of template.matchAll(/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g)) {
+    found.add(match[1]);
+  }
+  return [...found];
+}
+
+export function classifyVariables(
+  kind: string,
+  template: string | null
+): { caller: string[]; system: string[]; invalid: string[] } {
+  const systemNames = SYSTEM_VARIABLES[kind] ?? [];
+  const declared = templateVariables(template);
+  const system = declared.filter((name) => systemNames.includes(name));
+  const rest = declared.filter((name) => !systemNames.includes(name));
+  // schedule/event fire with no caller: an unknown placeholder can never be
+  // filled and the server refuses it at save — that's an error, not a
+  // caller variable.
+  const noCaller = kind === "schedule" || kind === "event";
+  return {
+    system,
+    caller: noCaller ? [] : rest,
+    invalid: noCaller ? rest : [],
+  };
+}
+
+export function contextExample(caller: string[]): string {
+  if (caller.length === 0) return "{}";
+  return `{"context": {${caller.map((name) => `"${name}": "…"`).join(", ")}}}`;
+}
+
+/** token null → the durable view: the secret is the caller's to hold, so
+ *  the curl reads it from the environment — double quotes, or the shell
+ *  ships the literal dollar text. hasTemplate false → the automation has no
+ *  stored template (override-only), so invoke REQUIRES a task in the body. */
+export function buildCurl(opts: {
+  invokeUrl: string;
+  token: string | null;
+  caller: string[];
+  hasTemplate: boolean;
+}): string {
+  const auth = opts.token
+    ? `  -H 'Authorization: Bearer ${opts.token}' \\`
+    : `  -H "Authorization: Bearer \${FLUIDBOX_TRIGGER_TOKEN}" \\`;
+  const body = opts.hasTemplate
+    ? contextExample(opts.caller)
+    : `{"task": "…what this invocation should do…"}`;
+  return [
+    `curl -X POST '${opts.invokeUrl}' \\`,
+    auth,
+    `  -H 'Content-Type: application/json' \\`,
+    `  -H 'Idempotency-Key: <your-unique-key>' \\`,
+    `  -d '${body}'`,
+  ].join("\n");
+}

--- a/crates/fluidbox-db/src/lib.rs
+++ b/crates/fluidbox-db/src/lib.rs
@@ -3907,6 +3907,117 @@ pub async fn set_trigger_subscription_enabled(
     Ok(__rls_out)
 }
 
+/// What PATCH does to the callback destination: leave it alone, remove it,
+/// or replace it with a freshly sealed secret. Owns its data — the sealed
+/// bytes are produced inside the handler's match arm.
+pub enum CallbackUpdate {
+    Keep,
+    Clear,
+    Set {
+        destinations: Value,
+        sealed: Vec<u8>,
+        key_version: i16,
+    },
+}
+
+pub struct ScheduleConfigUpdate {
+    pub cron: String,
+    pub timezone: String,
+    pub missed_run_policy: String,
+    pub next_fire_at: DateTime<Utc>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_trigger_subscription(
+    pool: &PgPool,
+    scope: TenantScope,
+    id: Uuid,
+    expect_updated_at: DateTime<Utc>,
+    name: &str,
+    task_template: Option<&str>,
+    allow_task_override: bool,
+    allow_workspace_override: bool,
+    concurrency_policy: &str,
+    callback: CallbackUpdate,
+    schedule: Option<&ScheduleConfigUpdate>,
+) -> sqlx::Result<Option<(TriggerSubscriptionRow, Option<ScheduleRow>)>> {
+    // key_version 1 when bytes are NULL: the column CHECKs in (1,2) and the
+    // version is moot without bytes (Sealed::split's convention).
+    let (cb_touched, cb_dests, cb_sealed, cb_kv): (bool, Value, Option<Vec<u8>>, i16) =
+        match callback {
+            CallbackUpdate::Keep => (false, Value::Array(vec![]), None, 1),
+            CallbackUpdate::Clear => (true, Value::Array(vec![]), None, 1),
+            CallbackUpdate::Set {
+                destinations,
+                sealed,
+                key_version,
+            } => (true, destinations, Some(sealed), key_version),
+        };
+    let mut tx = scoped_tx(pool, scope).await?;
+
+    let sub: Option<TriggerSubscriptionRow> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        "update trigger_subscriptions set
+           name = $2, task_template = $3, allow_task_override = $4,
+           allow_workspace_override = $5, concurrency_policy = $6,
+           result_destinations = case when $7 then $8 else result_destinations end,
+           callback_secret_sealed = case when $7 then $9 else callback_secret_sealed end,
+           callback_secret_key_version =
+             case when $7 then $10 else callback_secret_key_version end,
+           authority_generation =
+             authority_generation + case when $7 then 1 else 0 end,
+           updated_at = now()
+         where id = $1 and tenant_id = $11 and updated_at = $12
+         returning {SUBSCRIPTION_COLS}"
+    )))
+    .bind(id)
+    .bind(name)
+    .bind(task_template)
+    .bind(allow_task_override)
+    .bind(allow_workspace_override)
+    .bind(concurrency_policy)
+    .bind(cb_touched)
+    .bind(cb_dests)
+    .bind(cb_sealed)
+    .bind(cb_kv)
+    .bind(scope.tenant_id())
+    .bind(expect_updated_at)
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(sub) = sub else {
+        // Stale expect_updated_at or vanished row: nothing written, tx drops.
+        return Ok(None);
+    };
+
+    let schedule_row = match schedule {
+        None => None,
+        Some(s) => Some(
+            sqlx::query_as::<_, ScheduleRow>(
+                "update schedules set cron = $2, timezone = $3,
+                   missed_run_policy = $4, next_fire_at = $5, updated_at = now()
+                 where subscription_id = $1
+                   and exists (select 1 from trigger_subscriptions sub
+                               where sub.id = $1 and sub.tenant_id = $6)
+                 returning *",
+            )
+            .bind(id)
+            .bind(&s.cron)
+            .bind(&s.timezone)
+            .bind(&s.missed_run_policy)
+            .bind(s.next_fire_at)
+            .bind(scope.tenant_id())
+            .fetch_optional(&mut *tx)
+            .await?
+            // A schedule-kind subscription without its schedules row is
+            // corruption; error → the WHOLE tx (incl. the subscription
+            // update above) rolls back.
+            .ok_or(sqlx::Error::RowNotFound)?,
+        ),
+    };
+
+    tx.commit().await?;
+    Ok(Some((sub, schedule_row)))
+}
+
 /// The only reader of the sealed callback secret. Deliveries for in-flight
 /// runs must still sign after a disable, so this does not require `enabled`.
 pub async fn subscription_callback_secret_sealed(

--- a/crates/fluidbox-db/src/lib.rs
+++ b/crates/fluidbox-db/src/lib.rs
@@ -3924,7 +3924,11 @@ pub struct ScheduleConfigUpdate {
     pub cron: String,
     pub timezone: String,
     pub missed_run_policy: String,
-    pub next_fire_at: DateTime<Utc>,
+    /// The `schedules.next_fire_at` column is nullable. `None` preserves the
+    /// "no future fire" state: a cadence-neutral PATCH (e.g. missed_run_policy
+    /// only) carries the existing row's clock through unchanged rather than
+    /// resetting it, and that clock may itself be `None`.
+    pub next_fire_at: Option<DateTime<Utc>>,
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/fluidbox-server/src/connectors/github.rs
+++ b/crates/fluidbox-server/src/connectors/github.rs
@@ -233,6 +233,7 @@ pub fn normalize(
 
 /// Representative context for config-time template validation. Keys must
 /// stay a superset-match of what `normalize` produces.
+// Mirrored by apps/web/app/lib/automation-contract.ts SYSTEM_VARIABLES.event — keep in lockstep (vitest pins the list).
 pub fn sample_context() -> BTreeMap<String, String> {
     [
         ("repository", "acme/site"),

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -530,7 +530,7 @@ async fn main() -> anyhow::Result<()> {
         // the connection's sealed secret) is the authentication.
         .route("/ingress/{provider}/{connection_id}", post(events::ingress))
         .route("/triggers", get(triggers::list).post(triggers::create))
-        .route("/triggers/{id}", get(triggers::get))
+        .route("/triggers/{id}", get(triggers::get).patch(triggers::update))
         .route("/triggers/{id}/enable", post(triggers::enable))
         .route("/triggers/{id}/disable", post(triggers::disable))
         .route("/triggers/{id}/rotate_token", post(triggers::rotate_token))

--- a/crates/fluidbox-server/src/triggers.rs
+++ b/crates/fluidbox-server/src/triggers.rs
@@ -220,6 +220,57 @@ fn random_hex_token(prefix: &str) -> String {
     )
 }
 
+/// Caller-facing URL block for a subscription's integration contract.
+/// The control plane is the only party that knows its own public address
+/// (the dashboard reaches it through a same-origin proxy), so create,
+/// rotate, get, and update all hand these over rather than letting a client
+/// guess. Nothing here is secret: it is public_url + subscription id.
+fn contract_urls(
+    base: &str,
+    sub_id: Uuid,
+    ingress_path: Option<&str>,
+) -> serde_json::Map<String, Value> {
+    let base = base.trim_end_matches('/');
+    let mut m = serde_json::Map::new();
+    m.insert("base_url".into(), json!(base));
+    m.insert(
+        "invoke_url".into(),
+        json!(format!("{base}/v1/triggers/{sub_id}/invoke")),
+    );
+    m.insert(
+        "poll_url_template".into(),
+        json!(format!("{base}/v1/triggers/{sub_id}/runs/{{session_id}}")),
+    );
+    m.insert(
+        "ingress_url".into(),
+        json!(ingress_path.map(|p| format!("{base}{p}"))),
+    );
+    m
+}
+
+/// Recompute an event subscription's ingress path (registration-level for
+/// seamless connections, per-connection otherwise) so the contract is
+/// rebuildable forever, not a one-time artifact of the create response.
+/// api/schedule kinds have no ingress.
+async fn ingress_path_for(
+    state: &AppState,
+    scope: fluidbox_db::TenantScope,
+    sub: &fluidbox_db::TriggerSubscriptionRow,
+) -> ApiResult<Option<String>> {
+    let ("event", Some(cid)) = (sub.trigger_kind.as_str(), sub.connection_id) else {
+        return Ok(None);
+    };
+    let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+    let conn = fluidbox_db::get_connection(&mut *tx, scope, cid).await?;
+    tx.commit().await?;
+    Ok(conn.and_then(|c| {
+        crate::connectors::connector_for(&c.provider).map(|connector| match c.registration_id {
+            Some(rid) => format!("/v1/ingress/{connector}/app/{rid}"),
+            None => format!("/v1/ingress/{connector}/{cid}"),
+        })
+    }))
+}
+
 #[derive(Deserialize)]
 pub struct CreateTrigger {
     /// Agent id or name.
@@ -665,20 +716,18 @@ pub async fn create(
     // address (the dashboard reaches it through a same-origin proxy, so it
     // cannot derive it), and an integration contract with a placeholder host is
     // not a contract. Trailing slashes are trimmed so joins never double up.
-    let base = state.cfg.public_url.trim_end_matches('/');
-    Ok(Json(json!({
-        "subscription": sub,
-        "schedule": schedule_row,
-        "token": token,
-        "callback_secret": secret_plain,
-        "ingress_path": ingress_path,
-        "base_url": base,
-        "invoke_url": format!("{base}/v1/triggers/{}/invoke", sub.id),
-        "poll_url_template": format!("{base}/v1/triggers/{}/runs/{{session_id}}", sub.id),
-        "ingress_url": ingress_path
-            .as_ref()
-            .map(|path| format!("{base}{path}")),
-    })))
+    let mut body = serde_json::Map::new();
+    body.insert("subscription".into(), serde_json::to_value(&sub)?);
+    body.insert("schedule".into(), serde_json::to_value(&schedule_row)?);
+    body.insert("token".into(), json!(token));
+    body.insert("callback_secret".into(), json!(secret_plain));
+    body.insert("ingress_path".into(), json!(ingress_path));
+    body.extend(contract_urls(
+        &state.cfg.public_url,
+        sub.id,
+        ingress_path.as_deref(),
+    ));
+    Ok(Json(Value::Object(body)))
 }
 
 pub async fn list(principal: Principal, State(state): State<AppState>) -> ApiResult<Json<Value>> {
@@ -690,9 +739,11 @@ pub async fn list(principal: Principal, State(state): State<AppState>) -> ApiRes
     let scope = principal.scope();
     let subscriptions = fluidbox_db::list_trigger_subscriptions(&state.pool, scope).await?;
     let schedules = fluidbox_db::schedules_for_tenant(&state.pool, scope).await?;
-    Ok(Json(
-        json!({ "subscriptions": subscriptions, "schedules": schedules }),
-    ))
+    Ok(Json(json!({
+        "subscriptions": subscriptions,
+        "schedules": schedules,
+        "base_url": state.cfg.public_url.trim_end_matches('/'),
+    })))
 }
 
 pub async fn get(
@@ -714,10 +765,19 @@ pub async fn get(
     let schedule = fluidbox_db::schedule_for_subscription(&state.pool, scope, id).await?;
     let invocations =
         fluidbox_db::list_subscription_invocations(&state.pool, scope, id, 30).await?;
-    Ok(Json(json!({
-        "subscription": sub, "schedule": schedule, "sessions": sessions,
-        "deliveries": deliveries, "invocations": invocations
-    })))
+    let ingress_path = ingress_path_for(&state, scope, &sub).await?;
+    let mut body = serde_json::Map::new();
+    body.insert("subscription".into(), serde_json::to_value(&sub)?);
+    body.insert("schedule".into(), serde_json::to_value(&schedule)?);
+    body.insert("sessions".into(), serde_json::to_value(&sessions)?);
+    body.insert("deliveries".into(), serde_json::to_value(&deliveries)?);
+    body.insert("invocations".into(), serde_json::to_value(&invocations)?);
+    body.extend(contract_urls(
+        &state.cfg.public_url,
+        sub.id,
+        ingress_path.as_deref(),
+    ));
+    Ok(Json(Value::Object(body)))
 }
 
 async fn set_enabled(
@@ -782,14 +842,16 @@ pub async fn rotate_token(
     // A rotated token needs the same contract as a freshly-created one — the
     // caller has to re-wire an integration either way, and the dashboard cannot
     // derive these URLs itself.
-    let base = state.cfg.public_url.trim_end_matches('/');
-    Ok(Json(json!({
-        "token": token,
-        "revoked": revoked,
-        "base_url": base,
-        "invoke_url": format!("{base}/v1/triggers/{}/invoke", sub.id),
-        "poll_url_template": format!("{base}/v1/triggers/{}/runs/{{session_id}}", sub.id),
-    })))
+    let ingress_path = ingress_path_for(&state, scope, &sub).await?;
+    let mut body = serde_json::Map::new();
+    body.insert("token".into(), json!(token));
+    body.insert("revoked".into(), json!(revoked));
+    body.extend(contract_urls(
+        &state.cfg.public_url,
+        sub.id,
+        ingress_path.as_deref(),
+    ));
+    Ok(Json(Value::Object(body)))
 }
 
 // ─── Scoped: invoke & poll ────────────────────────────────────────────────
@@ -1308,5 +1370,24 @@ mod tests {
         assert_eq!(a, b); // BTreeMap canonicalizes key order
         let c = canonical_digest(&Some("t2".into()), &ctx(&[("a", "1"), ("b", "2")]), &None);
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn contract_urls_shapes_and_trims() {
+        let id = Uuid::nil();
+        let m = contract_urls("https://fb.example/", id, None);
+        assert_eq!(m["base_url"], "https://fb.example");
+        assert_eq!(
+            m["invoke_url"],
+            format!("https://fb.example/v1/triggers/{id}/invoke")
+        );
+        assert_eq!(
+            m["poll_url_template"],
+            format!("https://fb.example/v1/triggers/{id}/runs/{{session_id}}")
+        );
+        assert_eq!(m["ingress_url"], Value::Null);
+
+        let m = contract_urls("https://fb.example", id, Some("/v1/ingress/github/app/7"));
+        assert_eq!(m["ingress_url"], "https://fb.example/v1/ingress/github/app/7");
     }
 }

--- a/crates/fluidbox-server/src/triggers.rs
+++ b/crates/fluidbox-server/src/triggers.rs
@@ -389,7 +389,17 @@ impl UpdateTrigger {
             && self.allow_workspace_override.is_none()
             && self.concurrency_policy.is_none()
             && self.callback_url.is_none()
-            && self.schedule.is_none()
+            // `{"schedule": {}}` names no schedule field, so it is a no-op too:
+            // fold an all-None schedule object into "nothing to write".
+            && self.schedule.as_ref().is_none_or(ScheduleUpdate::is_empty)
+    }
+}
+
+impl ScheduleUpdate {
+    /// True when the schedule PATCH names no field — writing it would advance
+    /// `updated_at` (and, pre-F1, reset the fire clock) for no change.
+    pub fn is_empty(&self) -> bool {
+        self.cron.is_none() && self.timezone.is_none() && self.missed_run_policy.is_none()
     }
 }
 
@@ -496,6 +506,14 @@ fn merge_schedule(
             .unwrap_or(&current.missed_run_policy)
             .to_string(),
     )
+}
+
+/// Did a schedule PATCH change the firing cadence (cron OR timezone)? A
+/// cadence-neutral PATCH (e.g. missed_run_policy only) must NOT reset the fire
+/// clock — recomputing `next_fire_at` there would skip an imminent fire and
+/// discard missed-run state.
+fn cadence_changed(current: &fluidbox_db::ScheduleRow, merged_cron: &str, merged_tz: &str) -> bool {
+    merged_cron != current.cron || merged_tz != current.timezone
 }
 
 pub async fn create(
@@ -998,7 +1016,12 @@ pub async fn update(
             let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
             let conn = fluidbox_db::get_connection(&mut *tx, scope, cid)
                 .await?
-                .ok_or(ApiError::NotFound)?;
+                .ok_or_else(|| {
+                    ApiError::BadRequest(
+                        "this subscription's connection no longer exists — reconnect it before editing"
+                            .into(),
+                    )
+                })?;
             tx.commit().await?;
             let connector = crate::connectors::connector_for(&conn.provider).ok_or_else(|| {
                 ApiError::Internal(format!("provider '{}' has no connector", conn.provider))
@@ -1060,7 +1083,12 @@ pub async fn update(
     // fields keep the existing row's values (a cron-only PATCH must not
     // reset America/Chicago to UTC).
     let schedule_cfg = match &req.schedule {
+        // An all-None schedule object is a no-op — treat it like an omitted
+        // schedule (is_empty() already folds it into the top-level no-op path;
+        // this arm is the belt-and-braces guard should this handler run with a
+        // non-empty PATCH that carries an empty schedule alongside it).
         None => None,
+        Some(s) if s.is_empty() => None,
         Some(s) => {
             if current.trigger_kind != "schedule" {
                 return Err(ApiError::BadRequest(
@@ -1071,20 +1099,29 @@ pub async fn update(
                 ApiError::Internal("schedule subscription has no schedule row".into())
             })?;
             let (cron_expr, tz, missed) = merge_schedule(row, s);
+            // Validate the merged cron regardless of whether the cadence moved
+            // — validation must not weaken on a partial PATCH.
             let cron = CronSchedule::parse(&cron_expr, &tz).map_err(ApiError::BadRequest)?;
             if MissedRunPolicy::parse(&missed).is_none() {
                 return Err(ApiError::BadRequest(
                     "missed_run_policy must be skip | catch_up".into(),
                 ));
             }
-            let first = cron.next_fire_after(chrono::Utc::now()).ok_or_else(|| {
-                ApiError::BadRequest("cron expression never fires in the future".into())
-            })?;
+            // Cadence unchanged (e.g. a missed_run_policy-only PATCH): carry
+            // the existing row's clock through unchanged (F1). Only a changed
+            // cron/timezone resets it to the next fire from now.
+            let next_fire_at = if cadence_changed(row, &cron_expr, &tz) {
+                Some(cron.next_fire_after(chrono::Utc::now()).ok_or_else(|| {
+                    ApiError::BadRequest("cron expression never fires in the future".into())
+                })?)
+            } else {
+                row.next_fire_at
+            };
             Some(fluidbox_db::ScheduleConfigUpdate {
                 cron: cron_expr,
                 timezone: tz,
                 missed_run_policy: missed,
-                next_fire_at: first,
+                next_fire_at,
             })
         }
     };
@@ -1807,6 +1844,15 @@ mod tests {
         assert!(!ok.is_empty());
         let empty: UpdateTrigger = serde_json::from_str("{}").unwrap();
         assert!(empty.is_empty());
+        // `{"schedule": {}}` names no field — a full no-op PATCH (F4).
+        let empty_sched: ScheduleUpdate = serde_json::from_str("{}").unwrap();
+        assert!(empty_sched.is_empty());
+        let sched_noop: UpdateTrigger = serde_json::from_str(r#"{"schedule":{}}"#).unwrap();
+        assert!(sched_noop.is_empty());
+        // A schedule naming a field is NOT a no-op.
+        let sched_set: UpdateTrigger =
+            serde_json::from_str(r#"{"schedule":{"missed_run_policy":"skip"}}"#).unwrap();
+        assert!(!sched_set.is_empty());
     }
 
     #[test]
@@ -1882,5 +1928,25 @@ mod tests {
             (cron.as_str(), tz.as_str(), missed.as_str()),
             ("0 8 * * *", "America/Chicago", "catch_up")
         );
+    }
+
+    #[test]
+    fn cadence_changed_ignores_missed_run_policy() {
+        let row = fluidbox_db::ScheduleRow {
+            id: Uuid::nil(),
+            subscription_id: Uuid::nil(),
+            cron: "0 9 * * 1-5".into(),
+            timezone: "America/Chicago".into(),
+            next_fire_at: None,
+            missed_run_policy: "skip".into(),
+            last_fired_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        // Same cron+tz (a missed_run_policy-only PATCH) is cadence-neutral (F1).
+        assert!(!cadence_changed(&row, "0 9 * * 1-5", "America/Chicago"));
+        // A changed cron OR timezone moves the cadence.
+        assert!(cadence_changed(&row, "0 8 * * 1-5", "America/Chicago"));
+        assert!(cadence_changed(&row, "0 9 * * 1-5", "UTC"));
     }
 }

--- a/crates/fluidbox-server/src/triggers.rs
+++ b/crates/fluidbox-server/src/triggers.rs
@@ -343,7 +343,6 @@ pub struct ScheduleInput {
 /// otherwise accept-and-drop them, returning a lying 200).
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(dead_code)] // wired to the PATCH handler in Task 4
 pub struct UpdateTrigger {
     #[serde(default)]
     pub name: Option<String>,
@@ -370,7 +369,6 @@ pub struct UpdateTrigger {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(dead_code)] // wired to the PATCH handler in Task 4
 pub struct ScheduleUpdate {
     #[serde(default)]
     pub cron: Option<String>,
@@ -384,7 +382,6 @@ impl UpdateTrigger {
     /// True when the PATCH names nothing — the handler answers with the
     /// current state WITHOUT writing (an empty {} must not advance
     /// updated_at; the detail page's "as of" stamp would lie).
-    #[allow(dead_code)] // wired to the PATCH handler in Task 4
     pub fn is_empty(&self) -> bool {
         self.name.is_none()
             && self.task_template.is_none()
@@ -396,7 +393,6 @@ impl UpdateTrigger {
     }
 }
 
-#[allow(dead_code)] // wired to the PATCH handler in Task 4
 pub(crate) struct ResolvedUpdate {
     pub name: String,
     pub task_template: Option<String>,
@@ -405,7 +401,6 @@ pub(crate) struct ResolvedUpdate {
     pub concurrency_policy: String,
 }
 
-#[allow(dead_code)] // wired to the PATCH handler in Task 4
 fn resolve_update(
     current: &fluidbox_db::TriggerSubscriptionRow,
     req: &UpdateTrigger,
@@ -430,7 +425,9 @@ fn resolve_update(
             c.clone()
         }
     };
-    let allow_task_override = req.allow_task_override.unwrap_or(current.allow_task_override);
+    let allow_task_override = req
+        .allow_task_override
+        .unwrap_or(current.allow_task_override);
     let allow_workspace_override = req
         .allow_workspace_override
         .unwrap_or(current.allow_workspace_override);
@@ -480,8 +477,10 @@ fn resolve_update(
 
 /// Merge a partial schedule PATCH over the existing row → (cron, timezone,
 /// missed_run_policy), all still to be validated by the caller.
-#[allow(dead_code)] // wired to the PATCH handler in Task 4
-fn merge_schedule(current: &fluidbox_db::ScheduleRow, upd: &ScheduleUpdate) -> (String, String, String) {
+fn merge_schedule(
+    current: &fluidbox_db::ScheduleRow,
+    upd: &ScheduleUpdate,
+) -> (String, String, String) {
     (
         upd.cron
             .as_deref()
@@ -934,6 +933,201 @@ pub async fn get(
     body.insert("sessions".into(), serde_json::to_value(&sessions)?);
     body.insert("deliveries".into(), serde_json::to_value(&deliveries)?);
     body.insert("invocations".into(), serde_json::to_value(&invocations)?);
+    body.extend(contract_urls(
+        &state.cfg.public_url,
+        sub.id,
+        ingress_path.as_deref(),
+    ));
+    Ok(Json(Value::Object(body)))
+}
+
+/// PATCH — the mutable surface only: name, task_template, overrides,
+/// concurrency_policy, callback_url, and (schedule kind) the clock. Trigger
+/// kind and agent are immutable: UpdateTrigger is deny_unknown_fields, so a
+/// PATCH naming them (or anything else) is a 400, never a silent no-op.
+/// In-flight runs keep their frozen RunSpec; future firings use the updated
+/// values — the platform's existing immutability model.
+pub async fn update(
+    principal: Principal,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(raw): Json<Value>,
+) -> ApiResult<Json<Value>> {
+    if !rbac::can_manage_subscriptions(&principal) {
+        return Err(ApiError::Forbidden(
+            "managing trigger subscriptions requires admin or owner".into(),
+        ));
+    }
+    let req: UpdateTrigger = serde_json::from_value(raw).map_err(|e| {
+        ApiError::BadRequest(format!(
+            "invalid PATCH body ({e}). Mutable fields: name, task_template, \
+             allow_task_override, allow_workspace_override, concurrency_policy, \
+             callback_url, schedule{{cron,timezone,missed_run_policy}}. \
+             Trigger kind and agent are immutable — create a new automation instead."
+        ))
+    })?;
+    let scope = principal.scope();
+    let current = fluidbox_db::get_trigger_subscription(&state.pool, scope, id)
+        .await?
+        .ok_or(ApiError::NotFound)?;
+    let existing_schedule = fluidbox_db::schedule_for_subscription(&state.pool, scope, id).await?;
+
+    // An empty {} PATCH answers with current state, WITHOUT writing — the
+    // "as of" stamp must not advance for a no-op.
+    if req.is_empty() {
+        let ingress_path = ingress_path_for(&state, scope, &current).await?;
+        let mut body = serde_json::Map::new();
+        body.insert("subscription".into(), serde_json::to_value(&current)?);
+        body.insert("schedule".into(), serde_json::to_value(&existing_schedule)?);
+        body.insert("callback_secret".into(), Value::Null);
+        body.extend(contract_urls(
+            &state.cfg.public_url,
+            current.id,
+            ingress_path.as_deref(),
+        ));
+        return Ok(Json(Value::Object(body)));
+    }
+
+    // The kind's no-caller render context, when it has one.
+    let render_ctx = match current.trigger_kind.as_str() {
+        "schedule" => Some(schedule_context("2026-01-01T00:00:00Z")),
+        "event" => {
+            let cid = current
+                .connection_id
+                .ok_or_else(|| ApiError::Internal("event subscription has no connection".into()))?;
+            let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+            let conn = fluidbox_db::get_connection(&mut *tx, scope, cid)
+                .await?
+                .ok_or(ApiError::NotFound)?;
+            tx.commit().await?;
+            let connector = crate::connectors::connector_for(&conn.provider).ok_or_else(|| {
+                ApiError::Internal(format!("provider '{}' has no connector", conn.provider))
+            })?;
+            Some(crate::connectors::sample_context(connector))
+        }
+        _ => None,
+    };
+    let resolved =
+        resolve_update(&current, &req, render_ctx.as_ref()).map_err(ApiError::BadRequest)?;
+
+    // Callback: same admission + sealing as create; any change bumps the
+    // subscription's authority generation (Task 3 handles the bump).
+    let (callback, secret_plain) = match req.callback_url.as_deref().map(str::trim) {
+        None => (fluidbox_db::CallbackUpdate::Keep, None),
+        Some("") => (fluidbox_db::CallbackUpdate::Clear, None),
+        Some(url) => {
+            if !(url.starts_with("http://") || url.starts_with("https://")) {
+                return Err(ApiError::BadRequest("callback_url must be http(s)".into()));
+            }
+            crate::egress::admit_url(url, &state.egress_policy)
+                .map_err(|e| ApiError::BadRequest(format!("callback_url rejected: {e}")))?;
+            let sealer = state.sealer.as_ref().ok_or_else(|| {
+                ApiError::BadRequest(
+                    "signed callbacks are disabled: set FLUIDBOX_CREDENTIAL_KEY on the server"
+                        .into(),
+                )
+            })?;
+            let secret = random_hex_token(SECRET_PREFIX);
+            let sealed = sealer
+                .seal(
+                    &secret,
+                    crate::seal::SealCtx::new(
+                        scope.tenant_id(),
+                        crate::seal::SealFamily::SubscriptionCallbackSecret,
+                    ),
+                )
+                .await?;
+            let dests = serde_json::to_value(vec![ResultDestination::SignedWebhook {
+                url: url.to_string(),
+                binding_id: None,
+            }])?;
+            // Destructure the owned Sealed — do NOT call Sealed::split on a
+            // temporary Option (it returns a borrow of the temporary and
+            // does not compile).
+            let crate::seal::Sealed { bytes, key_version } = sealed;
+            (
+                fluidbox_db::CallbackUpdate::Set {
+                    destinations: dests,
+                    sealed: bytes,
+                    key_version,
+                },
+                Some(secret),
+            )
+        }
+    };
+
+    // Schedule: only meaningful on a schedule subscription; PARTIAL — omitted
+    // fields keep the existing row's values (a cron-only PATCH must not
+    // reset America/Chicago to UTC).
+    let schedule_cfg = match &req.schedule {
+        None => None,
+        Some(s) => {
+            if current.trigger_kind != "schedule" {
+                return Err(ApiError::BadRequest(
+                    "only schedule subscriptions carry a schedule".into(),
+                ));
+            }
+            let row = existing_schedule.as_ref().ok_or_else(|| {
+                ApiError::Internal("schedule subscription has no schedule row".into())
+            })?;
+            let (cron_expr, tz, missed) = merge_schedule(row, s);
+            let cron = CronSchedule::parse(&cron_expr, &tz).map_err(ApiError::BadRequest)?;
+            if MissedRunPolicy::parse(&missed).is_none() {
+                return Err(ApiError::BadRequest(
+                    "missed_run_policy must be skip | catch_up".into(),
+                ));
+            }
+            let first = cron.next_fire_after(chrono::Utc::now()).ok_or_else(|| {
+                ApiError::BadRequest("cron expression never fires in the future".into())
+            })?;
+            Some(fluidbox_db::ScheduleConfigUpdate {
+                cron: cron_expr,
+                timezone: tz,
+                missed_run_policy: missed,
+                next_fire_at: first,
+            })
+        }
+    };
+
+    let updated = fluidbox_db::update_trigger_subscription(
+        &state.pool,
+        scope,
+        id,
+        current.updated_at,
+        &resolved.name,
+        resolved.task_template.as_deref(),
+        resolved.allow_task_override,
+        resolved.allow_workspace_override,
+        &resolved.concurrency_policy,
+        callback,
+        schedule_cfg.as_ref(),
+    )
+    .await
+    .map_err(|e| match &e {
+        sqlx::Error::Database(db) if db.is_unique_violation() => ApiError::Conflict(format!(
+            "a trigger named '{}' already exists",
+            resolved.name
+        )),
+        _ => ApiError::Db(e),
+    })?;
+    let Some((sub, updated_schedule)) = updated else {
+        // The stale-guard fired: someone else edited between our read and
+        // write. Nothing was written; the one-time secret (if minted) was
+        // never stored and dies here with this error.
+        return Err(ApiError::Conflict(
+            "the automation changed since it was loaded — reload and retry".into(),
+        ));
+    };
+
+    let schedule = match updated_schedule {
+        Some(row) => Some(row),
+        None => fluidbox_db::schedule_for_subscription(&state.pool, scope, id).await?,
+    };
+    let ingress_path = ingress_path_for(&state, scope, &sub).await?;
+    let mut body = serde_json::Map::new();
+    body.insert("subscription".into(), serde_json::to_value(&sub)?);
+    body.insert("schedule".into(), serde_json::to_value(&schedule)?);
+    body.insert("callback_secret".into(), json!(secret_plain));
     body.extend(contract_urls(
         &state.cfg.public_url,
         sub.id,
@@ -1550,10 +1744,17 @@ mod tests {
         assert_eq!(m["ingress_url"], Value::Null);
 
         let m = contract_urls("https://fb.example", id, Some("/v1/ingress/github/app/7"));
-        assert_eq!(m["ingress_url"], "https://fb.example/v1/ingress/github/app/7");
+        assert_eq!(
+            m["ingress_url"],
+            "https://fb.example/v1/ingress/github/app/7"
+        );
     }
 
-    fn sub_row(kind: &str, template: Option<&str>, allow_task: bool) -> fluidbox_db::TriggerSubscriptionRow {
+    fn sub_row(
+        kind: &str,
+        template: Option<&str>,
+        allow_task: bool,
+    ) -> fluidbox_db::TriggerSubscriptionRow {
         fluidbox_db::TriggerSubscriptionRow {
             id: Uuid::nil(),
             tenant_id: Uuid::nil(),
@@ -1597,7 +1798,10 @@ mod tests {
     fn update_trigger_refuses_unknown_fields() {
         // Immutability enforcement: agent/kind are not silently ignored.
         for body in [r#"{"agent":"other"}"#, r#"{"trigger_kind":"schedule"}"#] {
-            assert!(serde_json::from_str::<UpdateTrigger>(body).is_err(), "{body}");
+            assert!(
+                serde_json::from_str::<UpdateTrigger>(body).is_err(),
+                "{body}"
+            );
         }
         let ok: UpdateTrigger = serde_json::from_str(r#"{"name":"x"}"#).unwrap();
         assert!(!ok.is_empty());
@@ -1645,7 +1849,10 @@ mod tests {
         assert!(resolve_update(&cur, &req, Some(&ctx)).is_err());
         req.task_template = Some("sweep {{fire_time}} again".into());
         let r = resolve_update(&cur, &req, Some(&ctx)).unwrap();
-        assert_eq!(r.task_template.as_deref(), Some("sweep {{fire_time}} again"));
+        assert_eq!(
+            r.task_template.as_deref(),
+            Some("sweep {{fire_time}} again")
+        );
         // A schedule can never clear its template (there is no caller).
         req.task_template = Some("".into());
         assert!(resolve_update(&cur, &req, Some(&ctx)).is_err());
@@ -1665,8 +1872,15 @@ mod tests {
             updated_at: chrono::Utc::now(),
         };
         // A cron-only PATCH must not reset timezone/missed policy.
-        let upd = ScheduleUpdate { cron: Some("0 8 * * *".into()), timezone: None, missed_run_policy: None };
+        let upd = ScheduleUpdate {
+            cron: Some("0 8 * * *".into()),
+            timezone: None,
+            missed_run_policy: None,
+        };
         let (cron, tz, missed) = merge_schedule(&row, &upd);
-        assert_eq!((cron.as_str(), tz.as_str(), missed.as_str()), ("0 8 * * *", "America/Chicago", "catch_up"));
+        assert_eq!(
+            (cron.as_str(), tz.as_str(), missed.as_str()),
+            ("0 8 * * *", "America/Chicago", "catch_up")
+        );
     }
 }

--- a/crates/fluidbox-server/src/triggers.rs
+++ b/crates/fluidbox-server/src/triggers.rs
@@ -337,6 +337,168 @@ pub struct ScheduleInput {
     pub missed_run_policy: Option<String>,
 }
 
+/// PATCH body — the mutable surface ONLY. deny_unknown_fields is the
+/// immutability enforcement: `agent`, `trigger_kind`, `connection`, etc.
+/// are refused with 400, not silently ignored (serde's default would
+/// otherwise accept-and-drop them, returning a lying 200).
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)] // wired to the PATCH handler in Task 4
+pub struct UpdateTrigger {
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Some("") clears the template (valid only when the resolved state
+    /// still passes the dead-config rule); omitted = unchanged.
+    #[serde(default)]
+    pub task_template: Option<String>,
+    #[serde(default)]
+    pub allow_task_override: Option<bool>,
+    #[serde(default)]
+    pub allow_workspace_override: Option<bool>,
+    #[serde(default)]
+    pub concurrency_policy: Option<String>,
+    /// Some("") removes the signed-webhook callback; Some(url) sets/replaces
+    /// it (mints a new secret, returned once); omitted = unchanged.
+    #[serde(default)]
+    pub callback_url: Option<String>,
+    /// Schedule-kind subscriptions only. Partial: omitted fields keep the
+    /// existing schedule's values (a cron-only PATCH must NOT reset
+    /// timezone/missed policy to defaults).
+    #[serde(default)]
+    pub schedule: Option<ScheduleUpdate>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)] // wired to the PATCH handler in Task 4
+pub struct ScheduleUpdate {
+    #[serde(default)]
+    pub cron: Option<String>,
+    #[serde(default)]
+    pub timezone: Option<String>,
+    #[serde(default)]
+    pub missed_run_policy: Option<String>,
+}
+
+impl UpdateTrigger {
+    /// True when the PATCH names nothing — the handler answers with the
+    /// current state WITHOUT writing (an empty {} must not advance
+    /// updated_at; the detail page's "as of" stamp would lie).
+    #[allow(dead_code)] // wired to the PATCH handler in Task 4
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.task_template.is_none()
+            && self.allow_task_override.is_none()
+            && self.allow_workspace_override.is_none()
+            && self.concurrency_policy.is_none()
+            && self.callback_url.is_none()
+            && self.schedule.is_none()
+    }
+}
+
+#[allow(dead_code)] // wired to the PATCH handler in Task 4
+pub(crate) struct ResolvedUpdate {
+    pub name: String,
+    pub task_template: Option<String>,
+    pub allow_task_override: bool,
+    pub allow_workspace_override: bool,
+    pub concurrency_policy: String,
+}
+
+#[allow(dead_code)] // wired to the PATCH handler in Task 4
+fn resolve_update(
+    current: &fluidbox_db::TriggerSubscriptionRow,
+    req: &UpdateTrigger,
+    render_ctx: Option<&std::collections::BTreeMap<String, String>>,
+) -> Result<ResolvedUpdate, String> {
+    let name = match &req.name {
+        None => current.name.clone(),
+        Some(n) => {
+            let n = n.trim();
+            if n.is_empty() {
+                return Err("name must not be empty".into());
+            }
+            n.to_string()
+        }
+    };
+    let concurrency_policy = match &req.concurrency_policy {
+        None => current.concurrency_policy.clone(),
+        Some(c) => {
+            if ConcurrencyPolicy::parse(c).is_none() {
+                return Err("concurrency_policy must be allow | skip_if_running | replace".into());
+            }
+            c.clone()
+        }
+    };
+    let allow_task_override = req.allow_task_override.unwrap_or(current.allow_task_override);
+    let allow_workspace_override = req
+        .allow_workspace_override
+        .unwrap_or(current.allow_workspace_override);
+    let task_template = match &req.task_template {
+        None => current.task_template.clone(),
+        Some(t) => {
+            let t = t.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_string())
+            }
+        }
+    };
+    // The create-time dead-config rule holds across every edit.
+    if task_template.is_none() && !allow_task_override {
+        return Err("provide a task_template or set allow_task_override".into());
+    }
+    // Schedule/event kinds fire with no caller: the template must exist and
+    // must render from the kind's sample context alone.
+    if let Some(ctx) = render_ctx {
+        let tpl = task_template.as_deref().ok_or_else(|| {
+            format!(
+                "a {} subscription needs a task_template (there is no caller)",
+                current.trigger_kind
+            )
+        })?;
+        render_task_template(tpl, ctx).map_err(|e| {
+            format!(
+                "task_template must render from the {} context ({}): {e}",
+                current.trigger_kind,
+                ctx.keys()
+                    .map(|k| format!("{{{{{k}}}}}"))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            )
+        })?;
+    }
+    Ok(ResolvedUpdate {
+        name,
+        task_template,
+        allow_task_override,
+        allow_workspace_override,
+        concurrency_policy,
+    })
+}
+
+/// Merge a partial schedule PATCH over the existing row → (cron, timezone,
+/// missed_run_policy), all still to be validated by the caller.
+#[allow(dead_code)] // wired to the PATCH handler in Task 4
+fn merge_schedule(current: &fluidbox_db::ScheduleRow, upd: &ScheduleUpdate) -> (String, String, String) {
+    (
+        upd.cron
+            .as_deref()
+            .unwrap_or(&current.cron)
+            .trim()
+            .to_string(),
+        upd.timezone
+            .as_deref()
+            .unwrap_or(&current.timezone)
+            .to_string(),
+        upd.missed_run_policy
+            .as_deref()
+            .unwrap_or(&current.missed_run_policy)
+            .to_string(),
+    )
+}
+
 pub async fn create(
     principal: Principal,
     State(state): State<AppState>,
@@ -1389,5 +1551,122 @@ mod tests {
 
         let m = contract_urls("https://fb.example", id, Some("/v1/ingress/github/app/7"));
         assert_eq!(m["ingress_url"], "https://fb.example/v1/ingress/github/app/7");
+    }
+
+    fn sub_row(kind: &str, template: Option<&str>, allow_task: bool) -> fluidbox_db::TriggerSubscriptionRow {
+        fluidbox_db::TriggerSubscriptionRow {
+            id: Uuid::nil(),
+            tenant_id: Uuid::nil(),
+            agent_id: Uuid::nil(),
+            name: "n".into(),
+            trigger_kind: kind.into(),
+            pinned_revision_id: None,
+            enabled: true,
+            task_template: template.map(str::to_string),
+            allow_task_override: allow_task,
+            allow_workspace_override: false,
+            autonomy: None,
+            concurrency_policy: "allow".into(),
+            budget_override: None,
+            workspace_override: None,
+            result_destinations: json!([]),
+            connection_id: None,
+            resource_selector: None,
+            event_filter: None,
+            event_publish: None,
+            capability_bundles: None,
+            authority_generation: 1,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn upd() -> UpdateTrigger {
+        UpdateTrigger {
+            name: None,
+            task_template: None,
+            allow_task_override: None,
+            allow_workspace_override: None,
+            concurrency_policy: None,
+            callback_url: None,
+            schedule: None,
+        }
+    }
+
+    #[test]
+    fn update_trigger_refuses_unknown_fields() {
+        // Immutability enforcement: agent/kind are not silently ignored.
+        for body in [r#"{"agent":"other"}"#, r#"{"trigger_kind":"schedule"}"#] {
+            assert!(serde_json::from_str::<UpdateTrigger>(body).is_err(), "{body}");
+        }
+        let ok: UpdateTrigger = serde_json::from_str(r#"{"name":"x"}"#).unwrap();
+        assert!(!ok.is_empty());
+        let empty: UpdateTrigger = serde_json::from_str("{}").unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn resolve_update_keeps_omitted_fields() {
+        let cur = sub_row("api", Some("do {{ticket}}"), false);
+        let r = resolve_update(&cur, &upd(), None).unwrap();
+        assert_eq!(r.name, "n");
+        assert_eq!(r.task_template.as_deref(), Some("do {{ticket}}"));
+        assert_eq!(r.concurrency_policy, "allow");
+    }
+
+    #[test]
+    fn resolve_update_rejects_dead_config() {
+        let cur = sub_row("api", Some("t"), false);
+        let mut req = upd();
+        req.task_template = Some("  ".into());
+        assert!(resolve_update(&cur, &req, None).is_err());
+        let cur = sub_row("api", Some("t"), true);
+        let r = resolve_update(&cur, &req, None).unwrap();
+        assert_eq!(r.task_template, None);
+    }
+
+    #[test]
+    fn resolve_update_rejects_empty_name_and_bad_concurrency() {
+        let cur = sub_row("api", Some("t"), false);
+        let mut req = upd();
+        req.name = Some("  ".into());
+        assert!(resolve_update(&cur, &req, None).is_err());
+        let mut req = upd();
+        req.concurrency_policy = Some("sometimes".into());
+        assert!(resolve_update(&cur, &req, None).is_err());
+    }
+
+    #[test]
+    fn resolve_update_revalidates_template_against_kind_context() {
+        let cur = sub_row("schedule", Some("sweep at {{fire_time}}"), false);
+        let mut req = upd();
+        req.task_template = Some("do {{ticket}}".into()); // not in schedule ctx
+        let ctx = ctx(&[("fire_time", "2026-01-01T00:00:00Z")]);
+        assert!(resolve_update(&cur, &req, Some(&ctx)).is_err());
+        req.task_template = Some("sweep {{fire_time}} again".into());
+        let r = resolve_update(&cur, &req, Some(&ctx)).unwrap();
+        assert_eq!(r.task_template.as_deref(), Some("sweep {{fire_time}} again"));
+        // A schedule can never clear its template (there is no caller).
+        req.task_template = Some("".into());
+        assert!(resolve_update(&cur, &req, Some(&ctx)).is_err());
+    }
+
+    #[test]
+    fn merge_schedule_keeps_omitted_fields() {
+        let row = fluidbox_db::ScheduleRow {
+            id: Uuid::nil(),
+            subscription_id: Uuid::nil(),
+            cron: "0 9 * * 1-5".into(),
+            timezone: "America/Chicago".into(),
+            next_fire_at: None,
+            missed_run_policy: "catch_up".into(),
+            last_fired_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        // A cron-only PATCH must not reset timezone/missed policy.
+        let upd = ScheduleUpdate { cron: Some("0 8 * * *".into()), timezone: None, missed_run_policy: None };
+        let (cron, tz, missed) = merge_schedule(&row, &upd);
+        assert_eq!((cron.as_str(), tz.as_str(), missed.as_str()), ("0 8 * * *", "America/Chicago", "catch_up"));
     }
 }

--- a/docs/superpowers/plans/2026-07-29-automation-api-contract.md
+++ b/docs/superpowers/plans/2026-07-29-automation-api-contract.md
@@ -1,0 +1,1560 @@
+# Automation API Contract & Template Clarity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the automation API contract durable (always copyable from a new `/automations/{id}` page, live-rendered from the DB), add `PATCH /v1/triggers/{id}` for the mutable subset, and make the composer's task-template box self-explanatory.
+
+**Architecture:** Backend: one URL helper shared by create/rotate/get/list, one pure update-resolution function + PATCH handler in `triggers.rs`, two new `fluidbox-db` methods (no migrations — all columns exist). Frontend: extract the contract-rendering logic into a pure lib (`automation-contract.ts`) + shared component (`AutomationContract.tsx`), consumed by a new detail page, a trimmed one-time-secrets modal, and a pre-save preview card in the composer.
+
+**Tech Stack:** Rust (axum, sqlx, serde_json), Next.js 16 App Router (client components), vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-automation-api-contract-design.md` — read it first.
+
+## Global Constraints
+
+- Backend is 100% Rust; the dashboard is presentation-only (all logic server-side or in pure, tested TS libs).
+- Trigger token & callback secret are one-time: sha256-hashed / sealed at rest, NEVER re-shown. Recovery = rotation.
+- Absolute URLs come ONLY from the server (`FLUIDBOX_PUBLIC_URL`); the dashboard must never derive hosts.
+- Trigger kind and agent are immutable on PATCH (400 attempts are impossible by schema — the fields simply don't exist on the request struct).
+- Tenant-owned DB methods take `TenantScope` and carry `tenant_id = $n` predicates (signature requirement).
+- Do NOT run `just check` / `just e2e` / DB-backed tests (they need env or spend money; owner-triggered only). Verify with: `cargo test -p fluidbox-server`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`, and in `apps/web`: `pnpm vitest run`, `pnpm build`.
+- Next.js in this repo is newer than training data — check `node_modules/next/dist/docs/` if any App Router API surprises you. Existing pages (`apps/web/app/sessions/[id]/page.tsx`) are the pattern reference.
+- Commit after every task. Commit trailer:
+  `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`
+
+---
+
+### Task 1: Rust — `contract_urls` helper + URL fields on GET/LIST
+
+**Files:**
+- Modify: `crates/fluidbox-server/src/triggers.rs` (helper near line 210; `create` ~line 668–681; `rotate_token` ~line 785–792; `get` ~line 698–721; `list` ~line 684–696; tests module at line 1115)
+- Modify: `crates/fluidbox-server/src/main.rs` (no route change in this task)
+
+**Interfaces:**
+- Produces: `fn contract_urls(base: &str, sub_id: Uuid, ingress_path: Option<&str>) -> serde_json::Map<String, Value>` — keys `base_url`, `invoke_url`, `poll_url_template`, `ingress_url`. `GET /v1/triggers/{id}` response gains those four keys; `GET /v1/triggers` gains top-level `base_url`.
+- Consumes: existing `connectors::connector_for(provider) -> Option<&'static str>`, `fluidbox_db::{scoped_tx, get_connection}`.
+
+- [ ] **Step 1: Write the failing test** (append inside `mod tests` in `triggers.rs`):
+
+```rust
+#[test]
+fn contract_urls_shapes_and_trims() {
+    let id = Uuid::nil();
+    let m = contract_urls("https://fb.example/", id, None);
+    assert_eq!(m["base_url"], "https://fb.example");
+    assert_eq!(
+        m["invoke_url"],
+        format!("https://fb.example/v1/triggers/{id}/invoke")
+    );
+    assert_eq!(
+        m["poll_url_template"],
+        format!("https://fb.example/v1/triggers/{id}/runs/{{session_id}}")
+    );
+    assert_eq!(m["ingress_url"], Value::Null);
+
+    let m = contract_urls("https://fb.example", id, Some("/v1/ingress/github/app/7"));
+    assert_eq!(m["ingress_url"], "https://fb.example/v1/ingress/github/app/7");
+}
+```
+
+- [ ] **Step 2: Run it — must fail to compile** (`contract_urls` not defined):
+`cargo test -p fluidbox-server contract_urls_shapes -- --nocapture` → expect compile error.
+
+- [ ] **Step 3: Implement the helper** (place after `random_hex_token`, ~line 221):
+
+```rust
+/// Caller-facing URL block for a subscription's integration contract.
+/// The control plane is the only party that knows its own public address
+/// (the dashboard reaches it through a same-origin proxy), so create,
+/// rotate, get, and list all hand these over rather than letting a client
+/// guess. Nothing here is secret: it is public_url + subscription id.
+fn contract_urls(
+    base: &str,
+    sub_id: Uuid,
+    ingress_path: Option<&str>,
+) -> serde_json::Map<String, Value> {
+    let base = base.trim_end_matches('/');
+    let mut m = serde_json::Map::new();
+    m.insert("base_url".into(), json!(base));
+    m.insert(
+        "invoke_url".into(),
+        json!(format!("{base}/v1/triggers/{sub_id}/invoke")),
+    );
+    m.insert(
+        "poll_url_template".into(),
+        json!(format!("{base}/v1/triggers/{sub_id}/runs/{{session_id}}")),
+    );
+    m.insert(
+        "ingress_url".into(),
+        json!(ingress_path.map(|p| format!("{base}{p}"))),
+    );
+    m
+}
+```
+
+- [ ] **Step 4: Test passes:** `cargo test -p fluidbox-server contract_urls_shapes` → PASS.
+
+- [ ] **Step 5: Use it in `create` and `rotate_token`** (replace the hand-built duplicate blocks). In `create` (lines 668–681) replace the final `Ok(Json(json!({...})))` with:
+
+```rust
+    let mut body = serde_json::Map::new();
+    body.insert("subscription".into(), serde_json::to_value(&sub)?);
+    body.insert("schedule".into(), serde_json::to_value(&schedule_row)?);
+    body.insert("token".into(), json!(token));
+    body.insert("callback_secret".into(), json!(secret_plain));
+    body.insert("ingress_path".into(), json!(ingress_path));
+    body.extend(contract_urls(
+        &state.cfg.public_url,
+        sub.id,
+        ingress_path.as_deref(),
+    ));
+    Ok(Json(Value::Object(body)))
+```
+
+In `rotate_token` (lines 785–792) replace the final `Ok(Json(json!({...})))` with:
+
+```rust
+    let mut body = serde_json::Map::new();
+    body.insert("token".into(), json!(token));
+    body.insert("revoked".into(), json!(revoked));
+    body.extend(contract_urls(&state.cfg.public_url, sub.id, None));
+    Ok(Json(Value::Object(body)))
+```
+
+- [ ] **Step 6: Add URLs to `get`.** Event subscriptions recompute their ingress path the same way `create` derived it (registration-level for seamless, per-connection otherwise). Replace the body of `get` after the four fetches (lines 717–720) with:
+
+```rust
+    // Recompute the ingress path for event subscriptions so the contract is
+    // rebuildable forever, not a one-time artifact of the create response.
+    let ingress_path = match (sub.trigger_kind.as_str(), sub.connection_id) {
+        ("event", Some(cid)) => {
+            let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+            let conn = fluidbox_db::get_connection(&mut *tx, scope, cid).await?;
+            tx.commit().await?;
+            conn.and_then(|c| {
+                crate::connectors::connector_for(&c.provider).map(|connector| {
+                    match c.registration_id {
+                        Some(rid) => format!("/v1/ingress/{connector}/app/{rid}"),
+                        None => format!("/v1/ingress/{connector}/{cid}"),
+                    }
+                })
+            })
+        }
+        _ => None,
+    };
+    let mut body = serde_json::Map::new();
+    body.insert("subscription".into(), serde_json::to_value(&sub)?);
+    body.insert("schedule".into(), serde_json::to_value(&schedule)?);
+    body.insert("sessions".into(), serde_json::to_value(&sessions)?);
+    body.insert("deliveries".into(), serde_json::to_value(&deliveries)?);
+    body.insert("invocations".into(), serde_json::to_value(&invocations)?);
+    body.extend(contract_urls(
+        &state.cfg.public_url,
+        sub.id,
+        ingress_path.as_deref(),
+    ));
+    Ok(Json(Value::Object(body)))
+```
+
+- [ ] **Step 7: Add `base_url` to `list`** (line 693):
+
+```rust
+    Ok(Json(json!({
+        "subscriptions": subscriptions,
+        "schedules": schedules,
+        "base_url": state.cfg.public_url.trim_end_matches('/'),
+    })))
+```
+
+- [ ] **Step 8: Verify:** `cargo test -p fluidbox-server && cargo clippy -p fluidbox-server -- -D warnings` → all green. (If `get_connection`'s signature differs from `get_connection(&mut *tx, scope, cid)`, copy the exact call shape from `create` at triggers.rs:426.)
+
+- [ ] **Step 9: Commit:** `git add crates/fluidbox-server/src/triggers.rs && git commit -m "feat(server): return contract URLs on trigger get/list"`
+
+---
+
+### Task 2: Rust — pure `resolve_update` + tests
+
+**Files:**
+- Modify: `crates/fluidbox-server/src/triggers.rs` (new struct + fn after `CreateTrigger`/`ScheduleInput`, ~line 288; tests in `mod tests`)
+
+**Interfaces:**
+- Produces:
+
+```rust
+#[derive(Deserialize)]
+pub struct UpdateTrigger {
+    #[serde(default)] pub name: Option<String>,
+    /// Some("") clears the template (valid only when the resolved state
+    /// still passes the dead-config rule); omitted = unchanged.
+    #[serde(default)] pub task_template: Option<String>,
+    #[serde(default)] pub allow_task_override: Option<bool>,
+    #[serde(default)] pub allow_workspace_override: Option<bool>,
+    #[serde(default)] pub concurrency_policy: Option<String>,
+    /// Some("") removes the signed-webhook callback; Some(url) sets/replaces
+    /// it (mints a new secret, returned once); omitted = unchanged.
+    #[serde(default)] pub callback_url: Option<String>,
+    /// Schedule-kind subscriptions only.
+    #[serde(default)] pub schedule: Option<ScheduleInput>,
+}
+
+pub(crate) struct ResolvedUpdate {
+    pub name: String,
+    pub task_template: Option<String>,
+    pub allow_task_override: bool,
+    pub allow_workspace_override: bool,
+    pub concurrency_policy: String,
+}
+
+/// Pure field resolution + validation for PATCH. `render_ctx` is the kind's
+/// sample context for schedule/event subscriptions (the template must render
+/// from it alone — there is no caller); None for api-kind (callers supply
+/// context, unknown placeholders are theirs to fill).
+fn resolve_update(
+    current: &fluidbox_db::TriggerSubscriptionRow,
+    req: &UpdateTrigger,
+    render_ctx: Option<&BTreeMap<String, String>>,
+) -> Result<ResolvedUpdate, String>
+```
+
+- Consumes: `render_task_template` (triggers.rs:38), `ConcurrencyPolicy::parse` (already imported).
+
+- [ ] **Step 1: Write the failing tests** (append inside `mod tests`; the tests build a minimal `TriggerSubscriptionRow` via a helper):
+
+```rust
+    fn sub_row(kind: &str, template: Option<&str>, allow_task: bool) -> fluidbox_db::TriggerSubscriptionRow {
+        fluidbox_db::TriggerSubscriptionRow {
+            id: Uuid::nil(),
+            tenant_id: Uuid::nil(),
+            agent_id: Uuid::nil(),
+            name: "n".into(),
+            trigger_kind: kind.into(),
+            pinned_revision_id: None,
+            enabled: true,
+            task_template: template.map(str::to_string),
+            allow_task_override: allow_task,
+            allow_workspace_override: false,
+            autonomy: None,
+            concurrency_policy: "allow".into(),
+            budget_override: None,
+            workspace_override: None,
+            result_destinations: json!([]),
+            connection_id: None,
+            resource_selector: None,
+            event_filter: None,
+            event_publish: None,
+            capability_bundles: None,
+            authority_generation: 1,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn upd() -> UpdateTrigger {
+        UpdateTrigger {
+            name: None,
+            task_template: None,
+            allow_task_override: None,
+            allow_workspace_override: None,
+            concurrency_policy: None,
+            callback_url: None,
+            schedule: None,
+        }
+    }
+
+    #[test]
+    fn resolve_update_keeps_omitted_fields() {
+        let cur = sub_row("api", Some("do {{ticket}}"), false);
+        let r = resolve_update(&cur, &upd(), None).unwrap();
+        assert_eq!(r.name, "n");
+        assert_eq!(r.task_template.as_deref(), Some("do {{ticket}}"));
+        assert_eq!(r.concurrency_policy, "allow");
+    }
+
+    #[test]
+    fn resolve_update_rejects_dead_config() {
+        // Clearing the template while override stays off = a subscription
+        // that can never produce a task (mirrors the create-time rule).
+        let cur = sub_row("api", Some("t"), false);
+        let mut req = upd();
+        req.task_template = Some("  ".into());
+        assert!(resolve_update(&cur, &req, None).is_err());
+        // …but clearing is fine when the caller may supply the task.
+        let cur = sub_row("api", Some("t"), true);
+        let r = resolve_update(&cur, &req, None).unwrap();
+        assert_eq!(r.task_template, None);
+    }
+
+    #[test]
+    fn resolve_update_rejects_empty_name_and_bad_concurrency() {
+        let cur = sub_row("api", Some("t"), false);
+        let mut req = upd();
+        req.name = Some("  ".into());
+        assert!(resolve_update(&cur, &req, None).is_err());
+        let mut req = upd();
+        req.concurrency_policy = Some("sometimes".into());
+        assert!(resolve_update(&cur, &req, None).is_err());
+    }
+
+    #[test]
+    fn resolve_update_revalidates_template_against_kind_context() {
+        let cur = sub_row("schedule", Some("sweep at {{fire_time}}"), false);
+        let mut req = upd();
+        req.task_template = Some("do {{ticket}}".into()); // not in schedule ctx
+        let ctx = ctx(&[("fire_time", "2026-01-01T00:00:00Z")]);
+        assert!(resolve_update(&cur, &req, Some(&ctx)).is_err());
+        req.task_template = Some("sweep {{fire_time}} again".into());
+        let r = resolve_update(&cur, &req, Some(&ctx)).unwrap();
+        assert_eq!(r.task_template.as_deref(), Some("sweep {{fire_time}} again"));
+        // A schedule can never clear its template (there is no caller).
+        req.task_template = Some("".into());
+        assert!(resolve_update(&cur, &req, Some(&ctx)).is_err());
+    }
+```
+
+Note: `sub_row` needs `TriggerSubscriptionRow`'s fields to be `pub` — they already are (fluidbox-db/src/lib.rs:3721). If the struct gains fields between now and implementation, update the literal; the compile error tells you.
+
+- [ ] **Step 2: Run — expect compile failure** (`UpdateTrigger`/`resolve_update` undefined):
+`cargo test -p fluidbox-server resolve_update -- --nocapture`
+
+- [ ] **Step 3: Implement** (after `ScheduleInput`, before `create`):
+
+```rust
+fn resolve_update(
+    current: &fluidbox_db::TriggerSubscriptionRow,
+    req: &UpdateTrigger,
+    render_ctx: Option<&std::collections::BTreeMap<String, String>>,
+) -> Result<ResolvedUpdate, String> {
+    let name = match &req.name {
+        None => current.name.clone(),
+        Some(n) => {
+            let n = n.trim();
+            if n.is_empty() {
+                return Err("name must not be empty".into());
+            }
+            n.to_string()
+        }
+    };
+    let concurrency_policy = match &req.concurrency_policy {
+        None => current.concurrency_policy.clone(),
+        Some(c) => {
+            if ConcurrencyPolicy::parse(c).is_none() {
+                return Err("concurrency_policy must be allow | skip_if_running | replace".into());
+            }
+            c.clone()
+        }
+    };
+    let allow_task_override = req.allow_task_override.unwrap_or(current.allow_task_override);
+    let allow_workspace_override = req
+        .allow_workspace_override
+        .unwrap_or(current.allow_workspace_override);
+    let task_template = match &req.task_template {
+        None => current.task_template.clone(),
+        Some(t) => {
+            let t = t.trim();
+            if t.is_empty() { None } else { Some(t.to_string()) }
+        }
+    };
+    // The create-time dead-config rule holds across every edit.
+    if task_template.is_none() && !allow_task_override {
+        return Err("provide a task_template or set allow_task_override".into());
+    }
+    // Schedule/event kinds fire with no caller: the template must exist and
+    // must render from the kind's sample context alone.
+    if let Some(ctx) = render_ctx {
+        let tpl = task_template.as_deref().ok_or_else(|| {
+            format!(
+                "a {} subscription needs a task_template (there is no caller)",
+                current.trigger_kind
+            )
+        })?;
+        render_task_template(tpl, ctx).map_err(|e| {
+            format!(
+                "task_template must render from the {} context ({}): {e}",
+                current.trigger_kind,
+                ctx.keys()
+                    .map(|k| format!("{{{{{k}}}}}"))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            )
+        })?;
+    }
+    Ok(ResolvedUpdate {
+        name,
+        task_template,
+        allow_task_override,
+        allow_workspace_override,
+        concurrency_policy,
+    })
+}
+```
+
+(Add `UpdateTrigger` + `ResolvedUpdate` exactly as in **Interfaces** above.)
+
+- [ ] **Step 4: Tests pass:** `cargo test -p fluidbox-server resolve_update` → 4 PASS. Expect a dead-code warning on `UpdateTrigger.callback_url`/`schedule` until Task 4 — suppress nothing; the handler lands two tasks later, so if clippy blocks, add `#[allow(dead_code)]` on `resolve_update` temporarily and REMOVE it in Task 4. `cargo clippy -p fluidbox-server -- -D warnings`.
+
+- [ ] **Step 5: Commit:** `git add crates/fluidbox-server/src/triggers.rs && git commit -m "feat(server): pure PATCH resolution for trigger subscriptions"`
+
+---
+
+### Task 3: Rust — DB methods `update_trigger_subscription` + `update_schedule_config`
+
+**Files:**
+- Modify: `crates/fluidbox-db/src/lib.rs` (after `set_trigger_subscription_enabled` ~line 3908; after `create_schedule` ~line 6931)
+
+**Interfaces:**
+- Produces:
+
+```rust
+/// What PATCH does to the callback destination: leave it alone, remove it,
+/// or replace it with a freshly sealed secret. Owns its data — the sealed
+/// bytes are produced inside the handler's match arm.
+pub enum CallbackUpdate {
+    Keep,
+    Clear,
+    Set { destinations: Value, sealed: Vec<u8>, key_version: i16 },
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_trigger_subscription(
+    pool: &PgPool,
+    scope: TenantScope,
+    id: Uuid,
+    name: &str,
+    task_template: Option<&str>,
+    allow_task_override: bool,
+    allow_workspace_override: bool,
+    concurrency_policy: &str,
+    callback: CallbackUpdate,
+) -> sqlx::Result<Option<TriggerSubscriptionRow>>
+
+pub async fn update_schedule_config(
+    pool: &PgPool,
+    scope: TenantScope,
+    subscription: Uuid,
+    cron: &str,
+    timezone: &str,
+    missed_run_policy: &str,
+    next_fire_at: DateTime<Utc>,
+) -> sqlx::Result<Option<ScheduleRow>>
+```
+
+- Consumes: `scoped_tx`, `SUBSCRIPTION_COLS`, `TriggerSubscriptionRow`, `ScheduleRow` (all existing).
+
+No DB-free test exists for these (DB tests need `DATABASE_URL` and are owner-triggered); correctness is carried by the SQL shape below + compile + the manual drill in Task 10. Follow the file's existing `scoped_tx`/`__rls_out` idiom exactly.
+
+- [ ] **Step 1: Implement `update_trigger_subscription`** (after `set_trigger_subscription_enabled`):
+
+```rust
+/// Full-row update of the PATCH-mutable surface. The handler resolves final
+/// values (current-or-requested) in Rust, so this sets every mutable column
+/// unconditionally; the callback trio is guarded by a touched flag. Any
+/// callback change (set OR clear) bumps authority_generation so
+/// subscription_secret bindings frozen on the old secret fail closed.
+pub async fn update_trigger_subscription(
+    pool: &PgPool,
+    scope: TenantScope,
+    id: Uuid,
+    name: &str,
+    task_template: Option<&str>,
+    allow_task_override: bool,
+    allow_workspace_override: bool,
+    concurrency_policy: &str,
+    callback: CallbackUpdate,
+) -> sqlx::Result<Option<TriggerSubscriptionRow>> {
+    let (cb_touched, cb_dests, cb_sealed, cb_kv): (bool, Value, Option<Vec<u8>>, i16) =
+        match callback {
+            CallbackUpdate::Keep => (false, Value::Array(vec![]), None, 0),
+            CallbackUpdate::Clear => (true, Value::Array(vec![]), None, 0),
+            CallbackUpdate::Set { destinations, sealed, key_version } => {
+                (true, destinations, Some(sealed), key_version)
+            }
+        };
+    let mut tx = scoped_tx(pool, scope).await?;
+
+    let __rls_out = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        "update trigger_subscriptions set
+           name = $2, task_template = $3, allow_task_override = $4,
+           allow_workspace_override = $5, concurrency_policy = $6,
+           result_destinations = case when $7 then $8 else result_destinations end,
+           callback_secret_sealed = case when $7 then $9 else callback_secret_sealed end,
+           callback_secret_key_version =
+             case when $7 then $10 else callback_secret_key_version end,
+           authority_generation =
+             authority_generation + case when $7 then 1 else 0 end,
+           updated_at = now()
+         where id = $1 and tenant_id = $11
+         returning {SUBSCRIPTION_COLS}"
+    )))
+    .bind(id)
+    .bind(name)
+    .bind(task_template)
+    .bind(allow_task_override)
+    .bind(allow_workspace_override)
+    .bind(concurrency_policy)
+    .bind(cb_touched)
+    .bind(cb_dests)
+    .bind(cb_sealed)
+    .bind(cb_kv)
+    .bind(scope.tenant_id())
+    .fetch_optional(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(__rls_out)
+}
+```
+
+- [ ] **Step 2: Implement `update_schedule_config`** (after `create_schedule`):
+
+```rust
+/// Reconfigure the clock on a schedule subscription. next_fire_at is the
+/// handler-computed first future firing of the NEW cron — the scheduler's
+/// tick worker picks it up unchanged.
+pub async fn update_schedule_config(
+    pool: &PgPool,
+    scope: TenantScope,
+    subscription: Uuid,
+    cron: &str,
+    timezone: &str,
+    missed_run_policy: &str,
+    next_fire_at: DateTime<Utc>,
+) -> sqlx::Result<Option<ScheduleRow>> {
+    let mut tx = scoped_tx(pool, scope).await?;
+
+    let __rls_out = sqlx::query_as(
+        "update schedules set cron = $2, timezone = $3, missed_run_policy = $4,
+           next_fire_at = $5, updated_at = now()
+         where subscription_id = $1
+           and exists (select 1 from trigger_subscriptions sub
+                       where sub.id = $1 and sub.tenant_id = $6)
+         returning *",
+    )
+    .bind(subscription)
+    .bind(cron)
+    .bind(timezone)
+    .bind(missed_run_policy)
+    .bind(next_fire_at)
+    .bind(scope.tenant_id())
+    .fetch_optional(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(__rls_out)
+}
+```
+
+- [ ] **Step 3: Compile clean:** `cargo clippy -p fluidbox-db -- -D warnings` (expect a dead-code allowance not needed — `pub` items are exported).
+
+- [ ] **Step 4: Commit:** `git add crates/fluidbox-db/src/lib.rs && git commit -m "feat(db): update methods for trigger subscription + schedule config"`
+
+---
+
+### Task 4: Rust — `PATCH /v1/triggers/{id}` handler + route
+
+**Files:**
+- Modify: `crates/fluidbox-server/src/triggers.rs` (new `update` handler after `get`, ~line 721)
+- Modify: `crates/fluidbox-server/src/main.rs:533` (route)
+
+**Interfaces:**
+- Consumes: Task 2's `UpdateTrigger`/`resolve_update`, Task 3's `update_trigger_subscription`/`CallbackUpdate`/`update_schedule_config`, Task 1's `contract_urls`; existing `schedule_context`, `connectors::{connector_for, sample_context}`, `egress::admit_url`, `seal::{Sealed, SealCtx, SealFamily}`, `random_hex_token`, `SECRET_PREFIX`, `CronSchedule`, `MissedRunPolicy`.
+- Produces: `PATCH /v1/triggers/{id}` → `{ subscription, schedule, callback_secret, base_url, invoke_url, poll_url_template, ingress_url }` (callback_secret non-null ONLY when a new callback was set — shown once, like create).
+
+- [ ] **Step 1: Implement the handler** (after `get`):
+
+```rust
+/// PATCH — the mutable surface only: name, task_template, overrides,
+/// concurrency_policy, callback_url, and (schedule kind) the clock. Trigger
+/// kind and agent are deliberately absent: changing those is a new
+/// automation. In-flight runs keep their frozen RunSpec; future firings use
+/// the updated values — the platform's existing immutability model.
+pub async fn update(
+    principal: Principal,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateTrigger>,
+) -> ApiResult<Json<Value>> {
+    if !rbac::can_manage_subscriptions(&principal) {
+        return Err(ApiError::Forbidden(
+            "managing trigger subscriptions requires admin or owner".into(),
+        ));
+    }
+    let scope = principal.scope();
+    let current = fluidbox_db::get_trigger_subscription(&state.pool, scope, id)
+        .await?
+        .ok_or(ApiError::NotFound)?;
+
+    // The kind's no-caller render context, when it has one.
+    let render_ctx = match current.trigger_kind.as_str() {
+        "schedule" => Some(schedule_context("2026-01-01T00:00:00Z")),
+        "event" => {
+            let cid = current.connection_id.ok_or_else(|| {
+                ApiError::Internal("event subscription has no connection".into())
+            })?;
+            let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+            let conn = fluidbox_db::get_connection(&mut *tx, scope, cid)
+                .await?
+                .ok_or(ApiError::NotFound)?;
+            tx.commit().await?;
+            let connector = crate::connectors::connector_for(&conn.provider)
+                .ok_or_else(|| {
+                    ApiError::Internal(format!("provider '{}' has no connector", conn.provider))
+                })?;
+            Some(crate::connectors::sample_context(connector))
+        }
+        _ => None,
+    };
+    let resolved =
+        resolve_update(&current, &req, render_ctx.as_ref()).map_err(ApiError::BadRequest)?;
+
+    // Callback: same admission + sealing as create; any change bumps the
+    // subscription's authority generation.
+    let (callback, secret_plain) = match req.callback_url.as_deref().map(str::trim) {
+        None => (fluidbox_db::CallbackUpdate::Keep, None),
+        Some("") => (fluidbox_db::CallbackUpdate::Clear, None),
+        Some(url) => {
+            if !(url.starts_with("http://") || url.starts_with("https://")) {
+                return Err(ApiError::BadRequest("callback_url must be http(s)".into()));
+            }
+            crate::egress::admit_url(url, &state.egress_policy)
+                .map_err(|e| ApiError::BadRequest(format!("callback_url rejected: {e}")))?;
+            let sealer = state.sealer.as_ref().ok_or_else(|| {
+                ApiError::BadRequest(
+                    "signed callbacks are disabled: set FLUIDBOX_CREDENTIAL_KEY on the server"
+                        .into(),
+                )
+            })?;
+            let secret = random_hex_token(SECRET_PREFIX);
+            let sealed = sealer
+                .seal(
+                    &secret,
+                    crate::seal::SealCtx::new(
+                        scope.tenant_id(),
+                        crate::seal::SealFamily::SubscriptionCallbackSecret,
+                    ),
+                )
+                .await?;
+            let dests = serde_json::to_value(vec![ResultDestination::SignedWebhook {
+                url: url.to_string(),
+                binding_id: None,
+            }])?;
+            let (cb_bytes, cb_kv) = crate::seal::Sealed::split(&Some(sealed));
+            (
+                fluidbox_db::CallbackUpdate::Set {
+                    destinations: dests,
+                    sealed: cb_bytes.expect("just sealed").to_vec(),
+                    key_version: cb_kv,
+                },
+                Some(secret),
+            )
+        }
+    };
+
+    // Schedule reconfiguration is only meaningful on a schedule subscription.
+    let schedule_update = match &req.schedule {
+        None => None,
+        Some(s) => {
+            if current.trigger_kind != "schedule" {
+                return Err(ApiError::BadRequest(
+                    "only schedule subscriptions carry a schedule".into(),
+                ));
+            }
+            let tz = s.timezone.as_deref().unwrap_or("UTC");
+            let cron = CronSchedule::parse(&s.cron, tz).map_err(ApiError::BadRequest)?;
+            let missed = s.missed_run_policy.as_deref().unwrap_or("skip");
+            if MissedRunPolicy::parse(missed).is_none() {
+                return Err(ApiError::BadRequest(
+                    "missed_run_policy must be skip | catch_up".into(),
+                ));
+            }
+            let first = cron.next_fire_after(chrono::Utc::now()).ok_or_else(|| {
+                ApiError::BadRequest("cron expression never fires in the future".into())
+            })?;
+            Some((s.cron.trim().to_string(), tz.to_string(), missed.to_string(), first))
+        }
+    };
+
+    let sub = fluidbox_db::update_trigger_subscription(
+        &state.pool,
+        scope,
+        id,
+        &resolved.name,
+        resolved.task_template.as_deref(),
+        resolved.allow_task_override,
+        resolved.allow_workspace_override,
+        &resolved.concurrency_policy,
+        callback,
+    )
+    .await
+    .map_err(|e| match &e {
+        sqlx::Error::Database(db) if db.is_unique_violation() => ApiError::Conflict(format!(
+            "a trigger named '{}' already exists",
+            resolved.name
+        )),
+        _ => ApiError::Db(e),
+    })?
+    .ok_or(ApiError::NotFound)?;
+
+    let schedule = match schedule_update {
+        Some((cron, tz, missed, first)) => {
+            fluidbox_db::update_schedule_config(&state.pool, scope, id, &cron, &tz, &missed, first)
+                .await?
+        }
+        None => fluidbox_db::schedule_for_subscription(&state.pool, scope, id).await?,
+    };
+
+    let mut body = serde_json::Map::new();
+    body.insert("subscription".into(), serde_json::to_value(&sub)?);
+    body.insert("schedule".into(), serde_json::to_value(&schedule)?);
+    body.insert("callback_secret".into(), json!(secret_plain));
+    body.extend(contract_urls(&state.cfg.public_url, sub.id, None));
+    Ok(Json(Value::Object(body)))
+}
+```
+
+**Seal-split note:** the `Sealed::split(&Some(sealed))` call mirrors create's handling at triggers.rs:614 (`let (cb_bytes, cb_kv) = crate::seal::Sealed::split(&secret_sealed);`). Check `Sealed::split`'s exact return types at crates/fluidbox-server/src/seal.rs before wiring — if it returns `(Option<&[u8]>, i16)` the `.to_vec()` above is right; adjust mechanically if the shapes differ. Also note the `update_trigger_subscription` call passes `callback` by VALUE (owned enum), not `.as_ref()`.
+
+- [ ] **Step 2: Register the route.** In `main.rs:533` change:
+
+```rust
+        .route("/triggers/{id}", get(triggers::get).patch(triggers::update))
+```
+
+and add `patch` to the `axum::routing` import at the top of `main.rs` if absent.
+
+- [ ] **Step 3: Remove any temporary `#[allow(dead_code)]` from Task 2.**
+
+- [ ] **Step 4: Verify:** `cargo test -p fluidbox-server && cargo clippy --workspace -- -D warnings && cargo fmt --all -- --check` → green.
+
+- [ ] **Step 5: Commit:** `git add crates/ && git commit -m "feat(server): PATCH /v1/triggers/{id} for the mutable subscription surface"`
+
+---
+
+### Task 5: Web — pure contract lib + tests
+
+**Files:**
+- Create: `apps/web/app/lib/automation-contract.ts`
+- Create: `apps/web/app/lib/automation-contract.test.ts`
+- Modify: `apps/web/app/components/RunComposer.tsx` (delete the local `SYSTEM_VARIABLES` at line 1709 and `templateVariables` at line 1715; import from the lib)
+
+**Interfaces:**
+- Produces (exact exports later tasks import):
+
+```ts
+export const SYSTEM_VARIABLES: Record<string, string[]>;
+export function templateVariables(template: string | null): string[];
+export function classifyVariables(kind: string, template: string | null): { caller: string[]; system: string[] };
+export function contextExample(caller: string[]): string;
+/** token null → the $FLUIDBOX_TRIGGER_TOKEN placeholder (durable/revisit view). */
+export function buildCurl(opts: { invokeUrl: string; token: string | null; caller: string[] }): string;
+```
+
+- [ ] **Step 1: Write the failing tests** (`automation-contract.test.ts`):
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  buildCurl,
+  classifyVariables,
+  contextExample,
+  templateVariables,
+} from "./automation-contract";
+
+describe("templateVariables", () => {
+  it("extracts unique placeholder names", () => {
+    expect(templateVariables("do {{ticket}} for {{ team }} re {{ticket}}")).toEqual([
+      "ticket",
+      "team",
+    ]);
+    expect(templateVariables(null)).toEqual([]);
+  });
+});
+
+describe("classifyVariables", () => {
+  it("splits caller vs system by trigger kind", () => {
+    const { caller, system } = classifyVariables(
+      "schedule",
+      "sweep {{fire_time}} for {{team}}"
+    );
+    expect(system).toEqual(["fire_time"]);
+    expect(caller).toEqual(["team"]);
+  });
+  it("api kind has no system variables", () => {
+    expect(classifyVariables("api", "do {{ticket}}").caller).toEqual(["ticket"]);
+    expect(classifyVariables("api", "do {{ticket}}").system).toEqual([]);
+  });
+});
+
+describe("buildCurl", () => {
+  it("uses the real token when given and a shell placeholder when not", () => {
+    const url = "https://fb.example/v1/triggers/x/invoke";
+    expect(buildCurl({ invokeUrl: url, token: "fbx_trig_abc", caller: [] })).toContain(
+      "Bearer fbx_trig_abc"
+    );
+    const durable = buildCurl({ invokeUrl: url, token: null, caller: ["ticket"] });
+    expect(durable).toContain("Bearer $FLUIDBOX_TRIGGER_TOKEN");
+    expect(durable).toContain('"ticket": "…"');
+  });
+});
+
+describe("contextExample", () => {
+  it("is {} with no caller variables", () => {
+    expect(contextExample([])).toBe("{}");
+    expect(contextExample(["a", "b"])).toBe('{"context": {"a": "…", "b": "…"}}');
+  });
+});
+```
+
+- [ ] **Step 2: Run — fail:** `cd apps/web && pnpm vitest run app/lib/automation-contract.test.ts` → module not found.
+
+- [ ] **Step 3: Implement the lib** (move the two definitions out of RunComposer verbatim, then add the two builders):
+
+```ts
+/** Pure integration-contract helpers shared by the composer preview, the
+ *  one-time secrets modal, and the durable automation detail page. Keeping
+ *  them here (tested, presentation-free) is what lets three surfaces render
+ *  the SAME contract without drifting. */
+
+/** Placeholders the platform fills in itself, per trigger kind. Anything else
+ *  in the template is the caller's to supply in `context`. */
+export const SYSTEM_VARIABLES: Record<string, string[]> = {
+  schedule: ["fire_time"],
+  event: ["repository", "pr_number", "pr_title"],
+  api: [],
+};
+
+export function templateVariables(template: string | null): string[] {
+  if (!template) return [];
+  const found = new Set<string>();
+  for (const match of template.matchAll(/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g)) {
+    found.add(match[1]);
+  }
+  return [...found];
+}
+
+export function classifyVariables(
+  kind: string,
+  template: string | null
+): { caller: string[]; system: string[] } {
+  const systemNames = SYSTEM_VARIABLES[kind] ?? [];
+  const declared = templateVariables(template);
+  return {
+    caller: declared.filter((name) => !systemNames.includes(name)),
+    system: declared.filter((name) => systemNames.includes(name)),
+  };
+}
+
+export function contextExample(caller: string[]): string {
+  if (caller.length === 0) return "{}";
+  return `{"context": {${caller.map((name) => `"${name}": "…"`).join(", ")}}}`;
+}
+
+/** token null → the durable view: the secret is the caller's to hold, so the
+ *  curl carries a shell variable instead of pretending we can re-show it. */
+export function buildCurl(opts: {
+  invokeUrl: string;
+  token: string | null;
+  caller: string[];
+}): string {
+  return [
+    `curl -X POST '${opts.invokeUrl}' \\`,
+    `  -H 'Authorization: Bearer ${opts.token ?? "$FLUIDBOX_TRIGGER_TOKEN"}' \\`,
+    `  -H 'Content-Type: application/json' \\`,
+    `  -H 'Idempotency-Key: <your-unique-key>' \\`,
+    `  -d '${contextExample(opts.caller)}'`,
+  ].join("\n");
+}
+```
+
+- [ ] **Step 4: Point RunComposer at the lib.** Delete `SYSTEM_VARIABLES` (RunComposer.tsx:1709-1713) and `templateVariables` (1715-1722); delete the hand-rolled `curl`/`contextExample` construction inside `ShowAutomationSecrets` (lines 1768-1779) and replace with:
+
+```ts
+  const { caller: callerVars, system: systemVars } = classifyVariables(kind, sub.task_template);
+  const declared = [...callerVars, ...systemVars];
+  const curl = buildCurl({ invokeUrl, token: minted.token, caller: callerVars });
+```
+
+adding the import `import { buildCurl, classifyVariables } from "../lib/automation-contract";`.
+
+- [ ] **Step 5: Verify:** `pnpm vitest run` (all web tests) and `pnpm build` → green.
+
+- [ ] **Step 6: Commit:** `git add apps/web/app/lib/automation-contract.* apps/web/app/components/RunComposer.tsx && git commit -m "feat(web): extract pure automation-contract helpers"`
+
+---
+
+### Task 6: Web — shared `AutomationContract` component; trim the secrets modal
+
+**Files:**
+- Create: `apps/web/app/components/AutomationContract.tsx`
+- Modify: `apps/web/app/components/RunComposer.tsx` (`CopyBlock` at 1724-1747 moves out; `ShowAutomationSecrets` at 1749-1926 shrinks)
+- Modify: `apps/web/app/globals.css` (one new class)
+
+**Interfaces:**
+- Produces:
+
+```tsx
+export function CopyBlock({ label, value, hint }: { label: string; value: string; hint?: string });
+export function AutomationContract({
+  subscription,   // TriggerSubscription
+  invokeUrl,      // string
+  pollUrl,        // string
+  ingressUrl,     // string | null
+  token,          // string | null — null renders $FLUIDBOX_TRIGGER_TOKEN
+  updatedAt,      // string | null — renders the "as of" stamp when given
+}: {...});
+```
+
+- Consumes: Task 5's lib; `TriggerSubscription` from `../lib/api`.
+
+- [ ] **Step 1: Create `AutomationContract.tsx`.** Move `CopyBlock` verbatim from RunComposer (1724-1747). Then move the Endpoint / Variables / Request / Responses / Result-delivery sections of `ShowAutomationSecrets` (lines 1822-1916 minus the secrets section) into:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { TriggerSubscription } from "../lib/api";
+import { buildCurl, classifyVariables } from "../lib/automation-contract";
+
+/* CopyBlock: moved verbatim from RunComposer.tsx */
+
+/** The durable integration contract, rendered live from the current
+ *  subscription. Everything here is always recoverable; only the token is
+ *  one-time (token=null renders the honest $FLUIDBOX_TRIGGER_TOKEN form). */
+export function AutomationContract({
+  subscription,
+  invokeUrl,
+  pollUrl,
+  ingressUrl,
+  token,
+  updatedAt,
+}: {
+  subscription: TriggerSubscription;
+  invokeUrl: string;
+  pollUrl: string;
+  ingressUrl: string | null;
+  token: string | null;
+  updatedAt: string | null;
+}) {
+  const kind = subscription.trigger_kind;
+  const { caller: callerVars, system: systemVars } = classifyVariables(
+    kind,
+    subscription.task_template
+  );
+  const declared = [...callerVars, ...systemVars];
+  const curl = buildCurl({ invokeUrl, token, caller: callerVars });
+  const hasCallback = subscription.result_destinations.some(
+    (destination) => destination.kind === "signed_webhook"
+  );
+  const responseExample = [
+    "200 OK",
+    JSON.stringify(
+      {
+        session_id: "019f…",
+        status: "queued",
+        replay: false,
+        poll_url: `/v1/triggers/${subscription.id}/runs/{session_id}`,
+      },
+      null,
+      2
+    ),
+  ].join("\n");
+
+  return (
+    <div className="contract">
+      {/* Endpoint / Variables / Request / Responses / Result delivery
+          sections: EXACTLY the JSX from ShowAutomationSecrets lines
+          1822-1916, with these substitutions:
+            minted.ingress_url  -> ingressUrl
+            sub                 -> subscription
+            the curl const      -> curl (above)
+            minted.callback_secret && (Result delivery ...) -> hasCallback && (...)
+          and WITHOUT the CopyBlock for the callback signing secret value
+          (that block stays in the secrets modal; the signature-format
+          CopyBlock here is fine — it contains no secret). */}
+      {updatedAt && (
+        <p className="contract-stamp">
+          Reflects the configuration as of {new Date(updatedAt).toLocaleString()}.
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+The comment block above is an instruction to YOU, the implementer — the shipped file must contain the real JSX moved from RunComposer, not the comment. `ResultDestination`-shaped objects in `result_destinations` use `kind: "signed_webhook"` — verify the exact discriminant with `grep -n "signed_webhook" apps/web/app/lib/api.ts crates/fluidbox-core/src/spec.rs` and match it.
+
+- [ ] **Step 2: Shrink `ShowAutomationSecrets`.** It keeps: the ModalShell chrome (title/sub/dirty/discard copy, lines 1795-1804), the **Secrets** section (1806-1820), and gains a pointer + compact contract. Replace everything from line 1822 (`<section className="contract-section"><h4>Endpoint</h4>`) through 1916 with:
+
+```tsx
+        <AutomationContract
+          subscription={sub}
+          invokeUrl={invokeUrl}
+          pollUrl={pollUrl}
+          ingressUrl={minted.ingress_url ?? null}
+          token={minted.token}
+          updatedAt={null}
+        />
+        <p className="contract-note">
+          Everything except the secrets above is always available at{" "}
+          <Link className="link" href={`/automations/${sub.id}`}>
+            Automations → {sub.name} → API
+          </Link>
+          . Lost token? Rotate it there.
+        </p>
+```
+
+(`Link` is already imported in RunComposer. The `curl`/`responseExample`/variable derivations local to `ShowAutomationSecrets` are now dead — delete them. `pollUrl` stays as computed at line 1761.)
+
+- [ ] **Step 3: CSS** — append to `apps/web/app/globals.css` next to the existing `.contract-*` rules (grep `contract-note` to find them):
+
+```css
+.contract-stamp {
+  font-size: 12px;
+  color: var(--muted, #888);
+  margin: 4px 0 0;
+}
+```
+
+(If the file uses different token names for muted text, copy whatever `.field-hint` uses.)
+
+- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` → green. Open nothing yet — the detail page arrives next task.
+
+- [ ] **Step 5: Commit:** `git add apps/web && git commit -m "feat(web): shared AutomationContract; secrets modal shows secrets + pointer"`
+
+---
+
+### Task 7: Web — types + `/automations/[id]` read-only detail page
+
+**Files:**
+- Modify: `apps/web/app/lib/api.ts` (TriggerSubscription at line 684: add `updated_at: string;` after `created_at`; add the detail-response type below)
+- Modify: `apps/web/app/components/AutomationPanel.tsx` (export `AutomationActivity`; title links)
+- Create: `apps/web/app/automations/[id]/page.tsx`
+- Modify: `apps/web/app/globals.css`
+
+**Interfaces:**
+- Produces: route `/automations/{id}`; `api.ts` gains:
+
+```ts
+/** GET /v1/triggers/{id} — subscription + activity + the caller-facing URLs
+ *  (server-derived from FLUIDBOX_PUBLIC_URL; the dashboard never builds hosts). */
+export interface TriggerDetail {
+  subscription: TriggerSubscription;
+  schedule: Schedule | null;
+  sessions: Session[];
+  deliveries: ResultDelivery[];
+  invocations: TriggerInvocation[];
+  base_url: string;
+  invoke_url: string;
+  poll_url_template: string;
+  ingress_url: string | null;
+}
+```
+
+- Consumes: Task 6's `AutomationContract`, existing `ShowAutomationSecrets` + rotate endpoint, `AutomationActivity` (change `function AutomationActivity` to `export function AutomationActivity` in AutomationPanel.tsx:253).
+
+- [ ] **Step 1: api.ts** — add `updated_at` to `TriggerSubscription` and the `TriggerDetail` interface above. `Session`, `ResultDelivery`, `TriggerInvocation`, `Schedule` already exist in the file.
+
+- [ ] **Step 2: Export `AutomationActivity`** (AutomationPanel.tsx:253) and link each row title to the page — in `AutomationRow` (line 215) wrap the name:
+
+```tsx
+            <Link className="link" href={`/automations/${subscription.id}`}>
+              <strong>{subscription.name}</strong>
+            </Link>
+```
+
+(`Link` is already imported at line 4.) Add an "Open →" link beside the "Activity" button:
+
+```tsx
+          <Link className="btn ghost sm" href={`/automations/${subscription.id}`}>
+            Open →
+          </Link>
+```
+
+- [ ] **Step 3: Note the routing collision and resolve it.** `apps/web/app/automations/page.tsx` redirects `/automations` → `/?view=automations`; a `[id]` sibling does not conflict. Create `apps/web/app/automations/[id]/page.tsx`:
+
+```tsx
+"use client";
+
+import { use, useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { apiGet, apiPost, TriggerDetail, TriggerSubscription } from "../../lib/api";
+import { AutomationContract } from "../../components/AutomationContract";
+import { MintedAutomation, ShowAutomationSecrets } from "../../components/RunComposer";
+import { LoadingRows } from "../../components/bits";
+
+export default function AutomationDetail({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [detail, setDetail] = useState<TriggerDetail | null>(null);
+  const [loadErr, setLoadErr] = useState("");
+  const [actionErr, setActionErr] = useState("");
+  const [minted, setMinted] = useState<MintedAutomation | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setDetail(await apiGet<TriggerDetail>(`/triggers/${id}`));
+      setLoadErr("");
+    } catch (error) {
+      setLoadErr(String(error));
+    }
+  }, [id]);
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = async (subscription: TriggerSubscription) => {
+    setActionErr("");
+    try {
+      await apiPost(`/triggers/${id}/${subscription.enabled ? "disable" : "enable"}`, {});
+      await load();
+    } catch (error) {
+      setActionErr(String(error));
+    }
+  };
+
+  const rotate = async (subscription: TriggerSubscription) => {
+    setActionErr("");
+    try {
+      const response = await apiPost<{
+        token: string;
+        base_url: string | null;
+        invoke_url: string | null;
+        poll_url_template: string | null;
+      }>(`/triggers/${id}/rotate_token`, {});
+      setMinted({
+        subscription,
+        token: response.token,
+        callback_secret: null,
+        rotated: true,
+        base_url: response.base_url,
+        invoke_url: response.invoke_url,
+        poll_url_template: response.poll_url_template,
+      });
+    } catch (error) {
+      setActionErr(String(error));
+    }
+  };
+
+  if (loadErr) {
+    return (
+      <main className="page automation-detail">
+        <div className="err">{loadErr}</div>
+      </main>
+    );
+  }
+  if (!detail) {
+    return (
+      <main className="page automation-detail">
+        <LoadingRows />
+      </main>
+    );
+  }
+  const sub = detail.subscription;
+  return (
+    <main className="page automation-detail">
+      <header className="automation-detail-head">
+        <div>
+          <span className="section-kicker">
+            {sub.trigger_kind === "api"
+              ? "API-invoked automation"
+              : sub.trigger_kind === "schedule"
+                ? "Scheduled automation"
+                : "Event automation"}
+          </span>
+          <h1>{sub.name}</h1>
+          <p className="automation-intro">
+            Saved run configuration — every firing creates a normal governed run.{" "}
+            <Link className="link" href="/?view=automations">
+              All automations
+            </Link>
+          </p>
+        </div>
+        <div className="automation-actions">
+          <button className="btn ghost sm" type="button" onClick={() => void rotate(sub)}>
+            Rotate token
+          </button>
+          <button className="btn sm" type="button" onClick={() => void toggle(sub)}>
+            {sub.enabled ? "Disable" : "Enable"}
+          </button>
+        </div>
+      </header>
+      {actionErr && <div className="err">{actionErr}</div>}
+
+      <section className="automation-detail-section">
+        <h2>API</h2>
+        <AutomationContract
+          subscription={sub}
+          invokeUrl={detail.invoke_url}
+          pollUrl={detail.poll_url_template}
+          ingressUrl={detail.ingress_url}
+          token={null}
+          updatedAt={sub.updated_at}
+        />
+      </section>
+
+      {/* Configuration + Template sections land in Task 8. */}
+
+      <section className="automation-detail-section">
+        <h2>Activity</h2>
+        <AutomationActivityBlock id={sub.id} />
+      </section>
+      {minted && (
+        <ShowAutomationSecrets
+          minted={minted}
+          onClose={() => {
+            setMinted(null);
+            void load();
+          }}
+        />
+      )}
+    </main>
+  );
+}
+```
+
+with, at the bottom of the file:
+
+```tsx
+import { AutomationActivity } from "../../components/AutomationPanel";
+
+function AutomationActivityBlock({ id }: { id: string }) {
+  return <AutomationActivity id={id} />;
+}
+```
+
+(Or import `AutomationActivity` directly in the header import block and use it inline — implementer's choice; keep imports at the top per lint.)
+
+- [ ] **Step 4: CSS** — append (near `.automation-panel` rules):
+
+```css
+.automation-detail { max-width: 880px; margin: 0 auto; padding: 24px 16px 64px; }
+.automation-detail-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 8px; }
+.automation-detail-section { margin-top: 28px; }
+.automation-detail-section > h2 { font-size: 15px; margin: 0 0 10px; }
+```
+
+Match the `main className` conventions of `apps/web/app/sessions/[id]/page.tsx` — if that page uses a different wrapper class than `page`, copy it.
+
+- [ ] **Step 5: Verify:** `pnpm build` green. Then the first manual checkpoint (needs `just dev` running — ask the owner if it isn't): create an API automation, close the secrets modal, click into `/automations/{id}`, confirm the contract renders with `$FLUIDBOX_TRIGGER_TOKEN`, copy works, Rotate shows the one-time modal.
+
+- [ ] **Step 6: Commit:** `git add apps/web && git commit -m "feat(web): durable /automations/{id} page with live API contract"`
+
+---
+
+### Task 8: Web — edit flows on the detail page (template + settings)
+
+**Files:**
+- Modify: `apps/web/app/automations/[id]/page.tsx`
+- Modify: `apps/web/app/globals.css` (chips)
+
+**Interfaces:**
+- Consumes: `apiPatch` (api.ts:138), Task 5's `classifyVariables`, `ScheduleBuilder`/`parseCron`/`describeSchedule` from `../../components/ScheduleBuilder`.
+- Produces: `PATCH /triggers/{id}` calls with bodies shaped like Task 4's `UpdateTrigger`; a `TemplateChips` component reused by Task 9.
+
+- [ ] **Step 1: Add `TemplateChips`** to `AutomationContract.tsx` (exported — the composer reuses it):
+
+```tsx
+/** Live placeholder read-back: which {{names}} the caller supplies vs which
+ *  the platform fills. Rendered under every template textarea so the
+ *  template's contract is visible while typing. */
+export function TemplateChips({ kind, template }: { kind: string; template: string }) {
+  const { caller, system } = classifyVariables(kind, template || null);
+  if (caller.length === 0 && system.length === 0) return null;
+  return (
+    <div className="tpl-chips">
+      {caller.map((name) => (
+        <span key={name} className="tpl-chip caller" title="Caller supplies this in `context`">
+          {`{{${name}}}`} · caller
+        </span>
+      ))}
+      {system.map((name) => (
+        <span key={name} className="tpl-chip system" title="Filled in by fluidbox">
+          {`{{${name}}}`} · fluidbox
+        </span>
+      ))}
+    </div>
+  );
+}
+```
+
+CSS:
+
+```css
+.tpl-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.tpl-chip { font-family: var(--mono, monospace); font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border, #333); }
+.tpl-chip.system { opacity: 0.7; }
+```
+
+(Adopt the repo's actual CSS variable names — grep `--border` in globals.css and reuse whatever the existing chips/badges use.)
+
+- [ ] **Step 2: Template section** on the detail page (between API and Activity):
+
+```tsx
+      <section className="automation-detail-section">
+        <h2>Task template</h2>
+        <TemplateSection detail={detail} onSaved={load} />
+      </section>
+```
+
+```tsx
+function TemplateSection({ detail, onSaved }: { detail: TriggerDetail; onSaved: () => Promise<void> }) {
+  const sub = detail.subscription;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(sub.task_template ?? "");
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState("");
+
+  const save = async () => {
+    setSaving(true);
+    setErr("");
+    try {
+      await apiPatch(`/triggers/${sub.id}`, { task_template: draft });
+      setEditing(false);
+      await onSaved();
+    } catch (error) {
+      setErr(String(error)); // server names the missing placeholder/context
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!editing) {
+    return (
+      <div>
+        {sub.task_template ? (
+          <>
+            <pre className="token">{sub.task_template}</pre>
+            <TemplateChips kind={sub.trigger_kind} template={sub.task_template} />
+          </>
+        ) : (
+          <p className="contract-note">
+            No template — every invocation must supply its own task (task override is on).
+          </p>
+        )}
+        <button
+          className="btn ghost sm"
+          type="button"
+          onClick={() => {
+            setDraft(sub.task_template ?? "");
+            setEditing(true);
+          }}
+        >
+          Edit template
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="field">
+      <textarea
+        className="inp run-task-input"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      <TemplateChips kind={sub.trigger_kind} template={draft} />
+      <span className="field-hint">
+        Future firings use the new template immediately; runs already in flight keep the
+        configuration they started with.
+      </span>
+      {err && <div className="err">{err}</div>}
+      <div className="automation-actions">
+        <button className="btn primary sm" type="button" disabled={saving} onClick={() => void save()}>
+          {saving ? "Saving…" : "Save template"}
+        </button>
+        <button className="btn ghost sm" type="button" disabled={saving} onClick={() => setEditing(false)}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Configuration section** (between API and Template):
+
+```tsx
+      <section className="automation-detail-section">
+        <h2>Configuration</h2>
+        <SettingsSection detail={detail} onSaved={load} />
+      </section>
+```
+
+`SettingsSection` mirrors `TemplateSection`'s view/edit toggle. View mode: a `rows`-style list of name, agent id (link `/agents` page style used elsewhere — plain text is fine), autonomy, concurrency policy, task/workspace override flags, callback destination (from `result_destinations[0]?.url`), and for schedule kind the cron/timezone/missed policy + next fire from `detail.schedule`. Edit mode: inputs for name (`inp`), checkboxes for the two overrides (`check`), select for concurrency (same options as RunComposer.tsx:1504-1508), input for callback URL (empty string = remove — mirror the PATCH semantics with a hint: "Clearing removes the signed callback; changing it mints a NEW signing secret shown once"), and for schedule kind the `ScheduleBuilder` (cron/timezone) + missed-policy select (options from RunComposer.tsx:892-895). Save builds the PATCH body with ONLY touched fields:
+
+```tsx
+    const body: Record<string, unknown> = {};
+    if (name !== sub.name) body.name = name;
+    if (allowTask !== sub.allow_task_override) body.allow_task_override = allowTask;
+    if (allowWorkspace !== sub.allow_workspace_override) body.allow_workspace_override = allowWorkspace;
+    if (concurrency !== sub.concurrency_policy) body.concurrency_policy = concurrency;
+    if (callbackUrl !== initialCallbackUrl) body.callback_url = callbackUrl; // "" clears
+    if (sub.trigger_kind === "schedule" && detail.schedule &&
+        (cron !== detail.schedule.cron || timezone !== detail.schedule.timezone || missed !== detail.schedule.missed_run_policy)) {
+      body.schedule = { cron, timezone, missed_run_policy: missed };
+    }
+    const response = await apiPatch<{ callback_secret: string | null }>(`/triggers/${sub.id}`, body);
+    if (response.callback_secret) setNewSecret(response.callback_secret);
+```
+
+When `callback_secret` comes back, show it in a `CopyBlock` inside a dismissable note ("New callback signing secret — copy it now, it will not be shown again."). Import `CopyBlock` from `AutomationContract`.
+
+- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` green. Manual: edit the template on a live automation → the API section's variables + curl update after save and the "as of" stamp advances.
+
+- [ ] **Step 5: Commit:** `git add apps/web && git commit -m "feat(web): edit template and settings on the automation detail page"`
+
+---
+
+### Task 9: Web — composer template box + pre-save API preview
+
+**Files:**
+- Modify: `apps/web/app/components/RunComposer.tsx` (label block 954-966; `templateHint` 758-763; `blockingIssue` 598-632; aside panel after the Guardrails SpecRow ~line 1619)
+- Modify: `apps/web/app/globals.css`
+
+**Interfaces:**
+- Consumes: Task 5's `buildCurl`/`classifyVariables`, Task 8's `TemplateChips` (from `./AutomationContract`).
+
+- [ ] **Step 1: Relabel the template field** (replace lines 954-966):
+
+```tsx
+            <label className="field">
+              <span className="lab">
+                {mode === "once"
+                  ? "What should the agent accomplish?"
+                  : kind === "api"
+                    ? "Task template — rendered for every API invocation"
+                    : kind === "schedule"
+                      ? "Task template — rendered at every scheduled firing"
+                      : "Task template — rendered for every matching PR event"}
+                {mode === "automation" && kind === "api" && allowTask && (
+                  <span className="optional-label"> optional — callers may send their own task</span>
+                )}
+              </span>
+              <textarea
+                className="inp run-task-input"
+                value={task}
+                onChange={(event) => setTask(event.target.value)}
+                placeholder={
+                  mode === "once"
+                    ? "Review the latest changes, identify regressions, and prepare a safe patch…"
+                    : kind === "schedule"
+                      ? "Sweep the queue as of {{fire_time}} and file a summary…"
+                      : kind === "event"
+                        ? "Review {{repository}} PR #{{pr_number}}: {{pr_title}}…"
+                        : "Investigate {{ticket}} and report the root cause…"
+                }
+              />
+              {mode === "automation" && <TemplateChips kind={kind} template={task} />}
+              {mode === "automation" && <span className="field-hint">{templateHint}</span>}
+            </label>
+```
+
+and tighten `templateHint` (758-763) to explain the mechanism once:
+
+```tsx
+  const templateHint =
+    kind === "schedule"
+      ? "Saved with the automation. {{fire_time}} is filled in at each firing; any other {{name}} is refused at save (a schedule has no caller to supply it)."
+      : kind === "event"
+        ? "Saved with the automation. {{repository}}, {{pr_number}}, {{pr_title}} are filled from the pull request; any other {{name}} is refused at save."
+        : "Saved with the automation. Every {{name}} you add becomes a required context value the API caller sends on invoke.";
+```
+
+- [ ] **Step 2: `blockingIssue` gains the no-caller rule** (insert after the existing dead-config check at line 614-616):
+
+```tsx
+      if (mode === "automation" && (kind === "schedule" || kind === "event") && !task.trim()) {
+        return "This trigger fires without a caller — write the task template it should run.";
+      }
+```
+
+- [ ] **Step 3: API preview card** in the aside, after the Guardrails `SpecRow` (~line 1619):
+
+```tsx
+            {!agentOnly && mode === "automation" && kind === "api" && !blockingIssue && (
+              <ApiPreview task={task} />
+            )}
+```
+
+with the component (place near `SpecRow` at the bottom):
+
+```tsx
+/** Pre-save preview of the integration contract. Deliberately labeled a
+ *  preview: the id and token exist only after save, so the copy carries
+ *  placeholders — nobody should wire an integration to this text. */
+function ApiPreview({ task }: { task: string }) {
+  const [copied, setCopied] = useState(false);
+  const { caller } = classifyVariables("api", task || null);
+  const curl = buildCurl({
+    invokeUrl: "{base_url}/v1/triggers/{id-assigned-on-save}/invoke",
+    token: "<minted-on-save>",
+    caller,
+  });
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(curl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      /* clipboard unavailable — the text is selectable either way */
+    }
+  };
+  return (
+    <div className="rc-api-preview">
+      <div className="contract-head">
+        <span className="rc-row-label">API preview</span>
+        <button type="button" className="btn ghost sm" onClick={copy}>
+          {copied ? "Copied" : "Copy preview"}
+        </button>
+      </div>
+      <pre className="token rc-api-preview-curl">{curl}</pre>
+      <span className="field-hint">
+        The real URL and one-time token are minted when you save; the full contract then
+        lives on the automation&apos;s page.
+      </span>
+    </div>
+  );
+}
+```
+
+Imports to add at the top of RunComposer: `buildCurl, classifyVariables` from `../lib/automation-contract`; `TemplateChips` from `./AutomationContract`.
+
+CSS:
+
+```css
+.rc-api-preview { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border, #333); }
+.rc-api-preview-curl { font-size: 11px; max-height: 140px; overflow: auto; }
+```
+
+- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` green. Manual: in the composer pick Automation → API call → watch the preview appear once name+template are valid, disappear on Schedule kind, chips update as you type `{{ticket}}`.
+
+- [ ] **Step 5: Commit:** `git add apps/web && git commit -m "feat(web): self-explanatory template box + pre-save API preview"`
+
+---
+
+### Task 10: Full verification + lifecycle drill
+
+**Files:** none new.
+
+- [ ] **Step 1: Full hermetic verification** (NOT `just check` — dotenv):
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+cargo test -p fluidbox-core
+cargo test -p fluidbox-server
+cd apps/web && pnpm vitest run && pnpm build
+```
+
+All must pass; paste outputs in the report.
+
+- [ ] **Step 2: Manual lifecycle drill** (needs the dev stack; coordinate with the owner before starting it — do not start `just dev`/DB yourself if anything is already running):
+1. Configure Run → Automation → API call: template box shows the new label, chips appear for `{{ticket}}`, API preview card renders, "Copy preview" copies placeholder curl.
+2. Save → secrets modal shows token + link "Automations → {name} → API".
+3. Follow the link → `/automations/{id}`: contract with `$FLUIDBOX_TRIGGER_TOKEN`, every CopyBlock copies, "as of" stamp present.
+4. Hard-refresh the page → identical (persistence).
+5. Edit template (add `{{env}}`) → save → variables table + curl show `env`, stamp advanced.
+6. Settings edit: flip concurrency to `skip_if_running` → save → view reflects it.
+7. Rotate token → one-time modal again → close → contract still shows placeholder form.
+8. Invoke with the real token (curl) → 200; confirms PATCH broke nothing at the invoke path.
+9. Schedule-kind automation: edit cron via ScheduleBuilder → next-fire updates.
+10. Negative: PATCH template to `{{nope}}` on the schedule automation → inline error naming the schedule context.
+
+- [ ] **Step 3: Report results** to the owner, including anything skipped and why. Offer to run `scripts/governance-e2e.sh` / `just e2e` ONLY as an owner-triggered follow-up.
+
+- [ ] **Step 4: Final commit if the drill produced fixes**, message `fix(web/server): lifecycle drill follow-ups for automation contract`.

--- a/docs/superpowers/plans/2026-07-29-automation-api-contract.md
+++ b/docs/superpowers/plans/2026-07-29-automation-api-contract.md
@@ -2,9 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Revision 2 (2026-07-30):** incorporates the external (Codex/GPT-5.6-sol) plan review. Material changes: `CallbackUpdate::Clear` binds key_version **1** not 0 (CHECK constraint `in (1,2)`, migration 0014:51); subscription+schedule PATCH is **one atomic transaction** with an `updated_at` optimistic-concurrency guard; `UpdateTrigger` is `deny_unknown_fields` deserialized from raw JSON so immutable-field attempts 400; schedule PATCH merges omitted fields from the existing row; `Sealed` is destructured (not `split(&Some(...))`, which doesn't compile); `buildCurl` uses shell-expandable quoting and emits a `task` body for template-less automations; the event system-variable list is the full 12-name `sample_context()` set; the secrets modal is truly secrets-only; the detail page follows Shell/last-good-snapshot conventions; the response table documents **422** for idempotency-key reuse (what the server actually returns — the current modal's 409 copy is a pre-existing bug we fix in passing).
+
 **Goal:** Make the automation API contract durable (always copyable from a new `/automations/{id}` page, live-rendered from the DB), add `PATCH /v1/triggers/{id}` for the mutable subset, and make the composer's task-template box self-explanatory.
 
-**Architecture:** Backend: one URL helper shared by create/rotate/get/list, one pure update-resolution function + PATCH handler in `triggers.rs`, two new `fluidbox-db` methods (no migrations — all columns exist). Frontend: extract the contract-rendering logic into a pure lib (`automation-contract.ts`) + shared component (`AutomationContract.tsx`), consumed by a new detail page, a trimmed one-time-secrets modal, and a pre-save preview card in the composer.
+**Architecture:** Backend: one URL helper + one ingress-path helper shared by every contract-carrying response, one pure update-resolution function + PATCH handler in `triggers.rs`, one new atomic `fluidbox-db` method (no migrations — all columns exist). Frontend: extract the contract-rendering logic into a pure lib (`automation-contract.ts`) + shared component (`AutomationContract.tsx`), consumed by a new detail page, a trimmed one-time-secrets modal, and a pre-save preview card in the composer.
 
 **Tech Stack:** Rust (axum, sqlx, serde_json), Next.js 16 App Router (client components), vitest.
 
@@ -13,25 +15,28 @@
 ## Global Constraints
 
 - Backend is 100% Rust; the dashboard is presentation-only (all logic server-side or in pure, tested TS libs).
-- Trigger token & callback secret are one-time: sha256-hashed / sealed at rest, NEVER re-shown. Recovery = rotation.
+- Trigger token & callback secret are one-time: sha256-hashed / sealed at rest, NEVER re-shown. Recovery = rotation. Consequence for PATCH: a response that mints a secret may only be sent AFTER the transaction that stored it commits, and that transaction must be all-or-nothing.
 - Absolute URLs come ONLY from the server (`FLUIDBOX_PUBLIC_URL`); the dashboard must never derive hosts.
-- Trigger kind and agent are immutable on PATCH (400 attempts are impossible by schema — the fields simply don't exist on the request struct).
+- Trigger kind and agent are immutable on PATCH — enforced by `deny_unknown_fields` + explicit 400 mapping (serde silently ignoring unknown keys is NOT enforcement).
+- `callback_secret_key_version` has `CHECK (in (1, 2))` (migration 0014:51). NULL bytes bind version 1 (the `Sealed::split` convention) — never 0.
 - Tenant-owned DB methods take `TenantScope` and carry `tenant_id = $n` predicates (signature requirement).
 - Do NOT run `just check` / `just e2e` / DB-backed tests (they need env or spend money; owner-triggered only). Verify with: `cargo test -p fluidbox-server`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`, and in `apps/web`: `pnpm vitest run`, `pnpm build`.
-- Next.js in this repo is newer than training data — check `node_modules/next/dist/docs/` if any App Router API surprises you. Existing pages (`apps/web/app/sessions/[id]/page.tsx`) are the pattern reference.
+- Next.js in this repo is newer than training data — check `node_modules/next/dist/docs/` if any App Router API surprises you. Existing pages (`apps/web/app/sessions/[id]/page.tsx`) are the pattern reference. `Shell` already wraps pages in `<main>` (`apps/web/app/components/Shell.tsx:33`) — new pages must NOT add their own `<main>`.
 - Commit after every task. Commit trailer:
   `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`
 
 ---
 
-### Task 1: Rust — `contract_urls` helper + URL fields on GET/LIST
+### Task 1: Rust — `contract_urls` + `ingress_path_for` helpers; URL fields on GET/LIST/rotate
 
 **Files:**
-- Modify: `crates/fluidbox-server/src/triggers.rs` (helper near line 210; `create` ~line 668–681; `rotate_token` ~line 785–792; `get` ~line 698–721; `list` ~line 684–696; tests module at line 1115)
-- Modify: `crates/fluidbox-server/src/main.rs` (no route change in this task)
+- Modify: `crates/fluidbox-server/src/triggers.rs` (helpers near line 210; `create` ~line 668–681; `rotate_token` ~line 785–792; `get` ~line 698–721; `list` ~line 684–696; tests module at line 1115)
 
 **Interfaces:**
-- Produces: `fn contract_urls(base: &str, sub_id: Uuid, ingress_path: Option<&str>) -> serde_json::Map<String, Value>` — keys `base_url`, `invoke_url`, `poll_url_template`, `ingress_url`. `GET /v1/triggers/{id}` response gains those four keys; `GET /v1/triggers` gains top-level `base_url`.
+- Produces:
+  - `fn contract_urls(base: &str, sub_id: Uuid, ingress_path: Option<&str>) -> serde_json::Map<String, Value>` — keys `base_url`, `invoke_url`, `poll_url_template`, `ingress_url`.
+  - `async fn ingress_path_for(state: &AppState, scope: fluidbox_db::TenantScope, sub: &fluidbox_db::TriggerSubscriptionRow) -> ApiResult<Option<String>>` — recomputes the event-ingress path (None for api/schedule kinds). Used by `get`, `rotate_token`, and Task 4's `update`.
+  - `GET /v1/triggers/{id}` response gains the four URL keys; `GET /v1/triggers` gains top-level `base_url` (deliberate: the list UI never renders contracts — spec amended to match).
 - Consumes: existing `connectors::connector_for(provider) -> Option<&'static str>`, `fluidbox_db::{scoped_tx, get_connection}`.
 
 - [ ] **Step 1: Write the failing test** (append inside `mod tests` in `triggers.rs`):
@@ -60,13 +65,13 @@ fn contract_urls_shapes_and_trims() {
 - [ ] **Step 2: Run it — must fail to compile** (`contract_urls` not defined):
 `cargo test -p fluidbox-server contract_urls_shapes -- --nocapture` → expect compile error.
 
-- [ ] **Step 3: Implement the helper** (place after `random_hex_token`, ~line 221):
+- [ ] **Step 3: Implement the helpers** (place after `random_hex_token`, ~line 221):
 
 ```rust
 /// Caller-facing URL block for a subscription's integration contract.
 /// The control plane is the only party that knows its own public address
 /// (the dashboard reaches it through a same-origin proxy), so create,
-/// rotate, get, and list all hand these over rather than letting a client
+/// rotate, get, and update all hand these over rather than letting a client
 /// guess. Nothing here is secret: it is public_url + subscription id.
 fn contract_urls(
     base: &str,
@@ -90,11 +95,36 @@ fn contract_urls(
     );
     m
 }
+
+/// Recompute an event subscription's ingress path (registration-level for
+/// seamless connections, per-connection otherwise) so the contract is
+/// rebuildable forever, not a one-time artifact of the create response.
+/// api/schedule kinds have no ingress.
+async fn ingress_path_for(
+    state: &AppState,
+    scope: fluidbox_db::TenantScope,
+    sub: &fluidbox_db::TriggerSubscriptionRow,
+) -> ApiResult<Option<String>> {
+    let ("event", Some(cid)) = (sub.trigger_kind.as_str(), sub.connection_id) else {
+        return Ok(None);
+    };
+    let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+    let conn = fluidbox_db::get_connection(&mut *tx, scope, cid).await?;
+    tx.commit().await?;
+    Ok(conn.and_then(|c| {
+        crate::connectors::connector_for(&c.provider).map(|connector| match c.registration_id {
+            Some(rid) => format!("/v1/ingress/{connector}/app/{rid}"),
+            None => format!("/v1/ingress/{connector}/{cid}"),
+        })
+    }))
+}
 ```
+
+(If the `let ("event", Some(cid)) = … else` destructuring displeases the borrow checker on `sub.trigger_kind.as_str()`, use a plain `match` returning early — behavior identical. If `get_connection`'s call shape differs, copy it from `create` at triggers.rs:426.)
 
 - [ ] **Step 4: Test passes:** `cargo test -p fluidbox-server contract_urls_shapes` → PASS.
 
-- [ ] **Step 5: Use it in `create` and `rotate_token`** (replace the hand-built duplicate blocks). In `create` (lines 668–681) replace the final `Ok(Json(json!({...})))` with:
+- [ ] **Step 5: Use the helpers in `create` and `rotate_token`.** In `create` (lines 668–681) replace the final `Ok(Json(json!({...})))` with:
 
 ```rust
     let mut body = serde_json::Map::new();
@@ -114,34 +144,22 @@ fn contract_urls(
 In `rotate_token` (lines 785–792) replace the final `Ok(Json(json!({...})))` with:
 
 ```rust
+    let ingress_path = ingress_path_for(&state, scope, &sub).await?;
     let mut body = serde_json::Map::new();
     body.insert("token".into(), json!(token));
     body.insert("revoked".into(), json!(revoked));
-    body.extend(contract_urls(&state.cfg.public_url, sub.id, None));
+    body.extend(contract_urls(
+        &state.cfg.public_url,
+        sub.id,
+        ingress_path.as_deref(),
+    ));
     Ok(Json(Value::Object(body)))
 ```
 
-- [ ] **Step 6: Add URLs to `get`.** Event subscriptions recompute their ingress path the same way `create` derived it (registration-level for seamless, per-connection otherwise). Replace the body of `get` after the four fetches (lines 717–720) with:
+- [ ] **Step 6: Add URLs to `get`.** Replace the body of `get` after the four fetches (lines 717–720) with:
 
 ```rust
-    // Recompute the ingress path for event subscriptions so the contract is
-    // rebuildable forever, not a one-time artifact of the create response.
-    let ingress_path = match (sub.trigger_kind.as_str(), sub.connection_id) {
-        ("event", Some(cid)) => {
-            let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
-            let conn = fluidbox_db::get_connection(&mut *tx, scope, cid).await?;
-            tx.commit().await?;
-            conn.and_then(|c| {
-                crate::connectors::connector_for(&c.provider).map(|connector| {
-                    match c.registration_id {
-                        Some(rid) => format!("/v1/ingress/{connector}/app/{rid}"),
-                        None => format!("/v1/ingress/{connector}/{cid}"),
-                    }
-                })
-            })
-        }
-        _ => None,
-    };
+    let ingress_path = ingress_path_for(&state, scope, &sub).await?;
     let mut body = serde_json::Map::new();
     body.insert("subscription".into(), serde_json::to_value(&sub)?);
     body.insert("schedule".into(), serde_json::to_value(&schedule)?);
@@ -166,22 +184,27 @@ In `rotate_token` (lines 785–792) replace the final `Ok(Json(json!({...})))` w
     })))
 ```
 
-- [ ] **Step 8: Verify:** `cargo test -p fluidbox-server && cargo clippy -p fluidbox-server -- -D warnings` → all green. (If `get_connection`'s signature differs from `get_connection(&mut *tx, scope, cid)`, copy the exact call shape from `create` at triggers.rs:426.)
+- [ ] **Step 8: Verify:** `cargo test -p fluidbox-server && cargo clippy -p fluidbox-server -- -D warnings` → all green.
 
-- [ ] **Step 9: Commit:** `git add crates/fluidbox-server/src/triggers.rs && git commit -m "feat(server): return contract URLs on trigger get/list"`
+- [ ] **Step 9: Commit:** `git add crates/fluidbox-server/src/triggers.rs && git commit -m "feat(server): contract URL + ingress helpers on trigger get/list/rotate"`
 
 ---
 
-### Task 2: Rust — pure `resolve_update` + tests
+### Task 2: Rust — `UpdateTrigger` (deny_unknown_fields), `ScheduleUpdate`, pure `resolve_update` + `merge_schedule` + tests
 
 **Files:**
-- Modify: `crates/fluidbox-server/src/triggers.rs` (new struct + fn after `CreateTrigger`/`ScheduleInput`, ~line 288; tests in `mod tests`)
+- Modify: `crates/fluidbox-server/src/triggers.rs` (new structs + fns after `CreateTrigger`/`ScheduleInput`, ~line 288; tests in `mod tests`)
 
 **Interfaces:**
 - Produces:
 
 ```rust
+/// PATCH body — the mutable surface ONLY. deny_unknown_fields is the
+/// immutability enforcement: `agent`, `trigger_kind`, `connection`, etc.
+/// are refused with 400, not silently ignored (serde's default would
+/// otherwise accept-and-drop them, returning a lying 200).
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct UpdateTrigger {
     #[serde(default)] pub name: Option<String>,
     /// Some("") clears the template (valid only when the resolved state
@@ -193,8 +216,33 @@ pub struct UpdateTrigger {
     /// Some("") removes the signed-webhook callback; Some(url) sets/replaces
     /// it (mints a new secret, returned once); omitted = unchanged.
     #[serde(default)] pub callback_url: Option<String>,
-    /// Schedule-kind subscriptions only.
-    #[serde(default)] pub schedule: Option<ScheduleInput>,
+    /// Schedule-kind subscriptions only. Partial: omitted fields keep the
+    /// existing schedule's values (a cron-only PATCH must NOT reset
+    /// timezone/missed policy to defaults).
+    #[serde(default)] pub schedule: Option<ScheduleUpdate>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScheduleUpdate {
+    #[serde(default)] pub cron: Option<String>,
+    #[serde(default)] pub timezone: Option<String>,
+    #[serde(default)] pub missed_run_policy: Option<String>,
+}
+
+impl UpdateTrigger {
+    /// True when the PATCH names nothing — the handler answers with the
+    /// current state WITHOUT writing (an empty {} must not advance
+    /// updated_at; the detail page's "as of" stamp would lie).
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.task_template.is_none()
+            && self.allow_task_override.is_none()
+            && self.allow_workspace_override.is_none()
+            && self.concurrency_policy.is_none()
+            && self.callback_url.is_none()
+            && self.schedule.is_none()
+    }
 }
 
 pub(crate) struct ResolvedUpdate {
@@ -205,20 +253,23 @@ pub(crate) struct ResolvedUpdate {
     pub concurrency_policy: String,
 }
 
-/// Pure field resolution + validation for PATCH. `render_ctx` is the kind's
-/// sample context for schedule/event subscriptions (the template must render
-/// from it alone — there is no caller); None for api-kind (callers supply
-/// context, unknown placeholders are theirs to fill).
 fn resolve_update(
     current: &fluidbox_db::TriggerSubscriptionRow,
     req: &UpdateTrigger,
-    render_ctx: Option<&BTreeMap<String, String>>,
+    render_ctx: Option<&std::collections::BTreeMap<String, String>>,
 ) -> Result<ResolvedUpdate, String>
+
+/// Merge a partial schedule PATCH over the existing row → (cron, timezone,
+/// missed_run_policy), all still to be validated by the caller.
+fn merge_schedule(
+    current: &fluidbox_db::ScheduleRow,
+    upd: &ScheduleUpdate,
+) -> (String, String, String)
 ```
 
 - Consumes: `render_task_template` (triggers.rs:38), `ConcurrencyPolicy::parse` (already imported).
 
-- [ ] **Step 1: Write the failing tests** (append inside `mod tests`; the tests build a minimal `TriggerSubscriptionRow` via a helper):
+- [ ] **Step 1: Write the failing tests** (append inside `mod tests`):
 
 ```rust
     fn sub_row(kind: &str, template: Option<&str>, allow_task: bool) -> fluidbox_db::TriggerSubscriptionRow {
@@ -262,6 +313,18 @@ fn resolve_update(
     }
 
     #[test]
+    fn update_trigger_refuses_unknown_fields() {
+        // Immutability enforcement: agent/kind are not silently ignored.
+        for body in [r#"{"agent":"other"}"#, r#"{"trigger_kind":"schedule"}"#] {
+            assert!(serde_json::from_str::<UpdateTrigger>(body).is_err(), "{body}");
+        }
+        let ok: UpdateTrigger = serde_json::from_str(r#"{"name":"x"}"#).unwrap();
+        assert!(!ok.is_empty());
+        let empty: UpdateTrigger = serde_json::from_str("{}").unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
     fn resolve_update_keeps_omitted_fields() {
         let cur = sub_row("api", Some("do {{ticket}}"), false);
         let r = resolve_update(&cur, &upd(), None).unwrap();
@@ -272,13 +335,10 @@ fn resolve_update(
 
     #[test]
     fn resolve_update_rejects_dead_config() {
-        // Clearing the template while override stays off = a subscription
-        // that can never produce a task (mirrors the create-time rule).
         let cur = sub_row("api", Some("t"), false);
         let mut req = upd();
         req.task_template = Some("  ".into());
         assert!(resolve_update(&cur, &req, None).is_err());
-        // …but clearing is fine when the caller may supply the task.
         let cur = sub_row("api", Some("t"), true);
         let r = resolve_update(&cur, &req, None).unwrap();
         assert_eq!(r.task_template, None);
@@ -309,14 +369,32 @@ fn resolve_update(
         req.task_template = Some("".into());
         assert!(resolve_update(&cur, &req, Some(&ctx)).is_err());
     }
+
+    #[test]
+    fn merge_schedule_keeps_omitted_fields() {
+        let row = fluidbox_db::ScheduleRow {
+            id: Uuid::nil(),
+            subscription_id: Uuid::nil(),
+            cron: "0 9 * * 1-5".into(),
+            timezone: "America/Chicago".into(),
+            next_fire_at: None,
+            missed_run_policy: "catch_up".into(),
+            last_fired_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        // A cron-only PATCH must not reset timezone/missed policy.
+        let upd = ScheduleUpdate { cron: Some("0 8 * * *".into()), timezone: None, missed_run_policy: None };
+        let (cron, tz, missed) = merge_schedule(&row, &upd);
+        assert_eq!((cron.as_str(), tz.as_str(), missed.as_str()), ("0 8 * * *", "America/Chicago", "catch_up"));
+    }
 ```
 
-Note: `sub_row` needs `TriggerSubscriptionRow`'s fields to be `pub` — they already are (fluidbox-db/src/lib.rs:3721). If the struct gains fields between now and implementation, update the literal; the compile error tells you.
+(`sub_row` / the `ScheduleRow` literal need those structs' fields `pub` — they already are, fluidbox-db/src/lib.rs:3721 and :6890. If either gains fields, the compile error tells you what to add.)
 
-- [ ] **Step 2: Run — expect compile failure** (`UpdateTrigger`/`resolve_update` undefined):
-`cargo test -p fluidbox-server resolve_update -- --nocapture`
+- [ ] **Step 2: Run — expect compile failure:** `cargo test -p fluidbox-server resolve_update -- --nocapture`
 
-- [ ] **Step 3: Implement** (after `ScheduleInput`, before `create`):
+- [ ] **Step 3: Implement** (structs from **Interfaces** verbatim, plus):
 
 ```rust
 fn resolve_update(
@@ -386,20 +464,35 @@ fn resolve_update(
         concurrency_policy,
     })
 }
+
+fn merge_schedule(
+    current: &fluidbox_db::ScheduleRow,
+    upd: &ScheduleUpdate,
+) -> (String, String, String) {
+    (
+        upd.cron.as_deref().unwrap_or(&current.cron).trim().to_string(),
+        upd.timezone
+            .as_deref()
+            .unwrap_or(&current.timezone)
+            .to_string(),
+        upd.missed_run_policy
+            .as_deref()
+            .unwrap_or(&current.missed_run_policy)
+            .to_string(),
+    )
+}
 ```
 
-(Add `UpdateTrigger` + `ResolvedUpdate` exactly as in **Interfaces** above.)
-
-- [ ] **Step 4: Tests pass:** `cargo test -p fluidbox-server resolve_update` → 4 PASS. Expect a dead-code warning on `UpdateTrigger.callback_url`/`schedule` until Task 4 — suppress nothing; the handler lands two tasks later, so if clippy blocks, add `#[allow(dead_code)]` on `resolve_update` temporarily and REMOVE it in Task 4. `cargo clippy -p fluidbox-server -- -D warnings`.
+- [ ] **Step 4: Tests pass:** `cargo test -p fluidbox-server -- resolve_update merge_schedule update_trigger_refuses` → 6 PASS. If clippy flags dead code before Task 4 wires the handler, add `#[allow(dead_code)]` on the new items temporarily and REMOVE it in Task 4. `cargo clippy -p fluidbox-server -- -D warnings`.
 
 - [ ] **Step 5: Commit:** `git add crates/fluidbox-server/src/triggers.rs && git commit -m "feat(server): pure PATCH resolution for trigger subscriptions"`
 
 ---
 
-### Task 3: Rust — DB methods `update_trigger_subscription` + `update_schedule_config`
+### Task 3: Rust — atomic DB method `update_trigger_subscription` (subscription + schedule, one tx, stale-guard)
 
 **Files:**
-- Modify: `crates/fluidbox-db/src/lib.rs` (after `set_trigger_subscription_enabled` ~line 3908; after `create_schedule` ~line 6931)
+- Modify: `crates/fluidbox-db/src/lib.rs` (after `set_trigger_subscription_enabled` ~line 3908)
 
 **Interfaces:**
 - Produces:
@@ -414,64 +507,69 @@ pub enum CallbackUpdate {
     Set { destinations: Value, sealed: Vec<u8>, key_version: i16 },
 }
 
+pub struct ScheduleConfigUpdate {
+    pub cron: String,
+    pub timezone: String,
+    pub missed_run_policy: String,
+    pub next_fire_at: DateTime<Utc>,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn update_trigger_subscription(
     pool: &PgPool,
     scope: TenantScope,
     id: Uuid,
+    expect_updated_at: DateTime<Utc>,
     name: &str,
     task_template: Option<&str>,
     allow_task_override: bool,
     allow_workspace_override: bool,
     concurrency_policy: &str,
     callback: CallbackUpdate,
-) -> sqlx::Result<Option<TriggerSubscriptionRow>>
-
-pub async fn update_schedule_config(
-    pool: &PgPool,
-    scope: TenantScope,
-    subscription: Uuid,
-    cron: &str,
-    timezone: &str,
-    missed_run_policy: &str,
-    next_fire_at: DateTime<Utc>,
-) -> sqlx::Result<Option<ScheduleRow>>
+    schedule: Option<&ScheduleConfigUpdate>,
+) -> sqlx::Result<Option<(TriggerSubscriptionRow, Option<ScheduleRow>)>>
 ```
+
+Semantics the handler relies on:
+- ONE `scoped_tx` for both writes. A schedule failure rolls the subscription back — a newly sealed callback secret is never committed unless the whole PATCH lands, so the one-time reveal in the response can never orphan.
+- `expect_updated_at` is an optimistic-concurrency guard (`and updated_at = $x`); a stale or vanished row returns `Ok(None)` — the handler answers 409. Two concurrent PATCHes can no longer silently overwrite each other's fields (the full-row write makes lost updates otherwise easy).
+- Any callback change (Set OR Clear) bumps `authority_generation`, so `subscription_secret` bindings frozen on the old secret fail closed.
+- NULL sealed bytes bind key_version **1** — `callback_secret_key_version` is `CHECK (in (1, 2))` (migration 0014:51); the version is moot when the bytes are null, same convention as `seal.rs::Sealed::split`.
+- `schedule: Some(_)` when no schedules row exists returns `Err(sqlx::Error::RowNotFound)` (rolls back) — the handler pre-validated the kind, so this only fires on genuine corruption/races.
 
 - Consumes: `scoped_tx`, `SUBSCRIPTION_COLS`, `TriggerSubscriptionRow`, `ScheduleRow` (all existing).
 
-No DB-free test exists for these (DB tests need `DATABASE_URL` and are owner-triggered); correctness is carried by the SQL shape below + compile + the manual drill in Task 10. Follow the file's existing `scoped_tx`/`__rls_out` idiom exactly.
+No DB-free test exists for this (DB tests need `DATABASE_URL` and are owner-triggered); correctness is carried by the SQL shape below + compile + the drill in Task 10. Follow the file's existing `scoped_tx`/`__rls_out` idiom.
 
-- [ ] **Step 1: Implement `update_trigger_subscription`** (after `set_trigger_subscription_enabled`):
+- [ ] **Step 1: Implement** (after `set_trigger_subscription_enabled`):
 
 ```rust
-/// Full-row update of the PATCH-mutable surface. The handler resolves final
-/// values (current-or-requested) in Rust, so this sets every mutable column
-/// unconditionally; the callback trio is guarded by a touched flag. Any
-/// callback change (set OR clear) bumps authority_generation so
-/// subscription_secret bindings frozen on the old secret fail closed.
 pub async fn update_trigger_subscription(
     pool: &PgPool,
     scope: TenantScope,
     id: Uuid,
+    expect_updated_at: DateTime<Utc>,
     name: &str,
     task_template: Option<&str>,
     allow_task_override: bool,
     allow_workspace_override: bool,
     concurrency_policy: &str,
     callback: CallbackUpdate,
-) -> sqlx::Result<Option<TriggerSubscriptionRow>> {
+    schedule: Option<&ScheduleConfigUpdate>,
+) -> sqlx::Result<Option<(TriggerSubscriptionRow, Option<ScheduleRow>)>> {
+    // key_version 1 when bytes are NULL: the column CHECKs in (1,2) and the
+    // version is moot without bytes (Sealed::split's convention).
     let (cb_touched, cb_dests, cb_sealed, cb_kv): (bool, Value, Option<Vec<u8>>, i16) =
         match callback {
-            CallbackUpdate::Keep => (false, Value::Array(vec![]), None, 0),
-            CallbackUpdate::Clear => (true, Value::Array(vec![]), None, 0),
+            CallbackUpdate::Keep => (false, Value::Array(vec![]), None, 1),
+            CallbackUpdate::Clear => (true, Value::Array(vec![]), None, 1),
             CallbackUpdate::Set { destinations, sealed, key_version } => {
                 (true, destinations, Some(sealed), key_version)
             }
         };
     let mut tx = scoped_tx(pool, scope).await?;
 
-    let __rls_out = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+    let sub: Option<TriggerSubscriptionRow> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
         "update trigger_subscriptions set
            name = $2, task_template = $3, allow_task_override = $4,
            allow_workspace_override = $5, concurrency_policy = $6,
@@ -482,7 +580,7 @@ pub async fn update_trigger_subscription(
            authority_generation =
              authority_generation + case when $7 then 1 else 0 end,
            updated_at = now()
-         where id = $1 and tenant_id = $11
+         where id = $1 and tenant_id = $11 and updated_at = $12
          returning {SUBSCRIPTION_COLS}"
     )))
     .bind(id)
@@ -496,54 +594,48 @@ pub async fn update_trigger_subscription(
     .bind(cb_sealed)
     .bind(cb_kv)
     .bind(scope.tenant_id())
+    .bind(expect_updated_at)
     .fetch_optional(&mut *tx)
     .await?;
+    let Some(sub) = sub else {
+        // Stale expect_updated_at or vanished row: nothing written, tx drops.
+        return Ok(None);
+    };
+
+    let schedule_row = match schedule {
+        None => None,
+        Some(s) => Some(
+            sqlx::query_as::<_, ScheduleRow>(
+                "update schedules set cron = $2, timezone = $3,
+                   missed_run_policy = $4, next_fire_at = $5, updated_at = now()
+                 where subscription_id = $1
+                   and exists (select 1 from trigger_subscriptions sub
+                               where sub.id = $1 and sub.tenant_id = $6)
+                 returning *",
+            )
+            .bind(id)
+            .bind(&s.cron)
+            .bind(&s.timezone)
+            .bind(&s.missed_run_policy)
+            .bind(s.next_fire_at)
+            .bind(scope.tenant_id())
+            .fetch_optional(&mut *tx)
+            .await?
+            // A schedule-kind subscription without its schedules row is
+            // corruption; error → the WHOLE tx (incl. the subscription
+            // update above) rolls back.
+            .ok_or(sqlx::Error::RowNotFound)?,
+        ),
+    };
+
     tx.commit().await?;
-    Ok(__rls_out)
+    Ok(Some((sub, schedule_row)))
 }
 ```
 
-- [ ] **Step 2: Implement `update_schedule_config`** (after `create_schedule`):
+- [ ] **Step 2: Compile clean:** `cargo clippy -p fluidbox-db -- -D warnings`.
 
-```rust
-/// Reconfigure the clock on a schedule subscription. next_fire_at is the
-/// handler-computed first future firing of the NEW cron — the scheduler's
-/// tick worker picks it up unchanged.
-pub async fn update_schedule_config(
-    pool: &PgPool,
-    scope: TenantScope,
-    subscription: Uuid,
-    cron: &str,
-    timezone: &str,
-    missed_run_policy: &str,
-    next_fire_at: DateTime<Utc>,
-) -> sqlx::Result<Option<ScheduleRow>> {
-    let mut tx = scoped_tx(pool, scope).await?;
-
-    let __rls_out = sqlx::query_as(
-        "update schedules set cron = $2, timezone = $3, missed_run_policy = $4,
-           next_fire_at = $5, updated_at = now()
-         where subscription_id = $1
-           and exists (select 1 from trigger_subscriptions sub
-                       where sub.id = $1 and sub.tenant_id = $6)
-         returning *",
-    )
-    .bind(subscription)
-    .bind(cron)
-    .bind(timezone)
-    .bind(missed_run_policy)
-    .bind(next_fire_at)
-    .bind(scope.tenant_id())
-    .fetch_optional(&mut *tx)
-    .await?;
-    tx.commit().await?;
-    Ok(__rls_out)
-}
-```
-
-- [ ] **Step 3: Compile clean:** `cargo clippy -p fluidbox-db -- -D warnings` (expect a dead-code allowance not needed — `pub` items are exported).
-
-- [ ] **Step 4: Commit:** `git add crates/fluidbox-db/src/lib.rs && git commit -m "feat(db): update methods for trigger subscription + schedule config"`
+- [ ] **Step 3: Commit:** `git add crates/fluidbox-db/src/lib.rs && git commit -m "feat(db): atomic subscription+schedule update with stale guard"`
 
 ---
 
@@ -554,32 +646,55 @@ pub async fn update_schedule_config(
 - Modify: `crates/fluidbox-server/src/main.rs:533` (route)
 
 **Interfaces:**
-- Consumes: Task 2's `UpdateTrigger`/`resolve_update`, Task 3's `update_trigger_subscription`/`CallbackUpdate`/`update_schedule_config`, Task 1's `contract_urls`; existing `schedule_context`, `connectors::{connector_for, sample_context}`, `egress::admit_url`, `seal::{Sealed, SealCtx, SealFamily}`, `random_hex_token`, `SECRET_PREFIX`, `CronSchedule`, `MissedRunPolicy`.
-- Produces: `PATCH /v1/triggers/{id}` → `{ subscription, schedule, callback_secret, base_url, invoke_url, poll_url_template, ingress_url }` (callback_secret non-null ONLY when a new callback was set — shown once, like create).
+- Consumes: Task 1's `contract_urls`/`ingress_path_for`; Task 2's `UpdateTrigger`/`ScheduleUpdate`/`resolve_update`/`merge_schedule`; Task 3's `update_trigger_subscription`/`CallbackUpdate`/`ScheduleConfigUpdate`; existing `schedule_context`, `connectors::{connector_for, sample_context}`, `egress::admit_url`, `seal::{Sealed, SealCtx, SealFamily}`, `random_hex_token`, `SECRET_PREFIX`, `CronSchedule`, `MissedRunPolicy`, `schedule_for_subscription`.
+- Produces: `PATCH /v1/triggers/{id}` → `{ subscription, schedule, callback_secret, base_url, invoke_url, poll_url_template, ingress_url }`. `callback_secret` non-null ONLY when a new callback was set (shown once). Errors: 400 unknown/immutable field or validation, 404 unknown id, 409 concurrent edit (or name collision), 403 RBAC.
 
-- [ ] **Step 1: Implement the handler** (after `get`):
+- [ ] **Step 1: Implement the handler** (after `get`). Note the extractor: `Json<Value>` + `from_value`, NOT `Json<UpdateTrigger>` — axum's rejection for a deserialization failure is a 422 with its own body; the immutable-field refusal must be OUR 400 naming the field:
 
 ```rust
 /// PATCH — the mutable surface only: name, task_template, overrides,
 /// concurrency_policy, callback_url, and (schedule kind) the clock. Trigger
-/// kind and agent are deliberately absent: changing those is a new
-/// automation. In-flight runs keep their frozen RunSpec; future firings use
-/// the updated values — the platform's existing immutability model.
+/// kind and agent are immutable: UpdateTrigger is deny_unknown_fields, so a
+/// PATCH naming them (or anything else) is a 400, never a silent no-op.
+/// In-flight runs keep their frozen RunSpec; future firings use the updated
+/// values — the platform's existing immutability model.
 pub async fn update(
     principal: Principal,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
-    Json(req): Json<UpdateTrigger>,
+    Json(raw): Json<Value>,
 ) -> ApiResult<Json<Value>> {
     if !rbac::can_manage_subscriptions(&principal) {
         return Err(ApiError::Forbidden(
             "managing trigger subscriptions requires admin or owner".into(),
         ));
     }
+    let req: UpdateTrigger = serde_json::from_value(raw).map_err(|e| {
+        ApiError::BadRequest(format!(
+            "invalid PATCH body ({e}). Mutable fields: name, task_template, \
+             allow_task_override, allow_workspace_override, concurrency_policy, \
+             callback_url, schedule{{cron,timezone,missed_run_policy}}. \
+             Trigger kind and agent are immutable — create a new automation instead."
+        ))
+    })?;
     let scope = principal.scope();
     let current = fluidbox_db::get_trigger_subscription(&state.pool, scope, id)
         .await?
         .ok_or(ApiError::NotFound)?;
+    let existing_schedule =
+        fluidbox_db::schedule_for_subscription(&state.pool, scope, id).await?;
+
+    // An empty {} PATCH answers with current state, WITHOUT writing — the
+    // "as of" stamp must not advance for a no-op.
+    if req.is_empty() {
+        let ingress_path = ingress_path_for(&state, scope, &current).await?;
+        let mut body = serde_json::Map::new();
+        body.insert("subscription".into(), serde_json::to_value(&current)?);
+        body.insert("schedule".into(), serde_json::to_value(&existing_schedule)?);
+        body.insert("callback_secret".into(), Value::Null);
+        body.extend(contract_urls(&state.cfg.public_url, current.id, ingress_path.as_deref()));
+        return Ok(Json(Value::Object(body)));
+    }
 
     // The kind's no-caller render context, when it has one.
     let render_ctx = match current.trigger_kind.as_str() {
@@ -605,7 +720,7 @@ pub async fn update(
         resolve_update(&current, &req, render_ctx.as_ref()).map_err(ApiError::BadRequest)?;
 
     // Callback: same admission + sealing as create; any change bumps the
-    // subscription's authority generation.
+    // subscription's authority generation (Task 3 handles the bump).
     let (callback, secret_plain) = match req.callback_url.as_deref().map(str::trim) {
         None => (fluidbox_db::CallbackUpdate::Keep, None),
         Some("") => (fluidbox_db::CallbackUpdate::Clear, None),
@@ -635,20 +750,25 @@ pub async fn update(
                 url: url.to_string(),
                 binding_id: None,
             }])?;
-            let (cb_bytes, cb_kv) = crate::seal::Sealed::split(&Some(sealed));
+            // Destructure the owned Sealed — do NOT call Sealed::split on a
+            // temporary Option (it returns a borrow of the temporary and
+            // does not compile).
+            let crate::seal::Sealed { bytes, key_version } = sealed;
             (
                 fluidbox_db::CallbackUpdate::Set {
                     destinations: dests,
-                    sealed: cb_bytes.expect("just sealed").to_vec(),
-                    key_version: cb_kv,
+                    sealed: bytes,
+                    key_version,
                 },
                 Some(secret),
             )
         }
     };
 
-    // Schedule reconfiguration is only meaningful on a schedule subscription.
-    let schedule_update = match &req.schedule {
+    // Schedule: only meaningful on a schedule subscription; PARTIAL — omitted
+    // fields keep the existing row's values (a cron-only PATCH must not
+    // reset America/Chicago to UTC).
+    let schedule_cfg = match &req.schedule {
         None => None,
         Some(s) => {
             if current.trigger_kind != "schedule" {
@@ -656,10 +776,12 @@ pub async fn update(
                     "only schedule subscriptions carry a schedule".into(),
                 ));
             }
-            let tz = s.timezone.as_deref().unwrap_or("UTC");
-            let cron = CronSchedule::parse(&s.cron, tz).map_err(ApiError::BadRequest)?;
-            let missed = s.missed_run_policy.as_deref().unwrap_or("skip");
-            if MissedRunPolicy::parse(missed).is_none() {
+            let row = existing_schedule.as_ref().ok_or_else(|| {
+                ApiError::Internal("schedule subscription has no schedule row".into())
+            })?;
+            let (cron_expr, tz, missed) = merge_schedule(row, s);
+            let cron = CronSchedule::parse(&cron_expr, &tz).map_err(ApiError::BadRequest)?;
+            if MissedRunPolicy::parse(&missed).is_none() {
                 return Err(ApiError::BadRequest(
                     "missed_run_policy must be skip | catch_up".into(),
                 ));
@@ -667,20 +789,27 @@ pub async fn update(
             let first = cron.next_fire_after(chrono::Utc::now()).ok_or_else(|| {
                 ApiError::BadRequest("cron expression never fires in the future".into())
             })?;
-            Some((s.cron.trim().to_string(), tz.to_string(), missed.to_string(), first))
+            Some(fluidbox_db::ScheduleConfigUpdate {
+                cron: cron_expr,
+                timezone: tz,
+                missed_run_policy: missed,
+                next_fire_at: first,
+            })
         }
     };
 
-    let sub = fluidbox_db::update_trigger_subscription(
+    let updated = fluidbox_db::update_trigger_subscription(
         &state.pool,
         scope,
         id,
+        current.updated_at,
         &resolved.name,
         resolved.task_template.as_deref(),
         resolved.allow_task_override,
         resolved.allow_workspace_override,
         &resolved.concurrency_policy,
         callback,
+        schedule_cfg.as_ref(),
     )
     .await
     .map_err(|e| match &e {
@@ -689,35 +818,39 @@ pub async fn update(
             resolved.name
         )),
         _ => ApiError::Db(e),
-    })?
-    .ok_or(ApiError::NotFound)?;
-
-    let schedule = match schedule_update {
-        Some((cron, tz, missed, first)) => {
-            fluidbox_db::update_schedule_config(&state.pool, scope, id, &cron, &tz, &missed, first)
-                .await?
-        }
-        None => fluidbox_db::schedule_for_subscription(&state.pool, scope, id).await?,
+    })?;
+    let Some((sub, updated_schedule)) = updated else {
+        // The stale-guard fired: someone else edited between our read and
+        // write. Nothing was written; the one-time secret (if minted) was
+        // never stored and dies here with this error.
+        return Err(ApiError::Conflict(
+            "the automation changed since it was loaded — reload and retry".into(),
+        ));
     };
 
+    let schedule = match updated_schedule {
+        Some(row) => Some(row),
+        None => fluidbox_db::schedule_for_subscription(&state.pool, scope, id).await?,
+    };
+    let ingress_path = ingress_path_for(&state, scope, &sub).await?;
     let mut body = serde_json::Map::new();
     body.insert("subscription".into(), serde_json::to_value(&sub)?);
     body.insert("schedule".into(), serde_json::to_value(&schedule)?);
     body.insert("callback_secret".into(), json!(secret_plain));
-    body.extend(contract_urls(&state.cfg.public_url, sub.id, None));
+    body.extend(contract_urls(&state.cfg.public_url, sub.id, ingress_path.as_deref()));
     Ok(Json(Value::Object(body)))
 }
 ```
 
-**Seal-split note:** the `Sealed::split(&Some(sealed))` call mirrors create's handling at triggers.rs:614 (`let (cb_bytes, cb_kv) = crate::seal::Sealed::split(&secret_sealed);`). Check `Sealed::split`'s exact return types at crates/fluidbox-server/src/seal.rs before wiring — if it returns `(Option<&[u8]>, i16)` the `.to_vec()` above is right; adjust mechanically if the shapes differ. Also note the `update_trigger_subscription` call passes `callback` by VALUE (owned enum), not `.as_ref()`.
+(If `Sealed`'s fields aren't `pub`, check crates/fluidbox-server/src/seal.rs:139 — they are (`pub bytes`, `pub key_version`).)
 
-- [ ] **Step 2: Register the route.** In `main.rs:533` change:
+- [ ] **Step 2: Register the route.** In `main.rs:533`:
 
 ```rust
         .route("/triggers/{id}", get(triggers::get).patch(triggers::update))
 ```
 
-and add `patch` to the `axum::routing` import at the top of `main.rs` if absent.
+adding `patch` to the `axum::routing` import if absent.
 
 - [ ] **Step 3: Remove any temporary `#[allow(dead_code)]` from Task 2.**
 
@@ -740,10 +873,14 @@ and add `patch` to the `axum::routing` import at the top of `main.rs` if absent.
 ```ts
 export const SYSTEM_VARIABLES: Record<string, string[]>;
 export function templateVariables(template: string | null): string[];
-export function classifyVariables(kind: string, template: string | null): { caller: string[]; system: string[] };
+/** invalid: placeholders a no-caller kind (schedule/event) declares that the
+ *  platform does NOT fill — save will refuse them; surfaced as errors. */
+export function classifyVariables(kind: string, template: string | null): { caller: string[]; system: string[]; invalid: string[] };
 export function contextExample(caller: string[]): string;
-/** token null → the $FLUIDBOX_TRIGGER_TOKEN placeholder (durable/revisit view). */
-export function buildCurl(opts: { invokeUrl: string; token: string | null; caller: string[] }): string;
+/** token null → $FLUIDBOX_TRIGGER_TOKEN in DOUBLE quotes (shell-expandable).
+ *  hasTemplate false → the body carries "task" (a template-less automation
+ *  requires the caller to send one; {} would 400 at invoke). */
+export function buildCurl(opts: { invokeUrl: string; token: string | null; caller: string[]; hasTemplate: boolean }): string;
 ```
 
 - [ ] **Step 1: Write the failing tests** (`automation-contract.test.ts`):
@@ -754,6 +891,7 @@ import {
   buildCurl,
   classifyVariables,
   contextExample,
+  SYSTEM_VARIABLES,
   templateVariables,
 } from "./automation-contract";
 
@@ -768,29 +906,44 @@ describe("templateVariables", () => {
 });
 
 describe("classifyVariables", () => {
-  it("splits caller vs system by trigger kind", () => {
-    const { caller, system } = classifyVariables(
-      "schedule",
-      "sweep {{fire_time}} for {{team}}"
-    );
-    expect(system).toEqual(["fire_time"]);
-    expect(caller).toEqual(["team"]);
+  it("api kind: everything is caller-supplied, nothing invalid", () => {
+    const r = classifyVariables("api", "do {{ticket}}");
+    expect(r).toEqual({ caller: ["ticket"], system: [], invalid: [] });
   });
-  it("api kind has no system variables", () => {
-    expect(classifyVariables("api", "do {{ticket}}").caller).toEqual(["ticket"]);
-    expect(classifyVariables("api", "do {{ticket}}").system).toEqual([]);
+  it("schedule kind: fire_time is system, anything else is invalid (no caller exists)", () => {
+    const r = classifyVariables("schedule", "sweep {{fire_time}} for {{team}}");
+    expect(r.system).toEqual(["fire_time"]);
+    expect(r.caller).toEqual([]);
+    expect(r.invalid).toEqual(["team"]);
+  });
+  it("event kind knows the full GitHub context, not just three names", () => {
+    // Mirrors connectors/github.rs sample_context() — 12 variables.
+    expect(SYSTEM_VARIABLES.event).toEqual([
+      "repository", "pr_number", "pr_title", "pr_url", "pr_author",
+      "head_sha", "head_ref", "base_sha", "base_ref", "action", "event", "fork",
+    ]);
+    const r = classifyVariables("event", "review {{pr_url}} by {{pr_author}} ({{oops}})");
+    expect(r.system).toEqual(["pr_url", "pr_author"]);
+    expect(r.invalid).toEqual(["oops"]);
   });
 });
 
 describe("buildCurl", () => {
-  it("uses the real token when given and a shell placeholder when not", () => {
-    const url = "https://fb.example/v1/triggers/x/invoke";
-    expect(buildCurl({ invokeUrl: url, token: "fbx_trig_abc", caller: [] })).toContain(
-      "Bearer fbx_trig_abc"
-    );
-    const durable = buildCurl({ invokeUrl: url, token: null, caller: ["ticket"] });
-    expect(durable).toContain("Bearer $FLUIDBOX_TRIGGER_TOKEN");
+  const url = "https://fb.example/v1/triggers/x/invoke";
+  it("real token rides in single quotes", () => {
+    expect(
+      buildCurl({ invokeUrl: url, token: "fbx_trig_abc", caller: [], hasTemplate: true })
+    ).toContain("-H 'Authorization: Bearer fbx_trig_abc'");
+  });
+  it("durable form uses DOUBLE quotes so the shell expands the variable", () => {
+    const durable = buildCurl({ invokeUrl: url, token: null, caller: ["ticket"], hasTemplate: true });
+    expect(durable).toContain('-H "Authorization: Bearer ${FLUIDBOX_TRIGGER_TOKEN}"');
     expect(durable).toContain('"ticket": "…"');
+  });
+  it("template-less automation sends a task, not {} (invoke would 400)", () => {
+    const c = buildCurl({ invokeUrl: url, token: null, caller: [], hasTemplate: false });
+    expect(c).toContain('"task"');
+    expect(c).not.toContain("-d '{}'");
   });
 });
 
@@ -804,7 +957,7 @@ describe("contextExample", () => {
 
 - [ ] **Step 2: Run — fail:** `cd apps/web && pnpm vitest run app/lib/automation-contract.test.ts` → module not found.
 
-- [ ] **Step 3: Implement the lib** (move the two definitions out of RunComposer verbatim, then add the two builders):
+- [ ] **Step 3: Implement the lib:**
 
 ```ts
 /** Pure integration-contract helpers shared by the composer preview, the
@@ -812,11 +965,16 @@ describe("contextExample", () => {
  *  them here (tested, presentation-free) is what lets three surfaces render
  *  the SAME contract without drifting. */
 
-/** Placeholders the platform fills in itself, per trigger kind. Anything else
- *  in the template is the caller's to supply in `context`. */
+/** Placeholders the platform fills in itself, per trigger kind. Anything
+ *  else is the caller's (api kind) or refused at save (schedule/event fire
+ *  with no caller). The event list mirrors connectors/github.rs
+ *  sample_context() — keep them in lockstep. */
 export const SYSTEM_VARIABLES: Record<string, string[]> = {
   schedule: ["fire_time"],
-  event: ["repository", "pr_number", "pr_title"],
+  event: [
+    "repository", "pr_number", "pr_title", "pr_url", "pr_author",
+    "head_sha", "head_ref", "base_sha", "base_ref", "action", "event", "fork",
+  ],
   api: [],
 };
 
@@ -832,12 +990,19 @@ export function templateVariables(template: string | null): string[] {
 export function classifyVariables(
   kind: string,
   template: string | null
-): { caller: string[]; system: string[] } {
+): { caller: string[]; system: string[]; invalid: string[] } {
   const systemNames = SYSTEM_VARIABLES[kind] ?? [];
   const declared = templateVariables(template);
+  const system = declared.filter((name) => systemNames.includes(name));
+  const rest = declared.filter((name) => !systemNames.includes(name));
+  // schedule/event fire with no caller: an unknown placeholder can never be
+  // filled and the server refuses it at save — that's an error, not a
+  // caller variable.
+  const noCaller = kind === "schedule" || kind === "event";
   return {
-    caller: declared.filter((name) => !systemNames.includes(name)),
-    system: declared.filter((name) => systemNames.includes(name)),
+    system,
+    caller: noCaller ? [] : rest,
+    invalid: noCaller ? rest : [],
   };
 }
 
@@ -846,19 +1011,28 @@ export function contextExample(caller: string[]): string {
   return `{"context": {${caller.map((name) => `"${name}": "…"`).join(", ")}}}`;
 }
 
-/** token null → the durable view: the secret is the caller's to hold, so the
- *  curl carries a shell variable instead of pretending we can re-show it. */
+/** token null → the durable view: the secret is the caller's to hold, so
+ *  the curl reads it from the environment — double quotes, or the shell
+ *  ships the literal dollar text. hasTemplate false → the automation has no
+ *  stored template (override-only), so invoke REQUIRES a task in the body. */
 export function buildCurl(opts: {
   invokeUrl: string;
   token: string | null;
   caller: string[];
+  hasTemplate: boolean;
 }): string {
+  const auth = opts.token
+    ? `  -H 'Authorization: Bearer ${opts.token}' \\`
+    : `  -H "Authorization: Bearer \${FLUIDBOX_TRIGGER_TOKEN}" \\`;
+  const body = opts.hasTemplate
+    ? contextExample(opts.caller)
+    : `{"task": "…what this invocation should do…"}`;
   return [
     `curl -X POST '${opts.invokeUrl}' \\`,
-    `  -H 'Authorization: Bearer ${opts.token ?? "$FLUIDBOX_TRIGGER_TOKEN"}' \\`,
+    auth,
     `  -H 'Content-Type: application/json' \\`,
     `  -H 'Idempotency-Key: <your-unique-key>' \\`,
-    `  -d '${contextExample(opts.caller)}'`,
+    `  -d '${body}'`,
   ].join("\n");
 }
 ```
@@ -868,22 +1042,27 @@ export function buildCurl(opts: {
 ```ts
   const { caller: callerVars, system: systemVars } = classifyVariables(kind, sub.task_template);
   const declared = [...callerVars, ...systemVars];
-  const curl = buildCurl({ invokeUrl, token: minted.token, caller: callerVars });
+  const curl = buildCurl({
+    invokeUrl,
+    token: minted.token,
+    caller: callerVars,
+    hasTemplate: !!sub.task_template,
+  });
 ```
 
-adding the import `import { buildCurl, classifyVariables } from "../lib/automation-contract";`.
+adding the import `import { buildCurl, classifyVariables } from "../lib/automation-contract";`. (This JSX moves again in Task 6 — the point here is that the lib compiles in place of the deleted locals.)
 
-- [ ] **Step 5: Verify:** `pnpm vitest run` (all web tests) and `pnpm build` → green.
+- [ ] **Step 5: Verify:** `pnpm vitest run` and `pnpm build` → green.
 
 - [ ] **Step 6: Commit:** `git add apps/web/app/lib/automation-contract.* apps/web/app/components/RunComposer.tsx && git commit -m "feat(web): extract pure automation-contract helpers"`
 
 ---
 
-### Task 6: Web — shared `AutomationContract` component; trim the secrets modal
+### Task 6: Web — shared `AutomationContract` component; secrets modal becomes secrets-ONLY
 
 **Files:**
 - Create: `apps/web/app/components/AutomationContract.tsx`
-- Modify: `apps/web/app/components/RunComposer.tsx` (`CopyBlock` at 1724-1747 moves out; `ShowAutomationSecrets` at 1749-1926 shrinks)
+- Modify: `apps/web/app/components/RunComposer.tsx` (`CopyBlock` at 1724-1747 moves out; `ShowAutomationSecrets` at 1749-1926 shrinks to secrets + link)
 - Modify: `apps/web/app/globals.css` (one new class)
 
 **Interfaces:**
@@ -896,134 +1075,90 @@ export function AutomationContract({
   invokeUrl,      // string
   pollUrl,        // string
   ingressUrl,     // string | null
-  token,          // string | null — null renders $FLUIDBOX_TRIGGER_TOKEN
+  token,          // string | null — null renders the ${FLUIDBOX_TRIGGER_TOKEN} form
   updatedAt,      // string | null — renders the "as of" stamp when given
 }: {...});
+export function TemplateChips({ kind, template }: { kind: string; template: string });
 ```
 
 - Consumes: Task 5's lib; `TriggerSubscription` from `../lib/api`.
 
-- [ ] **Step 1: Create `AutomationContract.tsx`.** Move `CopyBlock` verbatim from RunComposer (1724-1747). Then move the Endpoint / Variables / Request / Responses / Result-delivery sections of `ShowAutomationSecrets` (lines 1822-1916 minus the secrets section) into:
+- [ ] **Step 1: Create `AutomationContract.tsx`.** Move `CopyBlock` verbatim from RunComposer (1724-1747). Build `AutomationContract` from the Endpoint / Variables / Request / Responses / Result-delivery JSX currently in `ShowAutomationSecrets` (lines 1822-1916), with these changes — the shipped file contains the real JSX, adapted, not references to it:
+  - `sub` → `subscription`; `minted.ingress_url` → `ingressUrl`; the curl comes from `buildCurl({ invokeUrl, token, caller: callerVars, hasTemplate: !!subscription.task_template })`.
+  - **Kind-aware sections:** `api` kind renders Endpoint (Invoke + Poll CopyBlocks) + Request (curl). `event` kind renders the Webhook-ingress CopyBlock (when `ingressUrl`) + a note ("Runs start from repository events — there is no API caller to authenticate."). `schedule` kind renders a note ("Runs start on the clock — there is no API caller.") — no invoke curl for either no-caller kind. Variables + Responses + Result-delivery render for all kinds.
+  - The Variables section renders `invalid` names (from `classifyVariables`) with an error style and the caption "not available — save refuses this placeholder"; `caller` names say "you supply it in `context`"; `system` names say "filled in by fluidbox".
+  - **Responses:** the success example becomes `<CopyBlock label="Success" value={responseExample} />`. The error rows become: `409` — "a run is already active and this automation is set to `{subscription.concurrency_policy}`"; `422` — "the Idempotency-Key was already used with a different request body" (the modal's old text claimed 409 for this — the server returns 422, triggers.rs:975); `400` — "an override this subscription does not allow"; `401` — "wrong token, or the token was revoked".
+  - Result-delivery section renders when the subscription HAS a signed-webhook destination: `subscription.result_destinations.some((d) => d.kind === "signed_webhook")` — verify the discriminant with `grep -n "signed_webhook" apps/web/app/lib/api.ts crates/fluidbox-core/src/spec.rs` and match whatever serde emits.
+  - Bottom: `{updatedAt && <p className="contract-stamp">Reflects the configuration as of {new Date(updatedAt).toLocaleString()}.</p>}`
+  - Add `TemplateChips` (also consumed by Tasks 8 & 9):
 
 ```tsx
-"use client";
-
-import { useState } from "react";
-import { TriggerSubscription } from "../lib/api";
-import { buildCurl, classifyVariables } from "../lib/automation-contract";
-
-/* CopyBlock: moved verbatim from RunComposer.tsx */
-
-/** The durable integration contract, rendered live from the current
- *  subscription. Everything here is always recoverable; only the token is
- *  one-time (token=null renders the honest $FLUIDBOX_TRIGGER_TOKEN form). */
-export function AutomationContract({
-  subscription,
-  invokeUrl,
-  pollUrl,
-  ingressUrl,
-  token,
-  updatedAt,
-}: {
-  subscription: TriggerSubscription;
-  invokeUrl: string;
-  pollUrl: string;
-  ingressUrl: string | null;
-  token: string | null;
-  updatedAt: string | null;
-}) {
-  const kind = subscription.trigger_kind;
-  const { caller: callerVars, system: systemVars } = classifyVariables(
-    kind,
-    subscription.task_template
-  );
-  const declared = [...callerVars, ...systemVars];
-  const curl = buildCurl({ invokeUrl, token, caller: callerVars });
-  const hasCallback = subscription.result_destinations.some(
-    (destination) => destination.kind === "signed_webhook"
-  );
-  const responseExample = [
-    "200 OK",
-    JSON.stringify(
-      {
-        session_id: "019f…",
-        status: "queued",
-        replay: false,
-        poll_url: `/v1/triggers/${subscription.id}/runs/{session_id}`,
-      },
-      null,
-      2
-    ),
-  ].join("\n");
-
+/** Live placeholder read-back under a template textarea: which {{names}}
+ *  the caller supplies, which the platform fills, and which a no-caller
+ *  kind can never fill (save will refuse those). */
+export function TemplateChips({ kind, template }: { kind: string; template: string }) {
+  const { caller, system, invalid } = classifyVariables(kind, template || null);
+  if (caller.length === 0 && system.length === 0 && invalid.length === 0) return null;
   return (
-    <div className="contract">
-      {/* Endpoint / Variables / Request / Responses / Result delivery
-          sections: EXACTLY the JSX from ShowAutomationSecrets lines
-          1822-1916, with these substitutions:
-            minted.ingress_url  -> ingressUrl
-            sub                 -> subscription
-            the curl const      -> curl (above)
-            minted.callback_secret && (Result delivery ...) -> hasCallback && (...)
-          and WITHOUT the CopyBlock for the callback signing secret value
-          (that block stays in the secrets modal; the signature-format
-          CopyBlock here is fine — it contains no secret). */}
-      {updatedAt && (
-        <p className="contract-stamp">
-          Reflects the configuration as of {new Date(updatedAt).toLocaleString()}.
-        </p>
-      )}
+    <div className="tpl-chips">
+      {caller.map((name) => (
+        <span key={name} className="tpl-chip caller" title="Caller supplies this in `context`">
+          {`{{${name}}}`} · caller
+        </span>
+      ))}
+      {system.map((name) => (
+        <span key={name} className="tpl-chip system" title="Filled in by fluidbox">
+          {`{{${name}}}`} · fluidbox
+        </span>
+      ))}
+      {invalid.map((name) => (
+        <span key={name} className="tpl-chip invalid" title="This trigger has no caller and fluidbox does not fill this name — saving will be refused">
+          {`{{${name}}}`} · unknown
+        </span>
+      ))}
     </div>
   );
 }
 ```
 
-The comment block above is an instruction to YOU, the implementer — the shipped file must contain the real JSX moved from RunComposer, not the comment. `ResultDestination`-shaped objects in `result_destinations` use `kind: "signed_webhook"` — verify the exact discriminant with `grep -n "signed_webhook" apps/web/app/lib/api.ts crates/fluidbox-core/src/spec.rs` and match it.
-
-- [ ] **Step 2: Shrink `ShowAutomationSecrets`.** It keeps: the ModalShell chrome (title/sub/dirty/discard copy, lines 1795-1804), the **Secrets** section (1806-1820), and gains a pointer + compact contract. Replace everything from line 1822 (`<section className="contract-section"><h4>Endpoint</h4>`) through 1916 with:
+- [ ] **Step 2: Shrink `ShowAutomationSecrets` to secrets-only.** Per spec: the modal keeps the ModalShell chrome (title/sub/dirty/discard copy, lines 1795-1804), the **Secrets** section (1806-1820), and the footer. DELETE the Endpoint/Variables/Request/Responses/Result-delivery sections (1822-1916) — they do NOT reappear here via `AutomationContract`; the durable page is their home. In their place, one pointer block:
 
 ```tsx
-        <AutomationContract
-          subscription={sub}
-          invokeUrl={invokeUrl}
-          pollUrl={pollUrl}
-          ingressUrl={minted.ingress_url ?? null}
-          token={minted.token}
-          updatedAt={null}
-        />
-        <p className="contract-note">
-          Everything except the secrets above is always available at{" "}
-          <Link className="link" href={`/automations/${sub.id}`}>
-            Automations → {sub.name} → API
-          </Link>
-          . Lost token? Rotate it there.
-        </p>
+        <section className="contract-section">
+          <h4>Where everything else lives</h4>
+          <p className="contract-note">
+            The endpoint, request shape, variables, and response contract are always
+            available at{" "}
+            <Link className="link" href={`/automations/${sub.id}`} onClick={onClose}>
+              Automations → {sub.name} → API
+            </Link>
+            {" "}— only the secrets above are shown once. Lost token? Rotate it there.
+          </p>
+        </section>
 ```
 
-(`Link` is already imported in RunComposer. The `curl`/`responseExample`/variable derivations local to `ShowAutomationSecrets` are now dead — delete them. `pollUrl` stays as computed at line 1761.)
+The now-dead locals (`curl`, `responseExample`, `declared`/`callerVars`/`systemVars`, `contextExample` remnants, `invokeUrl`/`pollUrl` if unused) get deleted; keep whichever the remaining JSX still needs. Update the modal `sub=` copy (line 1798) to: "The token and signing secret exist only in this response — they are stored hashed and sealed and can never be shown again. Everything else stays available on the automation's page."
 
-- [ ] **Step 3: CSS** — append to `apps/web/app/globals.css` next to the existing `.contract-*` rules (grep `contract-note` to find them):
+- [ ] **Step 3: CSS** — append next to the existing `.contract-*` rules (grep `contract-note` in `apps/web/app/globals.css`), reusing whatever muted-text/border variables `.field-hint` and existing badges use:
 
 ```css
-.contract-stamp {
-  font-size: 12px;
-  color: var(--muted, #888);
-  margin: 4px 0 0;
-}
+.contract-stamp { font-size: 12px; color: var(--muted); margin: 4px 0 0; }
+.tpl-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.tpl-chip { font-family: var(--mono, monospace); font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); }
+.tpl-chip.system { opacity: 0.7; }
+.tpl-chip.invalid { border-color: var(--err, #b3423f); color: var(--err, #b3423f); }
 ```
 
-(If the file uses different token names for muted text, copy whatever `.field-hint` uses.)
+- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` → green.
 
-- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` → green. Open nothing yet — the detail page arrives next task.
-
-- [ ] **Step 5: Commit:** `git add apps/web && git commit -m "feat(web): shared AutomationContract; secrets modal shows secrets + pointer"`
+- [ ] **Step 5: Commit:** `git add apps/web && git commit -m "feat(web): shared AutomationContract; secrets modal is secrets-only"`
 
 ---
 
 ### Task 7: Web — types + `/automations/[id]` read-only detail page
 
 **Files:**
-- Modify: `apps/web/app/lib/api.ts` (TriggerSubscription at line 684: add `updated_at: string;` after `created_at`; add the detail-response type below)
+- Modify: `apps/web/app/lib/api.ts` (TriggerSubscription at line 684: add `updated_at: string;` after `created_at`; add `TriggerDetail`)
 - Modify: `apps/web/app/components/AutomationPanel.tsx` (export `AutomationActivity`; title links)
 - Create: `apps/web/app/automations/[id]/page.tsx`
 - Modify: `apps/web/app/globals.css`
@@ -1047,11 +1182,11 @@ export interface TriggerDetail {
 }
 ```
 
-- Consumes: Task 6's `AutomationContract`, existing `ShowAutomationSecrets` + rotate endpoint, `AutomationActivity` (change `function AutomationActivity` to `export function AutomationActivity` in AutomationPanel.tsx:253).
+- Consumes: Task 6's `AutomationContract`, existing `ShowAutomationSecrets` + rotate endpoint, `AutomationActivity` (change `function AutomationActivity` to `export function AutomationActivity` at AutomationPanel.tsx:253), `apiGetCached` for the agent name.
 
-- [ ] **Step 1: api.ts** — add `updated_at` to `TriggerSubscription` and the `TriggerDetail` interface above. `Session`, `ResultDelivery`, `TriggerInvocation`, `Schedule` already exist in the file.
+- [ ] **Step 1: api.ts** — add `updated_at` to `TriggerSubscription` and the `TriggerDetail` interface. `Session`, `ResultDelivery`, `TriggerInvocation`, `Schedule` already exist in the file.
 
-- [ ] **Step 2: Export `AutomationActivity`** (AutomationPanel.tsx:253) and link each row title to the page — in `AutomationRow` (line 215) wrap the name:
+- [ ] **Step 2: Export `AutomationActivity`** (AutomationPanel.tsx:253) and link each row to the page — in `AutomationRow` (line 215) wrap the name:
 
 ```tsx
             <Link className="link" href={`/automations/${subscription.id}`}>
@@ -1059,7 +1194,7 @@ export interface TriggerDetail {
             </Link>
 ```
 
-(`Link` is already imported at line 4.) Add an "Open →" link beside the "Activity" button:
+and add an "Open →" link beside the "Activity" button:
 
 ```tsx
           <Link className="btn ghost sm" href={`/automations/${subscription.id}`}>
@@ -1067,30 +1202,47 @@ export interface TriggerDetail {
           </Link>
 ```
 
-- [ ] **Step 3: Note the routing collision and resolve it.** `apps/web/app/automations/page.tsx` redirects `/automations` → `/?view=automations`; a `[id]` sibling does not conflict. Create `apps/web/app/automations/[id]/page.tsx`:
+(`Link` is already imported at line 4.)
+
+- [ ] **Step 3: Create `apps/web/app/automations/[id]/page.tsx`.** (`apps/web/app/automations/page.tsx` redirects `/automations` → `/?view=automations`; a `[id]` sibling does not conflict.) Conventions this page MUST follow — both flagged by review against the codebase: `Shell` already wraps pages in `<main>` (Shell.tsx:33), so the page root is a `<div>`; and a refresh failure keeps the last good snapshot (the pattern at page.tsx:44) instead of blanking a loaded page:
 
 ```tsx
 "use client";
 
 import { use, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { apiGet, apiPost, TriggerDetail, TriggerSubscription } from "../../lib/api";
+import {
+  Agent,
+  apiGet,
+  apiGetCached,
+  apiPost,
+  TriggerDetail,
+  TriggerSubscription,
+} from "../../lib/api";
 import { AutomationContract } from "../../components/AutomationContract";
+import { AutomationActivity } from "../../components/AutomationPanel";
 import { MintedAutomation, ShowAutomationSecrets } from "../../components/RunComposer";
 import { LoadingRows } from "../../components/bits";
 
 export default function AutomationDetail({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const [detail, setDetail] = useState<TriggerDetail | null>(null);
+  const [agents, setAgents] = useState<Agent[]>([]);
   const [loadErr, setLoadErr] = useState("");
   const [actionErr, setActionErr] = useState("");
   const [minted, setMinted] = useState<MintedAutomation | null>(null);
 
   const load = useCallback(async () => {
     try {
-      setDetail(await apiGet<TriggerDetail>(`/triggers/${id}`));
+      const [detailResponse, agentResponse] = await Promise.all([
+        apiGet<TriggerDetail>(`/triggers/${id}`),
+        apiGetCached<{ agents: Agent[] }>("/agents", { maxAgeMs: 15_000 }),
+      ]);
+      setDetail(detailResponse);
+      setAgents(agentResponse.agents);
       setLoadErr("");
     } catch (error) {
+      // Keep the last good snapshot; surface the failure without blanking.
       setLoadErr(String(error));
     }
   }, [id]);
@@ -1116,6 +1268,7 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
         base_url: string | null;
         invoke_url: string | null;
         poll_url_template: string | null;
+        ingress_url?: string | null;
       }>(`/triggers/${id}/rotate_token`, {});
       setMinted({
         subscription,
@@ -1125,41 +1278,48 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
         base_url: response.base_url,
         invoke_url: response.invoke_url,
         poll_url_template: response.poll_url_template,
+        ingress_url: response.ingress_url ?? null,
       });
     } catch (error) {
       setActionErr(String(error));
     }
   };
 
-  if (loadErr) {
-    return (
-      <main className="page automation-detail">
-        <div className="err">{loadErr}</div>
-      </main>
-    );
-  }
   if (!detail) {
     return (
-      <main className="page automation-detail">
-        <LoadingRows />
-      </main>
+      <div className="automation-detail">
+        {loadErr ? <div className="err">{loadErr}</div> : <LoadingRows />}
+      </div>
     );
   }
   const sub = detail.subscription;
+  const agentName = agents.find((agent) => agent.id === sub.agent_id)?.name ?? null;
   return (
-    <main className="page automation-detail">
+    <div className="automation-detail">
       <header className="automation-detail-head">
         <div>
-          <span className="section-kicker">
-            {sub.trigger_kind === "api"
-              ? "API-invoked automation"
-              : sub.trigger_kind === "schedule"
-                ? "Scheduled automation"
-                : "Event automation"}
-          </span>
-          <h1>{sub.name}</h1>
+          <div className="automation-title-line">
+            <span className="automation-kind">
+              {sub.trigger_kind === "schedule" ? "Schedule" : sub.trigger_kind === "event" ? "Event" : "API"}
+            </span>
+            <h1>{sub.name}</h1>
+            <span className={`badge ${sub.enabled ? "ok" : ""}`}>
+              {sub.enabled ? "enabled" : "disabled"}
+            </span>
+          </div>
           <p className="automation-intro">
-            Saved run configuration — every firing creates a normal governed run.{" "}
+            Runs{" "}
+            {agentName ? (
+              <Link className="link" href="/agents">
+                <b>{agentName}</b>
+              </Link>
+            ) : (
+              <span className="mono">{sub.agent_id.slice(0, 8)}</span>
+            )}
+            {detail.schedule?.next_fire_at && (
+              <> · next run {new Date(detail.schedule.next_fire_at).toLocaleString()}</>
+            )}
+            {" · "}
             <Link className="link" href="/?view=automations">
               All automations
             </Link>
@@ -1174,6 +1334,7 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
           </button>
         </div>
       </header>
+      {loadErr && <div className="note">Refresh failed — showing the last loaded state. {loadErr}</div>}
       {actionErr && <div className="err">{actionErr}</div>}
 
       <section className="automation-detail-section">
@@ -1192,7 +1353,7 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
 
       <section className="automation-detail-section">
         <h2>Activity</h2>
-        <AutomationActivityBlock id={sub.id} />
+        <AutomationActivity id={sub.id} />
       </section>
       {minted && (
         <ShowAutomationSecrets
@@ -1203,35 +1364,24 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
           }}
         />
       )}
-    </main>
+    </div>
   );
 }
 ```
 
-with, at the bottom of the file:
+If `MintedAutomation` lacks an `ingress_url` field, it already has one (RunComposer.tsx:110) — pass it through. If `/agents` is not the agents route, grep `href="/agents"` in Sidebar.tsx and use whatever it uses.
 
-```tsx
-import { AutomationActivity } from "../../components/AutomationPanel";
-
-function AutomationActivityBlock({ id }: { id: string }) {
-  return <AutomationActivity id={id} />;
-}
-```
-
-(Or import `AutomationActivity` directly in the header import block and use it inline — implementer's choice; keep imports at the top per lint.)
-
-- [ ] **Step 4: CSS** — append (near `.automation-panel` rules):
+- [ ] **Step 4: CSS** — append near the `.automation-panel` rules:
 
 ```css
 .automation-detail { max-width: 880px; margin: 0 auto; padding: 24px 16px 64px; }
 .automation-detail-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 8px; }
+.automation-detail-head h1 { font-size: 20px; margin: 0; }
 .automation-detail-section { margin-top: 28px; }
 .automation-detail-section > h2 { font-size: 15px; margin: 0 0 10px; }
 ```
 
-Match the `main className` conventions of `apps/web/app/sessions/[id]/page.tsx` — if that page uses a different wrapper class than `page`, copy it.
-
-- [ ] **Step 5: Verify:** `pnpm build` green. Then the first manual checkpoint (needs `just dev` running — ask the owner if it isn't): create an API automation, close the secrets modal, click into `/automations/{id}`, confirm the contract renders with `$FLUIDBOX_TRIGGER_TOKEN`, copy works, Rotate shows the one-time modal.
+- [ ] **Step 5: Verify:** `pnpm build` green. First manual checkpoint (needs the dev stack — coordinate with the owner): create an API automation, close the secrets modal, open `/automations/{id}`, confirm the contract renders the `${FLUIDBOX_TRIGGER_TOKEN}` curl, copy works, Rotate shows the one-time modal, and a schedule automation shows NO invoke curl but does show variables + next-fire.
 
 - [ ] **Step 6: Commit:** `git add apps/web && git commit -m "feat(web): durable /automations/{id} page with live API contract"`
 
@@ -1241,49 +1391,12 @@ Match the `main className` conventions of `apps/web/app/sessions/[id]/page.tsx` 
 
 **Files:**
 - Modify: `apps/web/app/automations/[id]/page.tsx`
-- Modify: `apps/web/app/globals.css` (chips)
 
 **Interfaces:**
-- Consumes: `apiPatch` (api.ts:138), Task 5's `classifyVariables`, `ScheduleBuilder`/`parseCron`/`describeSchedule` from `../../components/ScheduleBuilder`.
-- Produces: `PATCH /triggers/{id}` calls with bodies shaped like Task 4's `UpdateTrigger`; a `TemplateChips` component reused by Task 9.
+- Consumes: `apiPatch` (api.ts:138), Task 6's `TemplateChips`/`CopyBlock`, `ScheduleBuilder` from `../../components/ScheduleBuilder`.
+- Produces: `PATCH /triggers/{id}` calls with bodies shaped like Task 4's `UpdateTrigger` (partial `schedule` object included).
 
-- [ ] **Step 1: Add `TemplateChips`** to `AutomationContract.tsx` (exported — the composer reuses it):
-
-```tsx
-/** Live placeholder read-back: which {{names}} the caller supplies vs which
- *  the platform fills. Rendered under every template textarea so the
- *  template's contract is visible while typing. */
-export function TemplateChips({ kind, template }: { kind: string; template: string }) {
-  const { caller, system } = classifyVariables(kind, template || null);
-  if (caller.length === 0 && system.length === 0) return null;
-  return (
-    <div className="tpl-chips">
-      {caller.map((name) => (
-        <span key={name} className="tpl-chip caller" title="Caller supplies this in `context`">
-          {`{{${name}}}`} · caller
-        </span>
-      ))}
-      {system.map((name) => (
-        <span key={name} className="tpl-chip system" title="Filled in by fluidbox">
-          {`{{${name}}}`} · fluidbox
-        </span>
-      ))}
-    </div>
-  );
-}
-```
-
-CSS:
-
-```css
-.tpl-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
-.tpl-chip { font-family: var(--mono, monospace); font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border, #333); }
-.tpl-chip.system { opacity: 0.7; }
-```
-
-(Adopt the repo's actual CSS variable names — grep `--border` in globals.css and reuse whatever the existing chips/badges use.)
-
-- [ ] **Step 2: Template section** on the detail page (between API and Activity):
+- [ ] **Step 1: Template section** (between API and Activity):
 
 ```tsx
       <section className="automation-detail-section">
@@ -1366,16 +1479,7 @@ function TemplateSection({ detail, onSaved }: { detail: TriggerDetail; onSaved: 
 }
 ```
 
-- [ ] **Step 3: Configuration section** (between API and Template):
-
-```tsx
-      <section className="automation-detail-section">
-        <h2>Configuration</h2>
-        <SettingsSection detail={detail} onSaved={load} />
-      </section>
-```
-
-`SettingsSection` mirrors `TemplateSection`'s view/edit toggle. View mode: a `rows`-style list of name, agent id (link `/agents` page style used elsewhere — plain text is fine), autonomy, concurrency policy, task/workspace override flags, callback destination (from `result_destinations[0]?.url`), and for schedule kind the cron/timezone/missed policy + next fire from `detail.schedule`. Edit mode: inputs for name (`inp`), checkboxes for the two overrides (`check`), select for concurrency (same options as RunComposer.tsx:1504-1508), input for callback URL (empty string = remove — mirror the PATCH semantics with a hint: "Clearing removes the signed callback; changing it mints a NEW signing secret shown once"), and for schedule kind the `ScheduleBuilder` (cron/timezone) + missed-policy select (options from RunComposer.tsx:892-895). Save builds the PATCH body with ONLY touched fields:
+- [ ] **Step 2: Configuration section** (between API and Template). `SettingsSection` mirrors `TemplateSection`'s view/edit toggle. View mode: a `rows`-style list of name, autonomy, concurrency policy, task/workspace override flags, callback destination (`sub.result_destinations.find((d) => d.kind === "signed_webhook")?.url ?? "none"` — same discriminant as Task 6), and for schedule kind the cron/timezone/missed policy + next fire from `detail.schedule`. Edit mode: input for name (`inp`), checkboxes for the two overrides (`check`), select for concurrency (same three options as RunComposer.tsx:1504-1508), input for callback URL with the hint "Clearing removes the signed callback; changing it mints a NEW signing secret shown once", and for schedule kind `ScheduleBuilder` (cron/timezone) + missed-policy select (options from RunComposer.tsx:892-895). Save sends ONLY touched fields — and for schedules, only touched schedule keys (the PATCH schedule object is partial by design):
 
 ```tsx
     const body: Record<string, unknown> = {};
@@ -1384,19 +1488,26 @@ function TemplateSection({ detail, onSaved }: { detail: TriggerDetail; onSaved: 
     if (allowWorkspace !== sub.allow_workspace_override) body.allow_workspace_override = allowWorkspace;
     if (concurrency !== sub.concurrency_policy) body.concurrency_policy = concurrency;
     if (callbackUrl !== initialCallbackUrl) body.callback_url = callbackUrl; // "" clears
-    if (sub.trigger_kind === "schedule" && detail.schedule &&
-        (cron !== detail.schedule.cron || timezone !== detail.schedule.timezone || missed !== detail.schedule.missed_run_policy)) {
-      body.schedule = { cron, timezone, missed_run_policy: missed };
+    if (sub.trigger_kind === "schedule" && detail.schedule) {
+      const scheduleBody: Record<string, string> = {};
+      if (cron !== detail.schedule.cron) scheduleBody.cron = cron;
+      if (timezone !== detail.schedule.timezone) scheduleBody.timezone = timezone;
+      if (missed !== detail.schedule.missed_run_policy) scheduleBody.missed_run_policy = missed;
+      if (Object.keys(scheduleBody).length > 0) body.schedule = scheduleBody;
+    }
+    if (Object.keys(body).length === 0) {
+      setEditing(false);
+      return; // nothing touched — do not send an empty PATCH
     }
     const response = await apiPatch<{ callback_secret: string | null }>(`/triggers/${sub.id}`, body);
     if (response.callback_secret) setNewSecret(response.callback_secret);
 ```
 
-When `callback_secret` comes back, show it in a `CopyBlock` inside a dismissable note ("New callback signing secret — copy it now, it will not be shown again."). Import `CopyBlock` from `AutomationContract`.
+A 409 from the server means a concurrent edit — surface it verbatim (the message says reload and retry). When `callback_secret` returns, render it in a `CopyBlock` inside a dismissable note: "New callback signing secret — copy it now, it will not be shown again."
 
-- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` green. Manual: edit the template on a live automation → the API section's variables + curl update after save and the "as of" stamp advances.
+- [ ] **Step 3: Verify:** `pnpm build && pnpm vitest run` green. Manual: edit the template on a live automation → API section variables + curl update after save, "as of" stamp advances; cron-only schedule edit leaves the timezone untouched.
 
-- [ ] **Step 5: Commit:** `git add apps/web && git commit -m "feat(web): edit template and settings on the automation detail page"`
+- [ ] **Step 4: Commit:** `git add apps/web && git commit -m "feat(web): edit template and settings on the automation detail page"`
 
 ---
 
@@ -1407,7 +1518,7 @@ When `callback_secret` comes back, show it in a `CopyBlock` inside a dismissable
 - Modify: `apps/web/app/globals.css`
 
 **Interfaces:**
-- Consumes: Task 5's `buildCurl`/`classifyVariables`, Task 8's `TemplateChips` (from `./AutomationContract`).
+- Consumes: Task 5's `buildCurl`/`classifyVariables`, Task 6's `TemplateChips` (from `./AutomationContract`), `apiGetCached` (already imported in RunComposer).
 
 - [ ] **Step 1: Relabel the template field** (replace lines 954-966):
 
@@ -1444,18 +1555,18 @@ When `callback_secret` comes back, show it in a `CopyBlock` inside a dismissable
             </label>
 ```
 
-and tighten `templateHint` (758-763) to explain the mechanism once:
+and tighten `templateHint` (758-763):
 
 ```tsx
   const templateHint =
     kind === "schedule"
       ? "Saved with the automation. {{fire_time}} is filled in at each firing; any other {{name}} is refused at save (a schedule has no caller to supply it)."
       : kind === "event"
-        ? "Saved with the automation. {{repository}}, {{pr_number}}, {{pr_title}} are filled from the pull request; any other {{name}} is refused at save."
+        ? "Saved with the automation. Pull-request values ({{repository}}, {{pr_number}}, {{pr_title}}, {{pr_url}}, {{pr_author}}, …) are filled from the event; any other {{name}} is refused at save."
         : "Saved with the automation. Every {{name}} you add becomes a required context value the API caller sends on invoke.";
 ```
 
-- [ ] **Step 2: `blockingIssue` gains the no-caller rule** (insert after the existing dead-config check at line 614-616):
+- [ ] **Step 2: `blockingIssue` gains the no-caller rule** (insert after the existing dead-config check at lines 614-616):
 
 ```tsx
       if (mode === "automation" && (kind === "schedule" || kind === "event") && !task.trim()) {
@@ -1467,23 +1578,39 @@ and tighten `templateHint` (758-763) to explain the mechanism once:
 
 ```tsx
             {!agentOnly && mode === "automation" && kind === "api" && !blockingIssue && (
-              <ApiPreview task={task} />
+              <ApiPreview task={task} allowTask={allowTask} />
             )}
 ```
 
-with the component (place near `SpecRow` at the bottom):
+with the component (place near `SpecRow` at the bottom). The base URL is SERVER truth — fetched from the list endpoint Task 1 extended, never derived from `window.location`:
 
 ```tsx
 /** Pre-save preview of the integration contract. Deliberately labeled a
- *  preview: the id and token exist only after save, so the copy carries
- *  placeholders — nobody should wire an integration to this text. */
-function ApiPreview({ task }: { task: string }) {
+ *  preview: the id and token exist only after save, so those two are
+ *  placeholders — but the base URL is the server's real answer. */
+function ApiPreview({ task, allowTask }: { task: string; allowTask: boolean }) {
   const [copied, setCopied] = useState(false);
+  const [baseUrl, setBaseUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    apiGetCached<{ base_url?: string }>("/triggers", { maxAgeMs: 60_000 })
+      .then((response) => {
+        if (!cancelled && response.base_url) setBaseUrl(response.base_url);
+      })
+      .catch(() => {
+        /* preview keeps the {base_url} placeholder */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const { caller } = classifyVariables("api", task || null);
+  const hasTemplate = task.trim().length > 0;
   const curl = buildCurl({
-    invokeUrl: "{base_url}/v1/triggers/{id-assigned-on-save}/invoke",
+    invokeUrl: `${baseUrl ?? "{base_url}"}/v1/triggers/{id-assigned-on-save}/invoke`,
     token: "<minted-on-save>",
     caller,
+    hasTemplate: hasTemplate || !allowTask,
   });
   const copy = async () => {
     try {
@@ -1504,24 +1631,24 @@ function ApiPreview({ task }: { task: string }) {
       </div>
       <pre className="token rc-api-preview-curl">{curl}</pre>
       <span className="field-hint">
-        The real URL and one-time token are minted when you save; the full contract then
-        lives on the automation&apos;s page.
+        The id and one-time token are minted when you save; the full contract then lives on
+        the automation&apos;s page.
       </span>
     </div>
   );
 }
 ```
 
-Imports to add at the top of RunComposer: `buildCurl, classifyVariables` from `../lib/automation-contract`; `TemplateChips` from `./AutomationContract`.
+Imports to add at the top of RunComposer: `buildCurl, classifyVariables` from `../lib/automation-contract` (buildCurl may already be there from Task 5); `TemplateChips` from `./AutomationContract`.
 
 CSS:
 
 ```css
-.rc-api-preview { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border, #333); }
+.rc-api-preview { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border); }
 .rc-api-preview-curl { font-size: 11px; max-height: 140px; overflow: auto; }
 ```
 
-- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` green. Manual: in the composer pick Automation → API call → watch the preview appear once name+template are valid, disappear on Schedule kind, chips update as you type `{{ticket}}`.
+- [ ] **Step 4: Verify:** `pnpm build && pnpm vitest run` green. Manual: Automation → API call → preview appears once valid (with the real base URL after the fetch lands), disappears on Schedule kind; chips update as you type `{{ticket}}`; typing `{{oops}}` on a Schedule automation shows the red "unknown" chip AND the save is blocked server-side if forced.
 
 - [ ] **Step 5: Commit:** `git add apps/web && git commit -m "feat(web): self-explanatory template box + pre-save API preview"`
 
@@ -1543,18 +1670,19 @@ cd apps/web && pnpm vitest run && pnpm build
 
 All must pass; paste outputs in the report.
 
-- [ ] **Step 2: Manual lifecycle drill** (needs the dev stack; coordinate with the owner before starting it — do not start `just dev`/DB yourself if anything is already running):
-1. Configure Run → Automation → API call: template box shows the new label, chips appear for `{{ticket}}`, API preview card renders, "Copy preview" copies placeholder curl.
-2. Save → secrets modal shows token + link "Automations → {name} → API".
-3. Follow the link → `/automations/{id}`: contract with `$FLUIDBOX_TRIGGER_TOKEN`, every CopyBlock copies, "as of" stamp present.
-4. Hard-refresh the page → identical (persistence).
-5. Edit template (add `{{env}}`) → save → variables table + curl show `env`, stamp advanced.
-6. Settings edit: flip concurrency to `skip_if_running` → save → view reflects it.
-7. Rotate token → one-time modal again → close → contract still shows placeholder form.
-8. Invoke with the real token (curl) → 200; confirms PATCH broke nothing at the invoke path.
-9. Schedule-kind automation: edit cron via ScheduleBuilder → next-fire updates.
-10. Negative: PATCH template to `{{nope}}` on the schedule automation → inline error naming the schedule context.
+- [ ] **Step 2: Manual lifecycle drill** (needs the dev stack; coordinate with the owner before starting anything):
+1. Configure Run → Automation → API call: new label, chips for `{{ticket}}`, API preview with the server's real base URL, "Copy preview" copies shell-valid curl.
+2. Save → secrets modal shows ONLY token/secret + the link; follow it → `/automations/{id}`.
+3. Contract shows `-H "Authorization: Bearer ${FLUIDBOX_TRIGGER_TOKEN}"`; export the env var and paste the copied curl VERBATIM into a shell → 200 (this is the finding-6 regression test).
+4. Hard-refresh → identical (persistence).
+5. Edit template (add `{{env}}`) → save → variables + curl show `env`, "as of" stamp advanced.
+6. `PATCH {"agent":"x"}` via curl → 400 naming immutable fields; `PATCH {}` → 200 and the stamp did NOT advance.
+7. Two tabs: edit in one, then save in the other → 409 "changed since it was loaded".
+8. Settings: set a callback URL → new signing secret shown once; clear it → gone; check `authority_generation` bumped (visible in the DB or just trust the 200s).
+9. Schedule automation: cron-only edit → timezone/missed policy unchanged, next-fire updated; template with `{{nope}}` → error naming the schedule context.
+10. Event automation (if one exists): detail page shows ingress URL, no invoke curl; template chips know `{{pr_url}}`/`{{pr_author}}`.
+11. Rotate token → one-time modal → close → page still shows placeholder form.
 
-- [ ] **Step 3: Report results** to the owner, including anything skipped and why. Offer to run `scripts/governance-e2e.sh` / `just e2e` ONLY as an owner-triggered follow-up.
+- [ ] **Step 3: Report results** to the owner, including anything skipped and why. Offer `scripts/governance-e2e.sh` / `just e2e` ONLY as an owner-triggered follow-up.
 
 - [ ] **Step 4: Final commit if the drill produced fixes**, message `fix(web/server): lifecycle drill follow-ups for automation contract`.

--- a/docs/superpowers/specs/2026-07-29-automation-api-contract-design.md
+++ b/docs/superpowers/specs/2026-07-29-automation-api-contract-design.md
@@ -36,14 +36,14 @@
 Single scrolling page (no tabs). List rows on the Automations page link to it; "Rotate token" remains in both places.
 
 - **Header**: name, kind badge, enabled toggle, agent link, next-fire time for schedules.
-- **API section** (kind=api; events show their ingress URL here): invoke/poll URLs, curl with token placeholder, variables table, response codes (200/400/401/409), callback signature block — each a `CopyBlock`. Plus Rotate token.
+- **API section** (kind=api; events show their ingress URL here): invoke/poll URLs, curl with token placeholder, variables table, response codes (200/400/401/409 concurrency/422 idempotency-key reuse with a different body — 422 matches what the server actually returns), callback signature block — each a `CopyBlock`. Plus Rotate token.
 - **Configuration section**: agent, autonomy, concurrency, overrides, schedule facts, with **Edit** on the mutable subset (§4).
 - **Template section**: rendered template with placeholder chips; **Edit template** inline (textarea + the same validation as create — must render from the kind's sample context). Saving PATCHes; the API section re-renders immediately. A line under the contract reads *"Reflects the configuration as of {updated_at}"* so edits are visible, not silent.
 - **Activity section**: reuse `AutomationActivity` (runs / firings & skips / deliveries). The list-row expander stays but gains an "Open →" link.
 
 ## 4. Backend changes
 
-- **URL fields on read**: `GET /v1/triggers/{id}` and `GET /v1/triggers` gain `base_url`, `invoke_url`, `poll_url_template`, `ingress_url` — same derivation as create/rotate (`public_url` + id; no secrets). Refactor the duplicated JSON block into one helper used by all four sites.
+- **URL fields on read**: `GET /v1/triggers/{id}` gains `base_url`, `invoke_url`, `poll_url_template`, `ingress_url` — same derivation as create/rotate (`public_url` + id; no secrets); `GET /v1/triggers` gains `base_url` only (the list UI never renders contracts; the detail page carries the full block). Refactor the duplicated JSON block into one helper used by every response that carries the contract.
 - **`PATCH /v1/triggers/{id}`** — mutable surface only:
   - `name`, `task_template`, `allow_task_override`, `allow_workspace_override`, `callback_url` (re-runs the same SSRF admission check as create), `concurrency_policy`; for schedules also `cron`, `timezone`, `missed_policy`.
   - Trigger kind and agent are immutable — attempting to change them is a 400; changing those means a new automation.

--- a/docs/superpowers/specs/2026-07-29-automation-api-contract-design.md
+++ b/docs/superpowers/specs/2026-07-29-automation-api-contract-design.md
@@ -1,0 +1,75 @@
+# Automation API contract & template clarity — design
+
+**Date:** 2026-07-29
+**Status:** Approved (design review with owner)
+**Scope:** `apps/web` (Configure Run composer, Automations list, new detail page) + `crates/fluidbox-server/src/triggers.rs` + one `fluidbox-db` method. No migrations.
+
+## Problem
+
+1. The API integration contract (invoke URL, curl, variables, responses) is shown exactly once — in the post-save `ShowAutomationSecrets` modal — and is unreachable afterwards without rotating the token. Users have no durable place to inspect a saved configuration or re-copy the API request.
+2. `GET /v1/triggers/{id}` does not return the absolute `invoke_url`/`base_url` (only create and rotate do), so the dashboard *cannot* rebuild the contract later even though nothing secret is involved.
+3. Saved automations cannot be edited at all (no PATCH endpoint), so "edit → updated API representation" is impossible.
+4. The "What should happen each time? — optional template" box under-explains itself: it doesn't say it is a template rendered per firing, "optional" is only true for API-kind triggers, and placeholder behavior is a one-line passive hint.
+
+## Governing rule
+
+**The API contract is always copyable and always rendered live from the current saved subscription. Only the two secrets (trigger token, callback signing secret) are one-time.** The trigger token is sha256-hashed at rest and can never be re-shown; recovery is rotation. This is a kept security invariant, not a UX gap.
+
+## 1. Configure Run composer — template box
+
+- **Label renames, per trigger kind** (replaces "What should happen each time? optional template"):
+  - API call: **"Task template — rendered for every API invocation"**
+  - Schedule: **"Task template — rendered at every scheduled firing"**
+  - Pull request: **"Task template — rendered for every matching PR event"**
+  - Run-once mode is unchanged ("What should the agent accomplish?").
+- **Placeholder chips** under the textarea, live-parsed with the existing `templateVariables()` regex: caller-supplied vars styled one way ("caller sends in `context`"), system vars (`fire_time`, `repository`, `pr_number`, `pr_title`) another ("filled by fluidbox"). Replaces the passive `templateHint` line.
+- **"optional" appears only when it is true**: kind=api with `allow_task_override` on. Schedule/event kinds (and api without override) mark the template required and validate presence inline before save, mirroring the backend rules (`triggers.rs:382,507,325`).
+
+## 2. Copy API button lifecycle
+
+- **Before saving** (automation mode, kind=api, form valid — name present, template-or-override satisfied): the right-hand summary panel shows a compact **"API preview"** card — curl skeleton with `<minted-on-save>` for the token, real URL pattern, detected variables. Button label is **"Copy preview"** so nobody wires an integration to it. Hidden while the form is invalid.
+- **On save**: `ShowAutomationSecrets` is trimmed to what is truly one-time — token + callback secret stay front and center; endpoint/variables/curl/responses sections move to the detail page. Footer gains: *"Everything except these secrets is always available at Automations → {name} → API"* with a link to `/automations/{id}`.
+- **After saving, forever**: the detail page renders the full contract from `GET /triggers/{id}` with a Copy button on every block. The curl uses `Authorization: Bearer $FLUIDBOX_TRIGGER_TOKEN`. **Rotate token** sits beside it (existing flow → secrets modal).
+
+## 3. New page: `/automations/{id}`
+
+Single scrolling page (no tabs). List rows on the Automations page link to it; "Rotate token" remains in both places.
+
+- **Header**: name, kind badge, enabled toggle, agent link, next-fire time for schedules.
+- **API section** (kind=api; events show their ingress URL here): invoke/poll URLs, curl with token placeholder, variables table, response codes (200/400/401/409), callback signature block — each a `CopyBlock`. Plus Rotate token.
+- **Configuration section**: agent, autonomy, concurrency, overrides, schedule facts, with **Edit** on the mutable subset (§4).
+- **Template section**: rendered template with placeholder chips; **Edit template** inline (textarea + the same validation as create — must render from the kind's sample context). Saving PATCHes; the API section re-renders immediately. A line under the contract reads *"Reflects the configuration as of {updated_at}"* so edits are visible, not silent.
+- **Activity section**: reuse `AutomationActivity` (runs / firings & skips / deliveries). The list-row expander stays but gains an "Open →" link.
+
+## 4. Backend changes
+
+- **URL fields on read**: `GET /v1/triggers/{id}` and `GET /v1/triggers` gain `base_url`, `invoke_url`, `poll_url_template`, `ingress_url` — same derivation as create/rotate (`public_url` + id; no secrets). Refactor the duplicated JSON block into one helper used by all four sites.
+- **`PATCH /v1/triggers/{id}`** — mutable surface only:
+  - `name`, `task_template`, `allow_task_override`, `allow_workspace_override`, `callback_url` (re-runs the same SSRF admission check as create), `concurrency_policy`; for schedules also `cron`, `timezone`, `missed_policy`.
+  - Trigger kind and agent are immutable — attempting to change them is a 400; changing those means a new automation.
+  - Template validation identical to create: renders against the kind's sample context; api-kind requires template-or-override.
+  - RBAC: `can_manage_subscriptions`, same as the other trigger management endpoints.
+- **`fluidbox-db::update_trigger_subscription`** — TenantScope-signed like every tenant-owned method. All columns already exist; **no migration**.
+- **Invariant preserved**: RunSpec freezing is untouched. In-flight runs keep their snapshot; future firings use the updated template — exactly the platform's existing immutability model.
+
+## 5. Persistence semantics
+
+| Question | Answer |
+|---|---|
+| Contract across refresh / navigation / future sessions? | Always rebuildable — rendered from the DB row via `GET /triggers/{id}`; nothing lives only in client state. |
+| Unsaved composer state? | Already persisted by `useSessionDraft` (unchanged). |
+| Edit → API snippet? | Updates automatically (live render) + visible "as of {updated_at}" stamp. No snippet versioning (YAGNI) — per-run audit truth is the frozen RunSpec. |
+| Token after edit? | Unchanged. Rotation is a deliberate, separate act that revokes all live tokens. |
+
+## 6. Testing & verification
+
+- **Rust unit tests** (`triggers.rs`): PATCH validation (immutable-field 400, template re-validation per kind, callback_url admission), URL fields present on get/list.
+- **Web**: `pnpm build` must pass; component-level behavior follows existing patterns.
+- **Manual lifecycle drill**: configure → save → copy → leave → return via `/automations/{id}` → copy again → edit template → contract reflects the edit with updated stamp.
+- DB-backed and e2e suites are owner-triggered only (standing agreement); the implementation plan will call out which ones are worth running.
+
+## Out of scope
+
+- Editing trigger kind or agent in place (duplicate-as-new is the path; not built in this pass).
+- SDK snippets beyond curl.
+- Snippet/version history.


### PR DESCRIPTION
## What

Makes the automation API integration contract **durable** — always copyable, live-rendered from the DB — instead of a one-shot artifact of the save modal, and adds editing for saved automations.

### Backend (Rust, no migrations)
- `contract_urls` + `ingress_path_for` helpers; `GET /v1/triggers/{id}` now returns `base_url`/`invoke_url`/`poll_url_template`/`ingress_url` (list gains `base_url`; rotate gains `ingress_url`)
- **New `PATCH /v1/triggers/{id}`** for the mutable surface only (name, template, overrides, concurrency, callback, schedule):
  - `deny_unknown_fields` → immutable fields (agent, kind) are a **400 naming the mutable list**, never a silent no-op
  - subscription + schedule update in **one transaction** with an `updated_at` stale-guard → concurrent edits get **409**; a minted callback secret can never be committed-but-unrevealed
  - callback set/clear reseals under the tenant DEK and bumps `authority_generation` (stale `subscription_secret` bindings fail closed)
  - partial schedule merge: a cron-only PATCH keeps timezone/missed-policy; a missed-policy-only PATCH **preserves `next_fire_at`**
  - empty `{}` PATCH answers current state without writing (the "as of" stamp never lies)

### Web
- **New `/automations/{id}` page**: full API contract (curl with shell-expandable `${FLUIDBOX_TRIGGER_TOKEN}`, variables, responses incl. the corrected **422** idempotency row), template + settings editors, activity, "as of {updated_at}" stamp
- Save modal trimmed to **secrets-only** + a pointer to the durable page
- Composer: per-kind template labels, live placeholder chips (caller / fluidbox / invalid), pre-save **API preview** card with the server's real base URL
- Pure, vitest-tested `automation-contract.ts` (curl builder, variable classification — full 12-name GitHub event context)

## Design & review trail
- Spec: `docs/superpowers/specs/2026-07-29-automation-api-contract-design.md`
- Plan (rev 2): `docs/superpowers/plans/2026-07-29-automation-api-contract.md` — externally reviewed (Codex/GPT-5.6-sol max effort) before implementation; all confirmed findings absorbed
- 10 tasks, each independently reviewed; final whole-branch review + one fix wave (re-review clean)

## Testing
- `cargo test -p fluidbox-server` 427/0, `-p fluidbox-core` 119/0, clippy `-D warnings`, fmt clean
- `pnpm vitest run` 66/66, `pnpm build` green
- **Manual lifecycle drill** on a throwaway stack/DB: configure → save → paste copied curl verbatim → 200 → refresh → edit → contract updates → immutable-field 400 → `{}` no-op (stamp unchanged) → 8 racing PATCHes = one 200 + seven 409s → callback set/clear with generation bumps → schedule cadence semantics → rotate. 10/11 full pass, event-ingress rendering partial (no GitHub App connection in the throwaway DB; unit-covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4T6tKW1B7jvmHoL2YMtPD
