### PR TITLE
fix(codex): gate numfmt/tac; settle the ./cat execpolicy residual (#15)

### DIFF
--- a/images/codex-runner/rules/default.rules
+++ b/images/codex-runner/rules/default.rules
@@ -1,30 +1,41 @@
 # fluidbox execpolicy — force EVERY exec through the fluidbox permission gate.
 #
 # codex `approval_policy="untrusted"` AUTO-RUNS its built-in is_known_safe_command
-# set (29 read/util basenames in 0.144.1) WITHOUT firing an approval request —
-# a class of exec that would never cross the fluidbox gate (no ledger, budget,
-# or policy). execpolicy has ONLY prefix_rule (no wildcard: an empty prefix
-# matches nothing), and its match is on the LITERAL first argv token, so we
-# enumerate (a) the complete known-safe basename set and (b) their absolute-path
-# spellings across the standard bin dirs. Strictest decision wins
+# set WITHOUT firing an approval request: a class of exec that would never cross
+# the fluidbox gate (no ledger, budget, or policy). We give every known-safe
+# basename a `prompt` rule below. Strictest decision wins
 # (forbidden > prompt > allow), so a `prompt` rule can only make codex ASK MORE.
-# The result: every listed spelling escalates to item/commandExecution/requestApproval,
-# which the supervisor answers via /permission.
+# The result: every known-safe exec escalates to item/commandExecution/requestApproval,
+# which the supervisor answers via /permission. (execpolicy has ONLY prefix_rule,
+# no wildcard: an empty prefix matches nothing, so the set must be enumerated.)
 #
-# COMPLETENESS (risk-register #1): the 29 basenames are the AUTHORITATIVE
-# 0.144.1 set (codex is the source); the exact version pin freezes it. The
-# reviewer confirmed codex reduces `/bin/cat`→`cat` for its classifier, so a
-# bare `cat` rule would NOT catch `/bin/cat` unless the app-server resolves
-# executables first — hence the absolute-path variants below, AND the e2e
-# tier-2 HARD-asserts that `cat`, `/bin/cat`, and `git status` all gate (the
-# tripwire: if a spelling slips, the assertion fails and blocks the release).
-# RESIDUAL (recorded): a relative-path spelling (`./cat`) of a known-safe READ
-# with a pre-planted executable in the workspace is not caught by prefix rules;
-# it is an ungoverned READ of a disposable, egress-free workspace (no mutation,
-# no egress) — bounded by the containment envelope. All 29 are reads; every
-# WRITE gates via item/fileChange/requestApproval regardless of spelling.
+# COMPLETENESS (risk-register #1): the known-safe set is the AUTHORITATIVE 0.144.1
+# set, and the source is codex itself
+# (codex-rs/shell-command/src/command_safety/is_safe_command.rs); the exact
+# version pin freezes it. It is 31 basenames on the Linux runner image: the 29
+# cross-platform reads PLUS `numfmt` and `tac`, which is_safe_command.rs gates
+# behind `cfg!(target_os = "linux")`. The sandbox is node:24-bookworm-slim, so
+# both auto-run there and MUST be listed. (numfmt/tac were absent before, so they
+# crossed no gate in any spelling; see the bare list below and issue #15.)
 #
-# Validate:  codex execpolicy check --pretty --rules default.rules -- cat x
+# SPELLINGS, SETTLED (rust-v0.144.1, by source + `codex execpolicy check`): the
+# app-server evaluates execpolicy with resolve_host_executables=true
+# (codex-rs/core/src/exec_policy.rs), which basename-resolves argv[0] before rule
+# lookup (codex-rs/execpolicy/src/policy.rs::match_host_executable_rules; a
+# relative path is first absolutized against the cwd). So `/bin/cat` and `./cat`
+# both resolve to `cat`, and ONE bare rule per basename gates EVERY spelling:
+# bare, absolute, AND relative. This CLOSES the previously-recorded `./cat`
+# residual (a relative spelling of a known-safe read IS caught, not ungoverned).
+# The absolute-path block further down is thus redundant belt-and-suspenders,
+# kept only to keep the enumeration explicit. scripts/e2e-codex.sh HARD-asserts
+# (via `codex execpolicy check` against these baked rules) that `git status`,
+# `./cat`, and the numfmt/tac spellings all gate (the tripwire: if a spelling
+# slips on a codex bump, the assertion fails and blocks the release). All
+# known-safe commands are reads; every WRITE gates via
+# item/fileChange/requestApproval regardless of spelling.
+#
+# Validate:  codex execpolicy check --resolve-host-executables --pretty \
+#              --rules default.rules -- ./cat x     # => decision "prompt"
 
 def prompt(cmd):
     prefix_rule(
@@ -42,9 +53,15 @@ def prompt(cmd):
     "printenv", "hostname", "file", "du", "df", "dirname", "basename", "realpath",
     "readlink", "tree", "diff", "cmp", "md5sum", "sha1sum", "sha256sum", "cksum", "jq",
     "yq", "xxd", "od", "strings", "column", "tee", "sh", "bash", "zsh",
+    # numfmt and tac are known-safe reads only on Linux (is_safe_command.rs,
+    # cfg!(target_os = "linux")). The sandbox image is Linux, so both auto-run
+    # there; without these rules they crossed no gate in any spelling (issue #15).
+    "numfmt", "tac",
 ]]
 
