### PR TITLE
feat(k8s): Cilium enforcer + verify() at provision

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -86,6 +86,14 @@ jobs:
         run: |
           kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml
           kubectl -n kube-system rollout status ds/calico-node --timeout=240s
+      # The NEGATIVE CONTROL for enforcer detection. A detector that returned
+      # true unconditionally would pass every assertion in the kind-cilium job;
+      # only a cluster that genuinely lacks Cilium can prove it says no. A
+      # deployment here must come out offline-only.
+      - name: enforcer detection must report ABSENT without Cilium
+        run: |
+          kubectl create ns netgrant
+          cargo run --quiet -p fluidbox-provider-k8s --example enforcer_live -- netgrant --expect-absent
       - name: build + load collector + a tiny contract-stub runner
         run: |
           docker build -q -t fluidbox-workspaced:dev -f deploy/workspaced.Dockerfile .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,6 +1742,7 @@ dependencies = [
  "hex",
  "k8s-openapi",
  "kube",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/fluidbox-core/src/traits.rs
+++ b/crates/fluidbox-core/src/traits.rs
@@ -337,6 +337,18 @@ pub trait ExecutionProvider: Send + Sync {
     fn workspace_transport(&self) -> WorkspaceTransport {
         WorkspaceTransport::HostDir
     }
+    /// This provider's network-grant enforcer.
+    ///
+    /// The DEFAULT refuses anything above `offline`, which is what makes the
+    /// run gate fail closed for free: a provider that has not opted in cannot
+    /// accidentally admit a grant it has no way to enforce. Asking the PROVIDER
+    /// rather than the config is deliberate — a deployment configured
+    /// `FLUIDBOX_NETWORK_ENFORCER=auto` on a cluster without Cilium, or
+    /// `=cilium` against the Docker provider, would otherwise admit the grant
+    /// at creation and only discover the truth at provision time.
+    fn network_enforcer(&self) -> &dyn NetworkPolicyProvider {
+        &NoNetworkEnforcer
+    }
     fn runtime_name(&self) -> &'static str;
 }
 

--- a/crates/fluidbox-provider-k8s/Cargo.toml
+++ b/crates/fluidbox-provider-k8s/Cargo.toml
@@ -27,3 +27,9 @@ kube = { version = "4", default-features = false, features = [
     "ws",
 ] }
 k8s-openapi = { version = "0.28", features = ["latest"] }
+
+[dev-dependencies]
+# The live enforcer EXAMPLE drives kube-rs directly, so it needs the same
+# process-level CryptoProvider main.rs installs. Dev-only: the library itself
+# never picks a TLS backend for its embedder.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/fluidbox-provider-k8s/examples/enforcer_live.rs
+++ b/crates/fluidbox-provider-k8s/examples/enforcer_live.rs
@@ -1,0 +1,217 @@
+//! Live check of the Cilium enforcer against a real cluster.
+//!
+//! The unit tests in `enforcer.rs` pin the SHAPES this code reads, taken from a
+//! real 1.19.6 cluster. They cannot prove that `detect`, `prepare` and `verify`
+//! actually work against an API server — that a policy we build is accepted,
+//! that the endpoint we poll for appears, and above all that `verify` FAILS
+//! CLOSED when enforcement is absent. Only a cluster can prove those.
+//!
+//! Driven by `scripts/netgrant-kind-validation.sh`; run directly with an
+//! ambient kubeconfig:
+//!
+//! ```sh
+//! cargo run -p fluidbox-provider-k8s --example enforcer_live -- <namespace>
+//! ```
+//!
+//! Exits non-zero on the first failed assertion.
+
+use fluidbox_core::network::{
+    FqdnPattern, L4Protocol, NetworkGrant, NetworkGrantMode, PortSpec, TargetRule, SCHEMA_VERSION,
+};
+use fluidbox_core::traits::{GrantedNetwork, NetworkPolicyError, NetworkPolicyProvider};
+use fluidbox_provider_k8s::enforcer::CiliumNetworkEnforcer;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, DeleteParams, PostParams};
+use kube::Client;
+use serde_json::json;
+
+static mut PASS: u32 = 0;
+static mut FAIL: u32 = 0;
+
+fn ok(msg: &str) {
+    println!("  \x1b[1;32m✓\x1b[0m {msg}");
+    unsafe { PASS += 1 }
+}
+fn no(msg: &str) {
+    println!("  \x1b[1;31m✗\x1b[0m {msg}");
+    unsafe { FAIL += 1 }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // kube-rs (rustls 0.23) needs a process-level CryptoProvider chosen
+    // explicitly — the workspace has more than one backend in tree, so without
+    // this the Kubernetes client panics on its first TLS handshake. Same line
+    // `main.rs` carries, for the same reason.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let ns = std::env::args().nth(1).unwrap_or_else(|| "netgrant".into());
+    let client = Client::try_default().await?;
+    let pods: Api<Pod> = Api::namespaced(client.clone(), &ns);
+
+    println!("\n\x1b[1;36m== ENFORCER (live) — detect, prepare, verify, revoke ==\x1b[0m");
+
+    // ── detect ────────────────────────────────────────────────────────────
+    //
+    // `--expect-absent` is the NEGATIVE CONTROL, run on the Calico cluster: a
+    // detector that returned true unconditionally would sail through every
+    // positive assertion below, so the only honest guard is a cluster that
+    // genuinely has no Cilium. (A bogus NAMESPACE is not such a guard —
+    // listing a CRD in a namespace that does not exist returns an empty list,
+    // not a 404, because the resource TYPE is cluster-wide. Asserting on that
+    // tested Kubernetes' namespace semantics, not ours.)
+    let expect_absent = std::env::args().any(|a| a == "--expect-absent");
+    let found = CiliumNetworkEnforcer::detect(&client, &ns).await;
+    if expect_absent {
+        if found {
+            no("detect() claims Cilium on a cluster that does not have it");
+        } else {
+            ok("detect() correctly reports NO enforcer on a non-Cilium cluster");
+        }
+        // Nothing else is meaningful here: the whole point is that this
+        // deployment is offline-only.
+        let (p, f) = unsafe { (PASS, FAIL) };
+        println!("  \x1b[1;32m{p} passed\x1b[0m, \x1b[1;31m{f} failed\x1b[0m (enforcer)");
+        if f > 0 {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+    if found {
+        ok("detect() finds CiliumNetworkPolicy on a Cilium cluster");
+    } else {
+        no("detect() should find CiliumNetworkPolicy here");
+    }
+
+    let enforcer = CiliumNetworkEnforcer::new(
+        client.clone(),
+        ns.clone(),
+        20,
+        json!({
+            "k8s:io.kubernetes.pod.namespace": ns,
+            "app.kubernetes.io/component": "sandbox-dns",
+        }),
+    );
+
+    // ── verify() must FAIL CLOSED with nothing programmed ─────────────────
+    //
+    // The single most important assertion here: if this returned Ok for a run
+    // with no pod and no policy, every other check in the suite would be
+    // meaningless, because verify would be rubber-stamping.
+    let orphan = granted(uuid::Uuid::now_v7(), NetworkGrantMode::Approved);
+    match enforcer.verify(&orphan).await {
+        Err(NetworkPolicyError::Unverified(m)) => {
+            ok("verify() FAILS CLOSED when nothing is programmed");
+            println!("      ({})", m.lines().next().unwrap_or("").trim());
+        }
+        Err(e) => no(&format!("expected Unverified, got a different error: {e}")),
+        Ok(()) => no("verify() returned Ok with NOTHING programmed — it is rubber-stamping"),
+    }
+
+    // ── prepare + verify on a real pod ────────────────────────────────────
+    let run_id = uuid::Uuid::now_v7();
+    let g = granted(run_id, NetworkGrantMode::Approved);
+    let name = format!("fluidbox-{run_id}");
+    let pod: Pod = serde_json::from_value(json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": name,
+            "labels": {
+                "fluidbox.dev/managed": "true",
+                "fluidbox.dev/session": run_id.to_string(),
+                "fluidbox.dev/tenant": g.tenant_id.to_string(),
+                "fluidbox.dev/run": run_id.to_string(),
+            }
+        },
+        "spec": {
+            "tolerations": [{"operator": "Exists"}],
+            "containers": [{"name": "p", "image": "busybox:1.36", "command": ["sleep", "300"]}]
+        }
+    }))?;
+    pods.create(&PostParams::default(), &pod).await?;
+    ok(&format!("created pod {name}"));
+
+    match enforcer.prepare(&g).await {
+        Ok(()) => ok("prepare() wrote the per-run CiliumNetworkPolicy"),
+        Err(e) => no(&format!("prepare() failed: {e}")),
+    }
+    // Idempotent: a retried provision must not fail on its own prior success.
+    match enforcer.prepare(&g).await {
+        Ok(()) => ok("…and is idempotent (a retry does not fail on AlreadyExists)"),
+        Err(e) => no(&format!("prepare() is not idempotent: {e}")),
+    }
+
+    match enforcer.verify(&g).await {
+        Ok(()) => ok("verify() proves the policy is Valid and the endpoint has an identity"),
+        Err(e) => no(&format!(
+            "verify() failed on a correctly programmed run: {e}"
+        )),
+    }
+
+    // ── revoke, and its idempotence ───────────────────────────────────────
+    match enforcer.revoke(&g).await {
+        Ok(()) => ok("revoke() deleted the policy"),
+        Err(e) => no(&format!("revoke() failed: {e}")),
+    }
+    match enforcer.revoke(&g).await {
+        Ok(()) => ok("…and is idempotent (a second revoke is not an error)"),
+        Err(e) => no(&format!("revoke() is not idempotent: {e}")),
+    }
+    // After revocation, verify must fail again — proving it reads live state
+    // rather than caching its earlier success.
+    match enforcer.verify(&g).await {
+        Err(NetworkPolicyError::Unverified(_)) => {
+            ok("verify() fails again after revoke (it reads live state, not a cached verdict)")
+        }
+        Err(e) => no(&format!("expected Unverified after revoke, got: {e}")),
+        Ok(()) => no("verify() still returns Ok after the policy was revoked"),
+    }
+
+    // ── an OFFLINE grant needs no policy but still needs an endpoint ──────
+    let off = granted(run_id, NetworkGrantMode::Offline);
+    match enforcer.prepare(&off).await {
+        Ok(()) => ok("prepare() writes NO policy for an offline grant"),
+        Err(e) => no(&format!("offline prepare() should be a no-op: {e}")),
+    }
+    match enforcer.verify(&off).await {
+        Ok(()) => ok("verify() passes an offline grant on the endpoint check alone"),
+        Err(e) => no(&format!("offline verify() failed: {e}")),
+    }
+
+    let _ = pods.delete(&name, &DeleteParams::default()).await;
+
+    let (p, f) = unsafe { (PASS, FAIL) };
+    println!("  \x1b[1;32m{p} passed\x1b[0m, \x1b[1;31m{f} failed\x1b[0m (enforcer)");
+    if f > 0 {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn granted(run_id: uuid::Uuid, mode: NetworkGrantMode) -> GrantedNetwork {
+    let targets = if mode == NetworkGrantMode::Approved {
+        vec![TargetRule::dns(
+            FqdnPattern::Wildcard {
+                suffix: "example.com".into(),
+            },
+            vec![PortSpec::single(443)],
+            L4Protocol::Tcp,
+        )]
+    } else {
+        vec![]
+    };
+    let grant: NetworkGrant = serde_json::from_value(json!({
+        "schema_version": SCHEMA_VERSION,
+        "mode": mode.as_str(),
+        "targets": targets,
+        "expires_at": "2099-01-01T00:00:00Z",
+        "policy_digest": "sha256:live",
+    }))
+    .expect("grant fixture");
+    GrantedNetwork {
+        grant,
+        tenant_id: uuid::Uuid::nil(),
+        run_id,
+        grant_digest: "sha256:live".into(),
+    }
+}

--- a/crates/fluidbox-provider-k8s/src/enforcer.rs
+++ b/crates/fluidbox-provider-k8s/src/enforcer.rs
@@ -1,0 +1,420 @@
+//! The Cilium implementation of [`NetworkPolicyProvider`] — the half that talks
+//! to a cluster. The pure lowering lives in [`crate::netgrant`].
+//!
+//! ## What `verify()` can and cannot prove
+//!
+//! The plan originally had this read `CiliumEndpoint.status.policy` for
+//! `realized` / `policy-enabled` / `policy-revision`. The Phase 0 spike
+//! falsified that: on Cilium 1.19.x `status.policy` is EMPTY, and the
+//! `endpointStatus` Helm knob that used to populate it no longer exists in the
+//! chart (`helm show values cilium/cilium --version 1.19.6 | grep
+//! endpointStatus` returns nothing). The enforcement fact does exist, but only
+//! node-locally through the agent's own CLI — reachable solely by `exec`ing into
+//! the DaemonSet, a privilege the control plane must not take.
+//!
+//! So this is honest about its scope. It proves two things over the k8s API:
+//!
+//! 1. **The policy was ACCEPTED.** A structurally invalid policy is rejected by
+//!    CRD schema validation at the `create` call itself — a hard error with no
+//!    window in which a bad policy sits silently pending, which is a *better*
+//!    fail-closed signal than any status poll. Semantic acceptance then shows up
+//!    as `status.conditions[type=Valid]` from the Cilium operator.
+//! 2. **The pod has a real security identity**, and one derived from labels that
+//!    include this run's — so the policy's `endpointSelector` has something
+//!    specific to bind to.
+//!
+//! It does **not** prove datapath realization, and nothing available over the
+//! k8s API on 1.19.x does. Realization is proven from inside the pod's own
+//! network namespace by the `netpol-gate` init container, which observes the
+//! positive target reachable and the negative target blocked before any
+//! untrusted code runs. **Both must hold**; either failing is fail-closed. This
+//! is the belt, that is the braces, and the docs say so rather than implying
+//! this check is stronger than it is.
+
+use crate::netgrant;
+use fluidbox_core::traits::{GrantedNetwork, NetworkPolicyError, NetworkPolicyProvider};
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, ApiResource, DeleteParams, DynamicObject};
+use kube::Client;
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+/// How often to re-ask while waiting for the operator and the CNI to catch up.
+/// Both are fast (sub-second in practice); this is a poll floor, not a sleep.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// The `cilium.io/v2` resources this enforcer touches. Dynamic rather than
+/// typed: the CRDs have no Rust binding, and vendoring one for a handful of
+/// fields would be a schema we then have to keep in step with Cilium's.
+pub fn cnp_resource() -> ApiResource {
+    ApiResource {
+        group: "cilium.io".into(),
+        version: "v2".into(),
+        api_version: "cilium.io/v2".into(),
+        kind: "CiliumNetworkPolicy".into(),
+        plural: "ciliumnetworkpolicies".into(),
+    }
+}
+
+pub fn cep_resource() -> ApiResource {
+    ApiResource {
+        group: "cilium.io".into(),
+        version: "v2".into(),
+        api_version: "cilium.io/v2".into(),
+        kind: "CiliumEndpoint".into(),
+        plural: "ciliumendpoints".into(),
+    }
+}
+
+pub struct CiliumNetworkEnforcer {
+    cnps: Api<DynamicObject>,
+    ceps: Api<DynamicObject>,
+    pods: Api<Pod>,
+    namespace: String,
+    /// Bound on how long `verify` waits for the operator to mark the policy
+    /// valid and the CNI to give the pod an identity. Reuses the deployment's
+    /// existing NetworkPolicy convergence budget rather than inventing a second
+    /// knob for the same physical wait (AWS VPC CNI lands ~20 s; Cilium is much
+    /// faster, but the ceiling belongs to the operator, not to us).
+    verify_timeout_secs: u64,
+    /// Labels selecting the controlled resolver a per-run policy may allow.
+    resolver_labels: Value,
+}
+
+impl CiliumNetworkEnforcer {
+    pub fn new(
+        client: Client,
+        namespace: String,
+        verify_timeout_secs: u64,
+        resolver_labels: Value,
+    ) -> Self {
+        Self {
+            cnps: Api::namespaced_with(client.clone(), &namespace, &cnp_resource()),
+            ceps: Api::namespaced_with(client.clone(), &namespace, &cep_resource()),
+            pods: Api::namespaced(client, &namespace),
+            namespace,
+            verify_timeout_secs,
+            resolver_labels,
+        }
+    }
+
+    /// Can this deployment actually use CiliumNetworkPolicy? The `auto`
+    /// detection, and the precondition check for explicit `cilium`.
+    ///
+    /// Probed by LISTING the resource in our own namespace rather than reading
+    /// the discovery document, because that answers the question we actually
+    /// care about: not "does the CRD exist somewhere" but "can we read and
+    /// therefore write the objects this enforcer depends on". An enforcer we
+    /// lack RBAC for is not an enforcer, and treating it as one would admit
+    /// grants that fail at provision.
+    ///
+    /// The two failure causes are logged distinctly — a missing CRD is a
+    /// cluster without Cilium, a 403 is a chart/RBAC misconfiguration — because
+    /// they need completely different fixes.
+    pub async fn detect(client: &Client, namespace: &str) -> bool {
+        let cnps: Api<DynamicObject> =
+            Api::namespaced_with(client.clone(), namespace, &cnp_resource());
+        match cnps.list(&kube::api::ListParams::default().limit(1)).await {
+            Ok(_) => true,
+            Err(kube::Error::Api(e)) if e.code == 404 => {
+                tracing::debug!("cilium.io/v2 CiliumNetworkPolicy is not served by this cluster");
+                false
+            }
+            Err(kube::Error::Api(e)) if e.code == 403 => {
+                tracing::warn!(
+                    "cilium.io/v2 exists but this ServiceAccount may not list \
+                     CiliumNetworkPolicy ({}). The chart grants it when \
+                     networkGrants.enabled=true — without it the deployment is offline-only.",
+                    e.message
+                );
+                false
+            }
+            Err(e) => {
+                tracing::warn!("probing for CiliumNetworkPolicy failed: {e}");
+                false
+            }
+        }
+    }
+
+    /// The per-run objects are named after the session, which is also the pod's
+    /// name — `GrantedNetwork::run_id` IS the session id (stamped in the
+    /// orchestrator), so one identifier addresses the pod, the policy, and the
+    /// endpoint.
+    fn object_name(g: &GrantedNetwork) -> String {
+        crate::manifest::object_name(g.run_id)
+    }
+
+    /// The condition the Cilium operator sets once it has accepted a policy
+    /// semantically. Absent means "not yet"; `False` means rejected.
+    fn policy_is_valid(obj: &DynamicObject) -> Option<bool> {
+        let conditions = obj.data.get("status")?.get("conditions")?.as_array()?;
+        conditions
+            .iter()
+            .find(|c| c.get("type").and_then(|t| t.as_str()) == Some("Valid"))
+            .and_then(|c| c.get("status").and_then(|s| s.as_str()))
+            .map(|s| s == "True")
+    }
+
+    /// A CiliumEndpoint is usable when it is `ready` AND carries a concrete
+    /// security identity. The identity is what a policy's `endpointSelector`
+    /// binds to, so an endpoint without one has nothing for the policy to
+    /// select — it would run under whatever the cluster-wide baseline says,
+    /// which is default-deny, but it is not the state we asked for.
+    fn endpoint_identity(obj: &DynamicObject) -> Option<i64> {
+        let status = obj.data.get("status")?;
+        if status.get("state").and_then(|s| s.as_str()) != Some("ready") {
+            return None;
+        }
+        status.get("identity")?.get("id")?.as_i64()
+    }
+}
+
+#[async_trait::async_trait]
+impl NetworkPolicyProvider for CiliumNetworkEnforcer {
+    /// Write the per-run policy, owned by the pod.
+    ///
+    /// The pod's UID is read here rather than threaded through the trait: it
+    /// keeps [`NetworkPolicyProvider`] free of Kubernetes concepts, and the pod
+    /// provably exists by now because the caller creates it first.
+    async fn prepare(&self, granted: &GrantedNetwork) -> Result<(), NetworkPolicyError> {
+        if !granted.grant.grants_egress() {
+            // Offline is the ABSENCE of an allow, delivered by the chart-static
+            // baseline's default-deny. Writing an empty policy would be noise,
+            // and a hazard if "empty egress" ever gained a permissive reading.
+            return Ok(());
+        }
+        let name = Self::object_name(granted);
+        let pod = self
+            .pods
+            .get(&name)
+            .await
+            .map_err(|e| NetworkPolicyError::Write(format!("pod {name} not found: {e}")))?;
+        let uid = pod
+            .metadata
+            .uid
+            .clone()
+            .ok_or_else(|| NetworkPolicyError::Write(format!("pod {name} has no uid")))?;
+
+        let ctx = netgrant::PolicyContext {
+            namespace: self.namespace.clone(),
+            resolver_labels: self.resolver_labels.clone(),
+            owner_pod_uid: uid,
+            owner_pod_name: name.clone(),
+        };
+        let Some(policy) = netgrant::build_run_policy(granted, granted.run_id, &ctx) else {
+            return Ok(());
+        };
+        let obj: DynamicObject = serde_json::from_value(policy)
+            .map_err(|e| NetworkPolicyError::Lowering(format!("bad policy manifest: {e}")))?;
+
+        match self.cnps.create(&Default::default(), &obj).await {
+            Ok(_) => Ok(()),
+            // Already there: `prepare` is idempotent so a retried provision does
+            // not fail on its own previous success.
+            Err(kube::Error::Api(e)) if e.code == 409 => Ok(()),
+            Err(e) => Err(NetworkPolicyError::Write(format!(
+                "creating the network policy for run {} failed: {e}",
+                granted.run_id
+            ))),
+        }
+    }
+
+    /// Prove — over the k8s API only — that the policy was accepted and the pod
+    /// has an identity for it to bind to. See the module docs for exactly what
+    /// this does and does not establish.
+    async fn verify(&self, granted: &GrantedNetwork) -> Result<(), NetworkPolicyError> {
+        let name = Self::object_name(granted);
+        let deadline = Instant::now() + Duration::from_secs(self.verify_timeout_secs.max(5));
+        // Carried out of the loop so a timeout can say WHICH half never
+        // converged — "unverified" with no detail is a support ticket.
+        let mut policy_state = "not created";
+        let mut endpoint_state = "no endpoint";
+
+        loop {
+            // An offline run has no policy object, so only the identity half
+            // applies: there is still a pod that must be a real endpoint under
+            // the default-deny baseline.
+            let policy_ok = if granted.grant.grants_egress() {
+                match self.cnps.get_opt(&name).await {
+                    Ok(Some(obj)) => match Self::policy_is_valid(&obj) {
+                        Some(true) => true,
+                        Some(false) => {
+                            // The operator REJECTED it. Waiting cannot help, so
+                            // fail immediately rather than burning the deadline.
+                            return Err(NetworkPolicyError::Unverified(format!(
+                                "Cilium rejected the network policy for run {} \
+                                 (status.conditions[Valid]=False)",
+                                granted.run_id
+                            )));
+                        }
+                        None => {
+                            policy_state = "accepted, awaiting operator validation";
+                            false
+                        }
+                    },
+                    Ok(None) => {
+                        policy_state = "not created";
+                        false
+                    }
+                    Err(e) => {
+                        return Err(NetworkPolicyError::Unverified(format!(
+                            "reading the network policy for run {} failed: {e}",
+                            granted.run_id
+                        )))
+                    }
+                }
+            } else {
+                policy_state = "n/a (offline)";
+                true
+            };
+
+            let identity_ok = match self.ceps.get_opt(&name).await {
+                Ok(Some(obj)) => match Self::endpoint_identity(&obj) {
+                    Some(id) => {
+                        // No state assignment: the success path returns before
+                        // the timeout message that reads it.
+                        tracing::debug!(run_id = %granted.run_id, identity = id, "endpoint identity");
+                        true
+                    }
+                    None => {
+                        endpoint_state = "endpoint exists but is not ready / has no identity";
+                        false
+                    }
+                },
+                Ok(None) => {
+                    endpoint_state = "no endpoint";
+                    false
+                }
+                Err(e) => {
+                    return Err(NetworkPolicyError::Unverified(format!(
+                        "reading the Cilium endpoint for run {} failed: {e}",
+                        granted.run_id
+                    )))
+                }
+            };
+
+            if policy_ok && identity_ok {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                // FAIL CLOSED. An unproven policy is treated exactly like a
+                // refused one — the run does not start.
+                return Err(NetworkPolicyError::Unverified(format!(
+                    "network enforcement for run {} was not verified within {}s \
+                     (policy: {policy_state}; endpoint: {endpoint_state})",
+                    granted.run_id, self.verify_timeout_secs
+                )));
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    async fn revoke(&self, granted: &GrantedNetwork) -> Result<(), NetworkPolicyError> {
+        let name = Self::object_name(granted);
+        match self.cnps.delete(&name, &DeleteParams::default()).await {
+            Ok(_) => Ok(()),
+            // Already gone — owner-reference GC may have collected it first.
+            // Idempotence matters: this runs from terminal cleanup, the abandon
+            // paths, and the reconcile sweep.
+            Err(kube::Error::Api(e)) if e.code == 404 => Ok(()),
+            Err(e) => Err(NetworkPolicyError::Write(format!(
+                "deleting the network policy for run {} failed: {e}",
+                granted.run_id
+            ))),
+        }
+    }
+
+    fn enforcer_name(&self) -> &'static str {
+        "cilium"
+    }
+
+    fn supports_egress_grants(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn obj(v: serde_json::Value) -> DynamicObject {
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn policy_validity_reads_the_operators_condition() {
+        // Accepted.
+        assert_eq!(
+            CiliumNetworkEnforcer::policy_is_valid(&obj(json!({
+                "apiVersion": "cilium.io/v2", "kind": "CiliumNetworkPolicy",
+                "metadata": {"name": "x"},
+                "status": {"conditions": [
+                    {"type": "Valid", "status": "True", "message": "Policy validation succeeded"}
+                ]}
+            }))),
+            Some(true)
+        );
+        // REJECTED — distinct from "not yet", because waiting cannot fix it.
+        assert_eq!(
+            CiliumNetworkEnforcer::policy_is_valid(&obj(json!({
+                "apiVersion": "cilium.io/v2", "kind": "CiliumNetworkPolicy",
+                "metadata": {"name": "x"},
+                "status": {"conditions": [{"type": "Valid", "status": "False"}]}
+            }))),
+            Some(false)
+        );
+        // Not yet judged: no status, empty status, or another condition only.
+        for v in [
+            json!({"apiVersion":"cilium.io/v2","kind":"CiliumNetworkPolicy","metadata":{"name":"x"}}),
+            json!({"apiVersion":"cilium.io/v2","kind":"CiliumNetworkPolicy","metadata":{"name":"x"},"status":{}}),
+            json!({"apiVersion":"cilium.io/v2","kind":"CiliumNetworkPolicy","metadata":{"name":"x"},
+                   "status":{"conditions":[{"type":"Other","status":"True"}]}}),
+        ] {
+            assert_eq!(CiliumNetworkEnforcer::policy_is_valid(&obj(v)), None);
+        }
+    }
+
+    #[test]
+    fn endpoint_identity_requires_ready_and_a_real_id() {
+        // The shape observed on a live 1.19.6 cluster during the Phase 0 spike.
+        assert_eq!(
+            CiliumNetworkEnforcer::endpoint_identity(&obj(json!({
+                "apiVersion": "cilium.io/v2", "kind": "CiliumEndpoint",
+                "metadata": {"name": "fluidbox-x"},
+                "status": {"state": "ready", "identity": {"id": 39493}}
+            }))),
+            Some(39493)
+        );
+        // Not ready yet → not usable, even with an identity.
+        assert_eq!(
+            CiliumNetworkEnforcer::endpoint_identity(&obj(json!({
+                "apiVersion": "cilium.io/v2", "kind": "CiliumEndpoint",
+                "metadata": {"name": "fluidbox-x"},
+                "status": {"state": "waiting-for-identity", "identity": {"id": 39493}}
+            }))),
+            None
+        );
+        // Ready but no identity → nothing for an endpointSelector to bind to.
+        assert_eq!(
+            CiliumNetworkEnforcer::endpoint_identity(&obj(json!({
+                "apiVersion": "cilium.io/v2", "kind": "CiliumEndpoint",
+                "metadata": {"name": "fluidbox-x"},
+                "status": {"state": "ready"}
+            }))),
+            None
+        );
+        // The EMPTY `status.policy` the Phase 0 spike found on 1.19.x must NOT
+        // be what this reads — an endpoint with a ready state and an identity
+        // verifies even though `status.policy` is `{}`, which is exactly the
+        // situation on every 1.19.x cluster.
+        assert_eq!(
+            CiliumNetworkEnforcer::endpoint_identity(&obj(json!({
+                "apiVersion": "cilium.io/v2", "kind": "CiliumEndpoint",
+                "metadata": {"name": "fluidbox-x"},
+                "status": {"state": "ready", "identity": {"id": 1}, "policy": {}}
+            }))),
+            Some(1)
+        );
+    }
+}

--- a/crates/fluidbox-provider-k8s/src/lib.rs
+++ b/crates/fluidbox-provider-k8s/src/lib.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 pub mod config;
+pub mod enforcer;
 pub mod manifest;
 pub mod netgrant;
 pub mod netpol;
@@ -52,13 +53,22 @@ const MAX_DIFF_BYTES: usize = 16 * 1024 * 1024;
 /// before parse_collected's integrity check decides on what arrived.
 const MAX_STREAM_RESUMES: u32 = 4;
 
+/// What the deployment asked for, before detection resolves it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkEnforcerMode {
+    None,
+    Cilium,
+    Auto,
+}
+
 pub struct KubernetesProvider {
     pods: Api<Pod>,
     secrets: Api<Secret>,
-    /// `cilium.io/v2` CiliumNetworkPolicy, as a dynamic resource — the CRD has
-    /// no typed Rust binding and pulling one in for four fields would be a
-    /// dependency we would then have to keep in step with Cilium's schema.
-    cnps: Api<kube::api::DynamicObject>,
+    /// The network-grant enforcer, when this deployment has one. `None` means
+    /// offline-only: `ExecutionProvider::network_enforcer` then answers with the
+    /// refusing `NoNetworkEnforcer`, so `create_run` refuses a wider grant at
+    /// creation instead of letting it fail here.
+    enforcer: Option<std::sync::Arc<crate::enforcer::CiliumNetworkEnforcer>>,
     cfg: K8sConfig,
     namespace: String,
     /// The control plane's data dir: pre-launch collection (no pod ever
@@ -75,84 +85,122 @@ impl KubernetesProvider {
         Ok(Self::with_client(client, cfg, data_dir))
     }
 
+    /// Connect and RESOLVE the network enforcer.
+    ///
+    /// `auto` asks the API server whether `cilium.io/v2` is served — not whether
+    /// a Helm release or a DaemonSet by some name exists, because what matters
+    /// is whether the resources the enforcer writes are real. A cluster that
+    /// answers no is offline-only and says so at boot, rather than admitting a
+    /// grant and failing at provision.
+    pub async fn connect_with_enforcer(
+        cfg: K8sConfig,
+        data_dir: PathBuf,
+        mode: NetworkEnforcerMode,
+        verify_timeout_secs: u64,
+    ) -> anyhow::Result<Self> {
+        let client = Client::try_default().await?;
+        let mut me = Self::with_client(client.clone(), cfg, data_dir);
+        let wanted = match mode {
+            NetworkEnforcerMode::None => false,
+            NetworkEnforcerMode::Cilium => true,
+            NetworkEnforcerMode::Auto => {
+                let found =
+                    crate::enforcer::CiliumNetworkEnforcer::detect(&client, &me.namespace).await;
+                tracing::info!(
+                    "network enforcer auto-detection: cilium.io/v2 {}",
+                    if found { "present" } else { "absent" }
+                );
+                found
+            }
+        };
+        if wanted {
+            // An explicit `cilium` that is NOT actually present is a boot
+            // refusal, not a silent downgrade: the operator asked for
+            // enforcement and must not get a deployment that quietly cannot
+            // deliver it.
+            if mode == NetworkEnforcerMode::Cilium
+                && !crate::enforcer::CiliumNetworkEnforcer::detect(&client, &me.namespace).await
+            {
+                anyhow::bail!(
+                    "FLUIDBOX_NETWORK_ENFORCER=cilium but this cluster does not serve                      cilium.io/v2 — install Cilium, or set the enforcer to 'none' to run                      offline-only"
+                );
+            }
+            let ns = me.namespace.clone();
+            let resolver = me.cfg.sandbox_resolver_labels();
+            me.enforcer = Some(std::sync::Arc::new(
+                crate::enforcer::CiliumNetworkEnforcer::new(
+                    client,
+                    ns,
+                    verify_timeout_secs,
+                    resolver,
+                ),
+            ));
+        }
+        Ok(me)
+    }
+
     pub fn with_client(client: Client, cfg: K8sConfig, data_dir: PathBuf) -> Self {
         let namespace = cfg.namespace.clone();
-        let cnp_resource = kube::api::ApiResource {
-            group: "cilium.io".into(),
-            version: "v2".into(),
-            api_version: "cilium.io/v2".into(),
-            kind: "CiliumNetworkPolicy".into(),
-            plural: "ciliumnetworkpolicies".into(),
-        };
         Self {
             pods: Api::namespaced(client.clone(), &namespace),
             secrets: Api::namespaced(client.clone(), &namespace),
-            cnps: Api::namespaced_with(client, &namespace, &cnp_resource),
+            // Constructed only when the caller has proven Cilium is present
+            // (`with_enforcer`); plain `with_client` stays offline-only so no
+            // existing call site silently gains an enforcer.
+            enforcer: None,
             cfg,
             namespace,
             data_dir,
         }
     }
 
-    /// Program the per-run `CiliumNetworkPolicy` for a grant, if it needs one.
+    /// Program the run's grant and PROVE it, before the pod can start.
     ///
-    /// An OFFLINE grant needs no object: offline is the ABSENCE of an allow,
-    /// delivered by the chart-static baseline's default-deny. A run with no
-    /// grant at all (resolved before governed networking) is offline too.
+    /// Both halves go through [`NetworkPolicyProvider`], so the ordering that
+    /// matters — program, then verify, and only then release the pod by
+    /// creating its Secret — is expressed once and is the same for any future
+    /// enforcer.
     ///
-    /// Fails closed: a rejected or unwritable policy aborts provisioning rather
-    /// than letting the pod start unenforced. A grant whose enforcement we
-    /// cannot program is a refused run, never a quiet downgrade.
-    async fn apply_run_policy(
-        &self,
-        spec: &SandboxSpec,
-        pod_name: &str,
-        pod_uid: &str,
-    ) -> Result<(), ProviderError> {
+    /// Fails closed on every axis. A grant we cannot program, or cannot prove
+    /// was programmed, is a refused run — never a quiet downgrade to whatever
+    /// the datapath happens to be doing.
+    async fn program_and_verify_network(&self, spec: &SandboxSpec) -> Result<(), ProviderError> {
         let Some(granted) = &spec.network_grant else {
             return Ok(());
         };
-        let ctx = netgrant::PolicyContext {
-            namespace: self.namespace.clone(),
-            resolver_labels: self.cfg.sandbox_resolver_labels(),
-            owner_pod_uid: pod_uid.to_string(),
-            owner_pod_name: pod_name.to_string(),
-        };
-        let Some(policy) = netgrant::build_run_policy(granted, spec.session_id, &ctx) else {
-            return Ok(());
-        };
-        let obj: kube::api::DynamicObject = serde_json::from_value(policy)
-            .map_err(|e| ProviderError::Other(format!("bad network policy manifest: {e}")))?;
-        // A structurally invalid policy is rejected by CRD schema validation at
-        // THIS call — which the Phase 0 spike confirmed is a hard API error, and
-        // is a better fail-closed signal than any status poll: there is no
-        // window in which a bad policy sits silently pending.
-        self.cnps
-            .create(&Default::default(), &obj)
+        let enforcer = self.network_enforcer();
+        enforcer
+            .prepare(granted)
             .await
-            .map_err(|e| {
-                ProviderError::Other(format!(
-                    "programming the network grant for {} failed: {e}",
-                    spec.session_id
-                ))
-            })?;
+            .map_err(|e| ProviderError::Other(e.to_string()))?;
+        // The control-plane half of the proof. The in-netns `netpol-gate` init
+        // container proves the other half from the pod's own network identity;
+        // both must hold. See `enforcer.rs` for exactly what each establishes —
+        // this one is policy-acceptance and identity-binding, NOT datapath
+        // realization, and nothing on the k8s API can prove the latter.
+        enforcer
+            .verify(granted)
+            .await
+            .map_err(|e| ProviderError::Other(e.to_string()))?;
         Ok(())
     }
 
-    /// Delete a run's network policy. Idempotent — a missing object is success,
-    /// because this is called from teardown paths that must be safe to retry.
-    /// Owner-reference GC is the primary collector; this is the prompt path and
-    /// the belt-and-braces one.
+    /// Surrender a run's network authority. Idempotent — it runs from terminal
+    /// cleanup, the abandon paths, and the reconcile sweep, all of which retry.
     pub async fn revoke_run_policy(&self, session_id: uuid::Uuid) -> Result<(), ProviderError> {
-        match self
-            .cnps
-            .delete(&netgrant::policy_name(session_id), &DeleteParams::default())
+        // `revoke` needs only the run identity; the tenant and the grant body
+        // are irrelevant to deleting an object named after the run, so a
+        // minimal descriptor is honest here rather than inventing a grant.
+        let granted = fluidbox_core::traits::GrantedNetwork {
+            grant: fluidbox_core::network::NetworkGrant::offline(),
+            tenant_id: uuid::Uuid::nil(),
+            run_id: session_id,
+            grant_digest: String::new(),
+        };
+        self.network_enforcer()
+            .revoke(&granted)
             .await
-        {
-            Ok(_) => Ok(()),
-            Err(kube::Error::Api(e)) if e.code == 404 => Ok(()),
-            Err(e) => Err(map_err(e)),
-        }
+            .map_err(|e| ProviderError::Other(e.to_string()))
     }
 
     /// Build the persisted handle. `workload_addrs` carries the Gap-6 workload
@@ -452,7 +500,7 @@ impl ExecutionProvider for KubernetesProvider {
         // holds container start until it does. So enforcement is programmed
         // strictly before any untrusted code, GC backstops cleanup, and this is
         // a one-step delta from the pre-existing Pod-then-Secret order.
-        if let Err(e) = self.apply_run_policy(spec, &name, &uid).await {
+        if let Err(e) = self.program_and_verify_network(spec).await {
             let _ = self.delete_pod(&name, Some(&uid)).await;
             return Err(e);
         }
@@ -682,6 +730,15 @@ impl ExecutionProvider for KubernetesProvider {
 
     fn workspace_transport(&self) -> WorkspaceTransport {
         WorkspaceTransport::Archive
+    }
+
+    fn network_enforcer(&self) -> &dyn fluidbox_core::traits::NetworkPolicyProvider {
+        match &self.enforcer {
+            Some(e) => e.as_ref(),
+            // No enforcer detected/configured: offline-only, and the refusing
+            // default says so at CREATE time rather than at provision.
+            None => &fluidbox_core::traits::NoNetworkEnforcer,
+        }
     }
 
     fn runtime_name(&self) -> &'static str {

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -235,11 +235,22 @@ async fn main() -> anyhow::Result<()> {
     // Sandbox network grants. Saying this at boot matters: with no enforcer the
     // deployment is offline-only and every non-offline run is REFUSED, which an
     // operator should learn here rather than from a 422 on their first run.
-    match cfg.network_enforcer {
-        config::NetworkEnforcer::None => tracing::info!(
-            "sandbox network grants: no enforcer (FLUIDBOX_NETWORK_ENFORCER=none) —              runs are offline-only and any wider grant is refused at create time"
-        ),
-        other => tracing::info!("sandbox network grants: enforcer '{}'", other.as_str()),
+    // Report the RESOLVED enforcer, which is what actually governs: `auto` has
+    // been decided by detection at connect time, and the provider is the thing
+    // that knows the answer.
+    let enforcer = provider.network_enforcer();
+    if enforcer.supports_egress_grants() {
+        tracing::info!(
+            "sandbox network grants: enforcer '{}' (requested: {})",
+            enforcer.enforcer_name(),
+            cfg.network_enforcer.as_str()
+        );
+    } else {
+        tracing::info!(
+            "sandbox network grants: NO enforcer resolved (requested: {}) — runs are \
+             offline-only and any wider grant is refused at create time",
+            cfg.network_enforcer.as_str()
+        );
     }
 
     let events_tx = fluidbox_db::spawn_listener(cfg.database_url.clone());

--- a/crates/fluidbox-server/src/netgrant.rs
+++ b/crates/fluidbox-server/src/netgrant.rs
@@ -370,7 +370,7 @@ async fn reverify_context(
         now: chrono::Utc::now(),
         run_wall_clock_secs: spec.budgets.max_wall_clock_secs,
         has_brokered_surfaces: !spec.brokered.is_empty(),
-        enforcement_available: state.cfg.network_enforcer != crate::config::NetworkEnforcer::None,
+        enforcement_available: state.provider.network_enforcer().supports_egress_grants(),
     };
     Ok(reverify_before_release(row, &current, &request, &ctx).err())
 }

--- a/crates/fluidbox-server/src/run_service.rs
+++ b/crates/fluidbox-server/src/run_service.rs
@@ -421,8 +421,11 @@ pub async fn create_run(
             // that also holds brokered tool results is refused unless policy
             // opts in.
             has_brokered_surfaces: !brokered.is_empty(),
-            enforcement_available: state.cfg.network_enforcer
-                != crate::config::NetworkEnforcer::None,
+            // Ask the PROVIDER, not the config: it is the thing that knows
+            // whether an enforcer actually resolved on this cluster. Config
+            // alone would admit a grant under `auto` with no Cilium present,
+            // or under `cilium` against the Docker provider.
+            enforcement_available: state.provider.network_enforcer().supports_egress_grants(),
         },
     )
     // Tail 3 — REFUSE. Nothing has been created; the reason is enumerated.

--- a/scripts/netgrant-kind-validation.sh
+++ b/scripts/netgrant-kind-validation.sh
@@ -440,6 +440,31 @@ if [ "$HEAVY" = "1" ]; then
   expect app "http://$DENIED_IP:9099/clientip" BLOCK "DNS rebinding: the grant does not follow a name to a new address"
 fi
 
+# ── The ENFORCER itself, against this live cluster ─────────────────────────
+#
+# Everything above applies policies with kubectl, which proves the OBJECT MODEL
+# but not the Rust that writes it. This runs the real `NetworkPolicyProvider`
+# implementation against this API server — including, most importantly, that
+# `verify()` fails closed rather than rubber-stamping.
+say "ENFORCER — the Rust implementation, live"
+if command -v cargo >/dev/null 2>&1; then
+  # Keyed on the EXIT CODE, not on grepping the output: the example prints
+  # colour, so a pattern spanning "0 failed" and "(enforcer)" matches across
+  # an ANSI escape and silently never fires. The exit code cannot lie.
+  cargo run --quiet -p fluidbox-provider-k8s --example enforcer_live -- "$NS" \
+    > "$WORK/enforcer.log" 2>&1
+  enf_rc=$?
+  sed 's/^/  /' "$WORK/enforcer.log"
+  if [ "$enf_rc" -eq 0 ]; then
+    epass=$(grep -oE "[0-9]+ passed" "$WORK/enforcer.log" | tail -1 | cut -d" " -f1)
+    ok "live enforcer checks passed (${epass:-?} assertions)"
+  else
+    no "live enforcer checks FAILED — see the output above"
+  fi
+else
+  no "cargo is required for the live enforcer checks (no skips)"
+fi
+
 say "RESULT"
 printf "  \033[1;32m%d passed\033[0m, \033[1;31m%d failed\033[0m\n" "$pass" "$fail"
 [ "$fail" -eq 0 ] || echo "  (a failure here is a DATAPATH failure — do not ship past it)"


### PR DESCRIPTION
Closes the two gaps [#121](https://github.com/hrishikeshdkakkad/fluidbox/pull/121)
shipped knowingly: `NetworkPolicyProvider` had only `NoNetworkEnforcer`, and
`verify()` was never called.

## What changed

`CiliumNetworkEnforcer` implements `prepare` / `verify` / `revoke`, and the
Kubernetes provider now drives all three **through the trait** instead of
inline. The ordering that matters is therefore expressed once and holds for any
future enforcer: create the Pod → program the policy → **prove it** → and only
then release the pod by creating its Secret.

## What `verify()` actually proves

The plan wanted `CiliumEndpoint.status.policy`. The Phase 0 spike falsified
that — it is empty on 1.19.x and the Helm knob that populated it no longer
exists. So this proves two things over the k8s API:

1. **The policy was accepted** — a structurally invalid one is rejected at the
   `create` call itself (a hard error, no silently-pending window), then the
   operator's `status.conditions[Valid]` confirms semantic acceptance.
2. **The pod has a real security identity** for the `endpointSelector` to bind to.

It does **not** prove datapath realization, and nothing on the k8s API does.
That stays with the in-netns `netpol-gate` init container. Both must hold;
either failing is fail-closed. The module docs say this plainly rather than
implying the check is stronger than it is.

## A fail-open in the previous wiring

`enforcement_available` was read off the **config**, so `auto` on a cluster
without Cilium — or `cilium` against the Docker provider — admitted the grant at
create time and only discovered the truth at provision. It now asks the
**provider**, via a new `ExecutionProvider::network_enforcer()` whose default
refuses anything above `offline`. A provider that has not opted in cannot admit
a grant it has no way to enforce, and an explicit `cilium` on a cluster that does
not serve `cilium.io/v2` is now a **boot refusal** rather than a silent
downgrade.

Detection probes by *listing* the resource in our own namespace rather than
reading the discovery document: an enforcer we lack RBAC for is not an enforcer.
404 (no Cilium) and 403 (chart/RBAC misconfiguration) are logged distinctly —
they need different fixes.

## Verification

`scripts/netgrant-kind-validation.sh` is **38/38** on real Cilium 1.19.6,
including 11 new live enforcer assertions run against the API server rather than
against fixtures. The ones that carry weight:

- **`verify()` fails closed when nothing is programmed** — if this rubber-stamped,
  every other assertion in the suite would be meaningless.
- **`verify()` fails again after `revoke()`**, proving it reads live state rather
  than caching an earlier success.
- `prepare()` and `revoke()` are both idempotent, so a retried provision does not
  fail on its own prior success.

A `--expect-absent` **negative control** now runs in the `kind-calico` job.
Only a cluster that genuinely lacks Cilium can prove detection says *no*; my
first attempt used a bogus namespace, which does not work — listing a CRD there
returns an empty list rather than a 404, so that assertion was testing
Kubernetes' namespace semantics, not ours.

934 unit tests, clippy clean, chart renders.

## Still not wired

Nothing feeds `netobserve` — there is no Hubble client yet, so the bounded
denied-flow logic and its three event kinds remain dormant. Phase 6 (EKS
acceptance) is still a runbook awaiting a trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9tnBiMKjbdwvqouve7h3A