### PR TITLE
fix(release): don't let the Cargo.lock step mask the real release-please error

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,13 +54,27 @@ jobs:
       # and it runs on the Release PR, which the header above calls the last
       # checkpoint before public artifacts. So the lock is re-resolved here
       # rather than left for a human to notice.
-      - if: steps.release.outputs.prs_created == 'true'
+      # NOTE: `pr` is passed as a RAW STRING and parsed in the shell, never with
+      # `fromJSON(...)` in `env:`. A template expression is evaluated before the
+      # step's `if` can skip it, so when the action fails before setting `pr`,
+      # `fromJSON('')` aborts the whole job with
+      #   The template is not valid ... Error reading JToken from JsonReader
+      # which REPLACES the real error with a confusing one. Observed exactly
+      # that on f699bbe: release-please failed for an unrelated reason, and this
+      # step's template error was the second annotation on the run.
+      - if: steps.release.outputs.prs_created == 'true' && steps.release.outputs.pr != ''
         name: re-resolve Cargo.lock on the release branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           set -euo pipefail
+          BRANCH=$(printf '%s' "$PR_JSON" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("headBranchName",""))')
+          if [ -z "$BRANCH" ]; then
+            echo "::warning::release PR JSON carried no headBranchName; skipping Cargo.lock re-resolve"
+            exit 0
+          fi
           git clone --branch "$BRANCH" --depth 1 \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" rp
           cd rp


### PR DESCRIPTION
Follow-up to #109, from watching it run on main.

The run on `f699bbe` emitted **two** errors. The second one is mine:

```
X release-please failed: GitHub Actions is not permitted to create or approve pull requests.
X The template is not valid. .github/workflows/release-please.yml (Line: 61, Col: 19)
```

`fromJSON(steps.release.outputs.pr)` was in `env:`, and template expressions are evaluated **before** a step's `if` can skip them. So when the action fails before setting `pr`, `fromJSON('')` aborts the job with a JSON-parsing error that has nothing to do with the real failure — a diagnostic that hides the thing you need to see.

Now `pr` is passed as a raw string and parsed in the shell; the `if` also requires it to be non-empty; an absent `headBranchName` warns and exits 0. actionlint clean, no `fromJSON` left in any expression, parser exercised against a populated object and `{}`.

### What #109 actually achieved

Measured on `f699bbe`: **zero** `not a package manifest` errors, and release-please ran all the way through to creating the branch, tree and commit. That commit is correct:

```diff
-version = "0.4.0-rc.1" # x-release-please-version
+version = "0.5.0-rc.1" # x-release-please-version
```

13 files, CHANGELOG generated, `version.txt` bumped. The strategy fix is proven on real main.

### The remaining blocker is a repo setting, not code

```
can_approve_pull_request_reviews: false
```

release-please cannot open the PR until *Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"* is enabled. **Left for you to decide** — it also permits Actions to *approve* PRs, which interacts with this repo's review-required ruleset, so it is a security call rather than a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KVCWZDVRxBYbrbpMS6ikS