-# Absolute-path spellings of the known-safe basenames (bare rules miss these).
+# Absolute-path spellings of the known-safe basenames. REDUNDANT given
+# resolve_host_executables (a bare rule already catches these; see the header),
+# retained as explicit belt-and-suspenders.
 [prompt(c) for c in [
     "/bin/base64", "/usr/bin/base64", "/usr/local/bin/base64", "/sbin/base64",
     "/usr/sbin/base64", "/bin/cat", "/usr/bin/cat", "/usr/local/bin/cat", "/sbin/cat",
@@ -76,4 +93,7 @@ def prompt(cmd):
     "/sbin/wc", "/usr/sbin/wc", "/bin/which", "/usr/bin/which", "/usr/local/bin/which",
     "/sbin/which", "/usr/sbin/which", "/bin/whoami", "/usr/bin/whoami",
     "/usr/local/bin/whoami", "/sbin/whoami", "/usr/sbin/whoami",
+    "/bin/numfmt", "/usr/bin/numfmt", "/usr/local/bin/numfmt", "/sbin/numfmt",
+    "/usr/sbin/numfmt", "/bin/tac", "/usr/bin/tac", "/usr/local/bin/tac",
+    "/sbin/tac", "/usr/sbin/tac",
 ]]

--- a/scripts/e2e-codex.sh
+++ b/scripts/e2e-codex.sh
@@ -67,6 +67,41 @@ facade() { # llm-audience token, suffix, body -> "HTTP <code>"
 # ═══ TIER 1 — no-model parity probes ═══════════════════════════════════════
 say "TIER 1 — harness registry + facade dialect + canonical gate (no model)"
 
+# ── execpolicy gate-parity (issue #15): every codex known-safe read must gate ──
+# codex `approval_policy=untrusted` AUTO-RUNS its is_known_safe_command set
+# without asking, so each such basename needs a `prompt` rule or it bypasses the
+# gate. Assert it with codex's OWN checker, run INSIDE the pinned runner image
+# against the BAKED rules (no model, no key, no session). The app-server
+# evaluates approvals with resolve_host_executables=true (codex core
+# exec_policy.rs), so `--resolve-host-executables` here is faithful: one bare
+# rule must gate bare, absolute, AND relative spellings. This locks in the
+# Linux-only numfmt/tac coverage and the closed ./cat residual against codex
+# version drift. (execpolicy check evaluates the RULES layer only; the
+# "auto-run when unlisted" half lives in is_safe_command.rs, frozen by the pin.)
+CODEX_IMG="${FLUIDBOX_CODEX_SANDBOX_IMAGE:-fluidbox-codex-runner:dev}"
+# --rules path mirrors CODEX_HOME in images/codex-runner/Dockerfile.
+execpolicy_decision() { # argv... -> prompt|allow|forbidden|none
+  docker run --rm --entrypoint /opt/fluidbox-codex/node_modules/.bin/codex "$CODEX_IMG" \
+    execpolicy check --resolve-host-executables \
+      --rules /opt/fluidbox-codex/home/rules/default.rules -- "$@" 2>/dev/null \
+  | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("decision","none"))
+except Exception: print("none")'
+}
+while IFS='|' read -r elabel eargv; do
+  [ -z "$elabel" ] && continue
+  ED=$(execpolicy_decision ${eargv})
+  [ "$ED" = "prompt" ] && ok "execpolicy: $elabel gates (prompt)" \
+    || no "execpolicy: $elabel got '${ED}' (want prompt; an unlisted known-safe read auto-runs, bypassing /permission)"
+done <<'SPELLS'
+git status (control)|git status
+./cat (relative, residual closed)|./cat NOTE.txt
+numfmt (bare, #15)|numfmt 1000
+./numfmt (relative, planted-binary, #15)|./numfmt 1000
+tac (bare, #15)|tac NOTE.txt
+./tac (relative, planted-binary, #15)|./tac NOTE.txt
+SPELLS
+
 # per-harness defaults + validation
 A=$(mk_codex_agent codex-fixer)
 IMG=$(echo "$A" | j "['revision']['runner_image']"); MODEL=$(echo "$A" | j "['revision']['model']")
@@ -137,7 +172,7 @@ say "RESULT"
 # turn a token-grab miss into a recorded failure; this floor ALSO catches an
 # assertion line that gets accidentally dropped or skipped. It's a FLOOR (>=),
 # so adding assertions never trips it; it sits below the happy no-key count
-# (16) and above any token-miss remnant.
+# (22 after the 6 execpolicy gate-parity probes) and above any token-miss remnant.
 EXPECTED_MIN=15
 ran=$((pass + fail))
 [ "$ran" -ge "$EXPECTED_MIN" ] && ok "assertion-count tripwire ($ran ran ≥ $EXPECTED_MIN)" \


### PR DESCRIPTION
## What & why

Closes the gap behind #15, and settles the open question that issue recorded.

codex `approval_policy="untrusted"` auto-runs its built-in `is_known_safe_command` set without firing an approval, so every such basename needs a `prompt` rule in `default.rules` or it never crosses the fluidbox permission gate. At the pinned codex `0.144.1` that set is **31 basenames on Linux**, but the rules enumerated only **29**: `numfmt` and `tac` were missing.

They are gated in codex behind `cfg!(target_os = "linux")` (`codex-rs/shell-command/src/command_safety/is_safe_command.rs`, and the crate's own test asserts both auto-run on Linux). The runner is `node:24-bookworm-slim`, which ships both via coreutils, so this is reachable, not theoretical: `numfmt`/`tac` (in any spelling, including a workspace-planted `./numfmt`) auto-ran with **no ledger, budget, or policy** entry.

## The `./cat` residual in #15 is already closed (with evidence, not a key)

The header note in `default.rules` recorded that a relative spelling `./cat` of a known-safe read "is not caught by prefix rules." Reading the pinned codex source shows it **is** caught:

- the app-server evaluates approvals with `resolve_host_executables=true` (`codex-rs/core/src/exec_policy.rs`),
- which basename-resolves `argv[0]` before rule lookup (`codex-rs/execpolicy/src/policy.rs::match_host_executable_rules`); a relative path is absolutized against the cwd first (`utils/absolute-path`),
- so `/bin/cat` and `./cat` both resolve to `cat` and match the bare rule. The known-safe heuristic is only consulted when no rule matches.

So **one bare rule per basename gates every spelling** (bare, absolute, and relative), the recorded `./cat` residual is closed, and the absolute-path block is redundant belt-and-suspenders (kept; the header now says so). The maintainer's original validation command omitted `--resolve-host-executables`, which is why `./cat` looked unmatched.

## Changes

- **`images/codex-runner/rules/default.rules`** — add `numfmt`/`tac` (bare + absolute spellings), correct the `29` → `31` count, and rewrite the completeness/residual notes to reflect the source-verified behavior.
- **`scripts/e2e-codex.sh`** — a keyless regression tier that runs codex's own `execpolicy check --resolve-host-executables` inside the pinned image against the **baked** rules and asserts `git status`, `./cat`, and the `numfmt`/`tac` spellings all resolve to `prompt`.

## Testing

Validated with codex `0.144.1`'s `execpolicy check` against the edited rules:

| spelling | before | after |
|---|---|---|
| `numfmt 1000` / `./numfmt` / `/usr/bin/numfmt` | no match (auto-runs) | `prompt` |
| `tac x` / `./tac` / `/bin/tac` | no match (auto-runs) | `prompt` |
| `cat` / `./cat` / `git status` | `prompt` | `prompt` |

The new regression tier is red against the pre-fix rules (the four `numfmt`/`tac` spellings) and green after, with `git status`/`./cat` as controls. It runs in the existing `workflow_dispatch` `e2e` job (no-model tier, `E2E_SKIP_LIVE=1`), which already builds the codex image, so it adds coverage at zero model cost.

Note: `execpolicy check` exercises the rules layer; the "auto-run when unlisted" half lives in `is_safe_command.rs` and is frozen by the exact version pin, cited above.

## Scope

Bounded reads of a disposable, egress-free workspace, the same envelope #15 describes. All known-safe commands are reads; every write already gates via `item/fileChange/requestApproval` regardless of spelling. No Rust or dashboard changes. Sources read at tag `rust-v0.144.1`.
