### PR TITLE
fix(github-app): advisory-lock the installation lifecycle to close the sub-statement race (#16)

### DIFF
--- a/crates/fluidbox-db/src/lib.rs
+++ b/crates/fluidbox-db/src/lib.rs
@@ -1965,18 +1965,33 @@ pub async fn revoke_connection(
     id: Uuid,
 ) -> sqlx::Result<Option<IntegrationConnectionRow>> {
     let mut tx = scoped_tx(pool, scope).await?;
+    let out = revoke_connection_in_tx(&mut *tx, scope, id).await?;
+    tx.commit().await?;
+    Ok(out)
+}
 
-    let __rls_out = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+/// Executor-generic twin of [`revoke_connection`] for a caller already holding
+/// a `scoped_tx` + the (tenant, installation) advisory lock (issue #16): the
+/// per-installation revoke runs THROUGH that tx so it serializes against a
+/// concurrent approve/import on the same installation. The caller's `scoped_tx`
+/// has already set the RLS GUC — do NOT call this on a raw pool connection.
+pub async fn revoke_connection_in_tx<'e, E>(
+    exec: E,
+    scope: TenantScope,
+    id: Uuid,
+) -> sqlx::Result<Option<IntegrationConnectionRow>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_as(sqlx::AssertSqlSafe(format!(
         "update integration_connections set status = 'revoked', updated_at = now()
          where id = $1 and status <> 'revoked' and tenant_id = $2
          returning {CONNECTION_COLS}"
     )))
     .bind(id)
     .bind(scope.tenant_id())
-    .fetch_optional(&mut *tx)
-    .await?;
-    tx.commit().await?;
-    Ok(__rls_out)
+    .fetch_optional(exec)
+    .await
 }
 
 /// List connections through a visibility lens (design :274-296): `All` returns
@@ -3456,6 +3471,13 @@ pub async fn revoke_github_app_registration(
     id: Uuid,
 ) -> sqlx::Result<Option<Vec<Uuid>>> {
     let mut tx = scoped_tx(pool, scope).await?;
+    // issue #16: hold the registration advisory lock across the CAS + child
+    // cascade so a concurrent import/approve on any of this registration's
+    // installations (which takes the SAME lock, above the installation lock in
+    // the fixed order) cannot commit a live child under the registration we are
+    // revoking. Closes the "import landing just after a registration revoke"
+    // write skew (design §7.5); releases on commit/rollback.
+    acquire_github_app_registration_lock(&mut tx, id).await?;
     let reg = sqlx::query(
         "update github_app_registrations set status = 'revoked', updated_at = now()
          where id = $1 and status <> 'revoked' and tenant_id = $2",
@@ -3645,6 +3667,100 @@ pub async fn claim_github_app_flow(
     Ok(r.rows_affected() == 1)
 }
 
+// ─── GitHub App lifecycle advisory locks (issue #16) ────────────────────────
+//
+// The GitHub App lifecycle (setup/sync import, approve, per-installation and
+// registration revoke, webhook lifecycle) runs read-check-write sequences that,
+// before these locks, could interleave at sub-statement granularity under READ
+// COMMITTED (design 2026-07-11-github-seamless-connect-design.md §7.5): a fresh
+// import landing just after a registration revoke, or two imports of the same
+// installation racing an insert. Two lock domains, taken in a FIXED order to
+// avoid deadlock, REGISTRATION before INSTALLATION wherever both are held:
+//   * installation lock: serializes apply/approve/lifecycle/connection-revoke
+//     for ONE (tenant, installation).
+//   * registration lock: serializes the registration-wide revoke cascade
+//     against apply/approve. This is what closes the import-vs-registration-
+//     revoke write skew; the installation lock alone cannot, because the
+//     cascade touches every installation and takes no per-installation lock.
+
+/// Stable 64-bit advisory-lock key for a GitHub installation within a tenant,
+/// mirroring [`registration_lock_key`]'s sha256-fold over `tenant‖NUL‖id` (the
+/// NUL separator keeps `a‖bc` distinct from `ab‖c`).
+pub fn installation_lock_key(tenant: Uuid, installation_id: &str) -> i64 {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(tenant.as_bytes());
+    h.update([0u8]);
+    h.update(installation_id.as_bytes());
+    let d = h.finalize();
+    i64::from_be_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]])
+}
+
+/// Take a transaction-scoped advisory lock on (tenant, installation), serializing
+/// the per-installation lifecycle writes so a read-check-write sequence can no
+/// longer interleave with another actor on the same installation. Releases when
+/// `tx` commits or drops. Held BELOW the registration lock in the fixed order.
+pub async fn acquire_installation_lock(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    tenant: Uuid,
+    installation_id: &str,
+) -> sqlx::Result<()> {
+    sqlx::query("select pg_advisory_xact_lock($1)")
+        .bind(installation_lock_key(tenant, installation_id))
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Stable 64-bit advisory-lock key for a GitHub App registration. Uses a sha256
+/// fold over the FULL uuid (like [`registration_lock_key`] / [`installation_lock_key`])
+/// rather than [`oauth_lock_key`]'s leading-8-byte fold: registration ids are
+/// UUIDv7, whose leading bytes are a millisecond timestamp, so folding the head
+/// would make two registrations created in the same millisecond share a key and
+/// needlessly serialize their unrelated lifecycles. Hashing the full id spreads
+/// the key across the whole space.
+pub fn github_app_registration_lock_key(registration_id: Uuid) -> i64 {
+    use sha2::{Digest, Sha256};
+    let d = Sha256::digest(registration_id.as_bytes());
+    i64::from_be_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]])
+}
+
+/// Take a transaction-scoped advisory lock on a GitHub App registration,
+/// serializing the registration-wide revoke cascade against the per-installation
+/// import/approve paths. Held ABOVE the installation lock in the fixed order.
+pub async fn acquire_github_app_registration_lock(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registration_id: Uuid,
+) -> sqlx::Result<()> {
+    sqlx::query("select pg_advisory_xact_lock($1)")
+        .bind(github_app_registration_lock_key(registration_id))
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Read a GitHub App registration's current status THROUGH the caller's tx, used
+/// under the registration advisory lock to re-check freshness before an
+/// import/approve commits a live child under it. The caller's `scoped_tx` has
+/// already set the RLS GUC.
+pub async fn github_app_registration_status_in_tx<'e, E>(
+    exec: E,
+    scope: TenantScope,
+    id: Uuid,
+) -> sqlx::Result<Option<String>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let row: Option<(String,)> = sqlx::query_as(
+        "select status from github_app_registrations where id = $1 and tenant_id = $2",
+    )
+    .bind(id)
+    .bind(scope.tenant_id())
+    .fetch_optional(exec)
+    .await?;
+    Ok(row.map(|r| r.0))
+}
+
 /// Insert a seamless installation connection ONLY if the installation has
 /// never had a row of ANY status — the check rides inside the statement, so
 /// an insert can never land just after a concurrent revoke (F‑6: revoked
@@ -3662,8 +3778,39 @@ pub async fn create_github_app_connection_if_absent(
     registration_id: Uuid,
 ) -> sqlx::Result<Option<IntegrationConnectionRow>> {
     let mut tx = scoped_tx(pool, scope).await?;
+    let out = create_github_app_connection_if_absent_in_tx(
+        &mut *tx,
+        scope,
+        installation_id,
+        display_name,
+        metadata,
+        status,
+        registration_id,
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(out)
+}
 
-    let __rls_out = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+/// Executor-generic twin for a caller already holding a `scoped_tx` + the
+/// (tenant, installation) [+ registration] advisory locks (issue #16). Under
+/// those locks the `where not exists` insert can no longer race a concurrent
+/// import, and the caller has re-checked the registration status through the
+/// same tx, so an insert can never land under a just-revoked registration.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_github_app_connection_if_absent_in_tx<'e, E>(
+    exec: E,
+    scope: TenantScope,
+    installation_id: &str,
+    display_name: &str,
+    metadata: &Value,
+    status: &str,
+    registration_id: Uuid,
+) -> sqlx::Result<Option<IntegrationConnectionRow>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_as(sqlx::AssertSqlSafe(format!(
         // github_app connections are ALWAYS organization-owned (system custody
         // via the registration) — owner_type is stamped explicitly, never a
         // per-user personal connection.
@@ -3686,10 +3833,8 @@ pub async fn create_github_app_connection_if_absent(
     .bind(metadata)
     .bind(status)
     .bind(registration_id)
-    .fetch_optional(&mut *tx)
-    .await?;
-    tx.commit().await?;
-    Ok(__rls_out)
+    .fetch_optional(exec)
+    .await
 }
 
 /// The single live connection row for a GitHub installation, preferring a
@@ -3701,8 +3846,23 @@ pub async fn get_github_app_connection_by_installation(
     installation_id: &str,
 ) -> sqlx::Result<Option<IntegrationConnectionRow>> {
     let mut tx = scoped_tx(pool, scope).await?;
+    let out =
+        get_github_app_connection_by_installation_in_tx(&mut *tx, scope, installation_id).await?;
+    tx.commit().await?;
+    Ok(out)
+}
 
-    let __rls_out = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+/// Executor-generic twin for a caller holding the installation advisory lock
+/// (issue #16): the authoritative re-read runs THROUGH the locked tx.
+pub async fn get_github_app_connection_by_installation_in_tx<'e, E>(
+    exec: E,
+    scope: TenantScope,
+    installation_id: &str,
+) -> sqlx::Result<Option<IntegrationConnectionRow>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_as(sqlx::AssertSqlSafe(format!(
         "select {CONNECTION_COLS} from integration_connections
          where tenant_id = $1 and provider = 'github_app' and external_account_id = $2
          order by (status <> 'revoked') desc, created_at desc
@@ -3710,10 +3870,8 @@ pub async fn get_github_app_connection_by_installation(
     )))
     .bind(scope.tenant_id())
     .bind(installation_id)
-    .fetch_optional(&mut *tx)
-    .await?;
-    tx.commit().await?;
-    Ok(__rls_out)
+    .fetch_optional(exec)
+    .await
 }
 
 /// Guarded status transition: only fires when the current status is one of
@@ -3726,9 +3884,27 @@ pub async fn set_connection_status(
     allowed_from: &[&str],
 ) -> sqlx::Result<Option<IntegrationConnectionRow>> {
     let mut tx = scoped_tx(pool, scope).await?;
+    let out = set_connection_status_in_tx(&mut *tx, scope, id, status, allowed_from).await?;
+    tx.commit().await?;
+    Ok(out)
+}
 
+/// Executor-generic twin of [`set_connection_status`] for a caller holding a
+/// `scoped_tx` + the (tenant, installation) advisory lock (issue #16): the
+/// guarded CAS runs THROUGH that tx so it serializes against a concurrent
+/// approve/import/lifecycle on the same installation.
+pub async fn set_connection_status_in_tx<'e, E>(
+    exec: E,
+    scope: TenantScope,
+    id: Uuid,
+    status: &str,
+    allowed_from: &[&str],
+) -> sqlx::Result<Option<IntegrationConnectionRow>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
     let from: Vec<String> = allowed_from.iter().map(|s| s.to_string()).collect();
-    let __rls_out = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+    sqlx::query_as(sqlx::AssertSqlSafe(format!(
         "update integration_connections set status = $2, updated_at = now()
          where id = $1 and status = any($3) and tenant_id = $4
          returning {CONNECTION_COLS}"
@@ -3737,10 +3913,8 @@ pub async fn set_connection_status(
     .bind(status)
     .bind(&from)
     .bind(scope.tenant_id())
-    .fetch_optional(&mut *tx)
-    .await?;
-    tx.commit().await?;
-    Ok(__rls_out)
+    .fetch_optional(exec)
+    .await
 }
 
 /// Refresh the display metadata a setup/sync re-verification produced.
@@ -3752,7 +3926,23 @@ pub async fn refresh_connection_metadata(
     metadata: &Value,
 ) -> sqlx::Result<()> {
     let mut tx = scoped_tx(pool, scope).await?;
+    refresh_connection_metadata_in_tx(&mut *tx, scope, id, display_name, metadata).await?;
+    tx.commit().await?;
+    Ok(())
+}
 
+/// Executor-generic twin for a caller holding the installation advisory lock
+/// (issue #16): the metadata refresh runs THROUGH the locked tx.
+pub async fn refresh_connection_metadata_in_tx<'e, E>(
+    exec: E,
+    scope: TenantScope,
+    id: Uuid,
+    display_name: &str,
+    metadata: &Value,
+) -> sqlx::Result<()>
+where
+    E: sqlx::PgExecutor<'e>,
+{
     sqlx::query(
         "update integration_connections
          set display_name = $2, metadata = $3, updated_at = now()
@@ -3762,9 +3952,8 @@ pub async fn refresh_connection_metadata(
     .bind(display_name)
     .bind(metadata)
     .bind(scope.tenant_id())
-    .execute(&mut *tx)
+    .execute(exec)
     .await?;
-    tx.commit().await?;
     Ok(())
 }
 
@@ -14903,6 +15092,227 @@ mod tests {
             .unwrap();
         assert!(freed, "the lock is free after tx1 released");
         tx3.rollback().await.unwrap();
+    }
+
+    // ─── GitHub App lifecycle advisory locks (issue #16) ─────────────────────
+
+    // The (tenant, installation) advisory lock serializes the per-installation
+    // lifecycle writes: while one tx holds a key, a second cannot take the SAME
+    // key but CAN take a different one; it frees on transaction end.
+    #[tokio::test]
+    async fn installation_lock_serializes_same_key() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let pool = test_connect(&url).await.expect("connect");
+        let tenant = Uuid::now_v7();
+        let key = installation_lock_key(tenant, "123");
+        assert_ne!(
+            key,
+            installation_lock_key(tenant, "124"),
+            "distinct installations fold to distinct keys"
+        );
+        assert_ne!(
+            key,
+            installation_lock_key(Uuid::now_v7(), "123"),
+            "the same installation id under a different tenant is a different key"
+        );
+
+        let mut tx1 = pool.begin().await.unwrap();
+        acquire_installation_lock(&mut tx1, tenant, "123")
+            .await
+            .unwrap();
+        let mut c2 = pool.acquire().await.unwrap();
+        let (same,): (bool,) = sqlx::query_as("select pg_try_advisory_xact_lock($1)")
+            .bind(key)
+            .fetch_one(&mut *c2)
+            .await
+            .unwrap();
+        assert!(!same, "same (tenant, installation) key is held by tx1");
+        let (other,): (bool,) = sqlx::query_as("select pg_try_advisory_xact_lock($1)")
+            .bind(installation_lock_key(tenant, "124"))
+            .fetch_one(&mut *c2)
+            .await
+            .unwrap();
+        assert!(other, "a different installation key is independent");
+        drop(c2);
+        tx1.rollback().await.unwrap();
+        let mut tx3 = pool.begin().await.unwrap();
+        let (freed,): (bool,) = sqlx::query_as("select pg_try_advisory_xact_lock($1)")
+            .bind(key)
+            .fetch_one(&mut *tx3)
+            .await
+            .unwrap();
+        assert!(freed, "the lock is free after tx1 released");
+        tx3.rollback().await.unwrap();
+    }
+
+    #[test]
+    fn github_app_registration_lock_key_is_stable_and_distinct() {
+        let a = Uuid::now_v7();
+        let b = Uuid::now_v7();
+        assert_eq!(
+            github_app_registration_lock_key(a),
+            github_app_registration_lock_key(a),
+            "stable for one registration"
+        );
+        assert_ne!(
+            github_app_registration_lock_key(a),
+            github_app_registration_lock_key(b),
+            "distinct registrations fold to distinct keys"
+        );
+    }
+
+    // A fresh tenant + an ACTIVE github_app registration. Activation proper needs
+    // sealed key material we don't exercise here, so the status is flipped
+    // directly on the RLS-bypassing test pool.
+    async fn active_gh_reg(pool: &PgPool) -> (TenantScope, Uuid) {
+        let slug = format!("t-{}", Uuid::now_v7().simple());
+        let org = identity::create_org(pool, &slug, None).await.unwrap();
+        let scope = TenantScope::assume(org.id);
+        let reg = create_github_app_registration(pool, scope, "org", Some("acme"))
+            .await
+            .unwrap();
+        sqlx::query("update github_app_registrations set status = 'active' where id = $1")
+            .bind(reg.id)
+            .execute(pool)
+            .await
+            .unwrap();
+        (scope, reg.id)
+    }
+
+    // Mirrors apply_verified_installation's locked import critical section: one
+    // scoped_tx holds the registration + installation locks, re-checks the
+    // registration status, and only inserts if it is still live. Returns the new
+    // row, or None when the import was refused (registration revoked) or a row
+    // already existed.
+    async fn locked_import(
+        pool: &PgPool,
+        scope: TenantScope,
+        reg_id: Uuid,
+        installation_id: &str,
+    ) -> Option<IntegrationConnectionRow> {
+        let mut tx = scoped_tx(pool, scope).await.unwrap();
+        acquire_github_app_registration_lock(&mut tx, reg_id)
+            .await
+            .unwrap();
+        acquire_installation_lock(&mut tx, scope.tenant_id(), installation_id)
+            .await
+            .unwrap();
+        let status = github_app_registration_status_in_tx(&mut *tx, scope, reg_id)
+            .await
+            .unwrap();
+        if matches!(status.as_deref(), Some("revoked") | None) {
+            // Refuse: dropping tx rolls back, releasing both locks.
+            return None;
+        }
+        let created = create_github_app_connection_if_absent_in_tx(
+            &mut *tx,
+            scope,
+            installation_id,
+            "acme/repo",
+            &serde_json::json!({}),
+            "active",
+            reg_id,
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+        created
+    }
+
+    async fn live_children_under_revoked_registration(pool: &PgPool, reg_id: Uuid) -> i64 {
+        let (n,): (i64,) = sqlx::query_as(
+            "select count(*) from integration_connections c
+               join github_app_registrations r on r.id = c.registration_id
+              where r.id = $1 and r.status = 'revoked' and c.status <> 'revoked'",
+        )
+        .bind(reg_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        n
+    }
+
+    // Order A: a registration revoke commits first; a later import must observe
+    // the revoked status under the shared registration lock and refuse, so no
+    // live child is created under the revoked registration.
+    #[tokio::test]
+    async fn github_app_import_refused_after_registration_revoke() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let pool = test_connect(&url).await.expect("connect");
+        let (scope, reg_id) = active_gh_reg(&pool).await;
+
+        revoke_github_app_registration(&pool, scope, reg_id)
+            .await
+            .unwrap();
+        let created = locked_import(&pool, scope, reg_id, "77").await;
+        assert!(
+            created.is_none(),
+            "import must be refused under a revoked registration"
+        );
+        assert_eq!(
+            live_children_under_revoked_registration(&pool, reg_id).await,
+            0,
+            "no live connection may exist under a revoked registration"
+        );
+    }
+
+    // Order B + the concurrent race: an import that commits first is caught by
+    // the revoke cascade; and running import against revoke concurrently (both
+    // taking the shared registration lock) converges on the same invariant in
+    // either interleaving.
+    #[tokio::test]
+    async fn github_app_registration_revoke_wins_over_concurrent_import() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let pool = test_connect(&url).await.expect("connect");
+
+        // Order B (sequential): import first, then revoke cascades over it.
+        let (scope, reg_id) = active_gh_reg(&pool).await;
+        let created = locked_import(&pool, scope, reg_id, "88").await;
+        assert!(
+            created.is_some(),
+            "an import under an active registration creates a live row"
+        );
+        revoke_github_app_registration(&pool, scope, reg_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            live_children_under_revoked_registration(&pool, reg_id).await,
+            0,
+            "the revoke cascade caught the imported connection"
+        );
+
+        // Concurrent: race import against revoke on fresh registrations; the
+        // shared registration lock serializes them, so whichever wins, no live
+        // child survives under a revoked registration.
+        for i in 0..8u32 {
+            let (scope, reg_id) = active_gh_reg(&pool).await;
+            let iid = format!("c{i}");
+            let (p1, p2) = (pool.clone(), pool.clone());
+            let iid1 = iid.clone();
+            let importer =
+                tokio::spawn(async move { locked_import(&p1, scope, reg_id, &iid1).await });
+            let revoker = tokio::spawn(async move {
+                revoke_github_app_registration(&p2, scope, reg_id)
+                    .await
+                    .unwrap()
+            });
+            let _ = importer.await.unwrap();
+            let _ = revoker.await.unwrap();
+            assert_eq!(
+                live_children_under_revoked_registration(&pool, reg_id).await,
+                0,
+                "iteration {i}: no live child may survive under a revoked registration"
+            );
+        }
     }
 
     // ─── Connector OAuth flows (Phase D Task 4, #32 — invariant 20) ──────────

--- a/crates/fluidbox-server/src/connections.rs
+++ b/crates/fluidbox-server/src/connections.rs
@@ -595,9 +595,28 @@ pub async fn revoke(
     // Personal ⇒ owner-only (else 404); organization ⇒ admin/owner.
     let conn = connection_for_mutation(&state, &principal, id, "revoking").await?;
     let scope = principal.scope();
-    let row = fluidbox_db::revoke_connection(&state.pool, scope, conn.id)
-        .await?
-        .ok_or_else(|| ApiError::Conflict("connection is already revoked".into()))?;
+    // issue #16: revoking a github_app connection is a per-(tenant, installation)
+    // lifecycle write, so it takes the same advisory locks as apply/approve
+    // (fixed order: registration ABOVE installation) to serialize against a
+    // concurrent import/approve reviving the row. Other providers keep the plain
+    // single-statement revoke.
+    let revoked = match (conn.provider.as_str(), conn.registration_id) {
+        ("github_app", Some(reg_id)) => {
+            let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+            fluidbox_db::acquire_github_app_registration_lock(&mut tx, reg_id).await?;
+            fluidbox_db::acquire_installation_lock(
+                &mut tx,
+                scope.tenant_id(),
+                &conn.external_account_id,
+            )
+            .await?;
+            let out = fluidbox_db::revoke_connection_in_tx(&mut *tx, scope, conn.id).await?;
+            tx.commit().await?;
+            out
+        }
+        _ => fluidbox_db::revoke_connection(&state.pool, scope, conn.id).await?,
+    };
+    let row = revoked.ok_or_else(|| ApiError::Conflict("connection is already revoked".into()))?;
     state.metrics.connection_revocations.inc();
     // A cached installation/access token must not outlive the revocation.
     crate::oauth::invalidate_access(&state, row.id).await;
@@ -675,66 +694,77 @@ pub async fn approve(
     let login = inst["account"]["login"].as_str().unwrap_or("unknown");
     let suspended = inst["suspended_at"].is_string();
     let to = if suspended { "suspended" } else { "active" };
-    let row = match fluidbox_db::set_connection_status(
-        &state.pool,
+    // issue #16: take the registration + installation advisory locks (fixed
+    // order: registration ABOVE installation) and do the authoritative re-read +
+    // transition inside ONE scoped_tx. The registration lock is the same one
+    // revoke_github_app_registration holds, so a revoke can no longer interleave
+    // with this approve — which is what lets us drop the old compensating
+    // re-read/revert (design §7.5). The installation lock serializes against a
+    // concurrent import/lifecycle/connection-revoke on the same installation, so
+    // the reads above are advisory and this section is authoritative. The HTTP
+    // re-verify stays OUTSIDE the lock (above), so no pooled connection is held
+    // across a GitHub round-trip.
+    let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+    fluidbox_db::acquire_github_app_registration_lock(&mut tx, reg.id).await?;
+    fluidbox_db::acquire_installation_lock(&mut tx, scope.tenant_id(), &conn.external_account_id)
+        .await?;
+    // The registration must still be active under the lock: a revoke that
+    // committed before we acquired the lock is now visible, so refuse rather
+    // than activating a connection under a revoked registration.
+    if !matches!(
+        fluidbox_db::github_app_registration_status_in_tx(&mut *tx, scope, reg.id)
+            .await?
+            .as_deref(),
+        Some("active")
+    ) {
+        return Err(ApiError::Conflict(
+            "the github app registration was revoked during approval".into(),
+        ));
+    }
+    // Authoritative re-check of the collision the preflight flagged (now under
+    // the installation lock, so no other live row can appear): reviving a
+    // revoked row must not collide with a DIFFERENT live row.
+    if let Some(other) = fluidbox_db::get_github_app_connection_by_installation_in_tx(
+        &mut *tx,
+        scope,
+        &conn.external_account_id,
+    )
+    .await?
+    .filter(|c| c.id != conn.id && c.status != "revoked")
+    {
+        return Err(ApiError::Conflict(format!(
+            "installation {} is already live on connection {} — revoke that one first",
+            conn.external_account_id, other.id
+        )));
+    }
+    fluidbox_db::set_connection_status_in_tx(
+        &mut *tx,
         scope,
         conn.id,
         to,
         &["pending", "revoked", "suspended", "error"],
     )
-    .await
-    {
-        Ok(row) => row,
-        // Race-safe fallback for the preflight above.
-        Err(sqlx::Error::Database(e)) if e.is_unique_violation() => {
-            return Err(ApiError::Conflict(
-                "another live connection claimed this installation — revoke it first".into(),
-            ))
-        }
-        Err(e) => return Err(e.into()),
-    }
+    .await?
     .ok_or_else(|| ApiError::Conflict("connection changed state underneath".into()))?;
     // After the transition — the refresh skips revoked rows by design.
-    fluidbox_db::refresh_connection_metadata(
-        &state.pool,
+    fluidbox_db::refresh_connection_metadata_in_tx(
+        &mut *tx,
         scope,
-        row.id,
+        conn.id,
         &crate::github_app::installation_display(&reg, login),
         &crate::github_app::installation_metadata(&reg, &conn.external_account_id, login),
     )
     .await?;
+    let row = fluidbox_db::get_connection(&mut *tx, scope, conn.id)
+        .await?
+        .ok_or_else(|| ApiError::Conflict("connection changed state underneath".into()))?;
+    tx.commit().await?;
     // Reactivating a github_app connection does NOT bump the authorization
     // generation (unlike an OAuth reconnect): the installation id is a
     // positively proven stable identity, so the logical account is unchanged and
     // in-flight bindings stay valid. Only the cached installation token is
     // evicted so a re-mint picks up the reconciled state.
     crate::oauth::invalidate_access(&state, conn.id).await;
-    // Compensating check: a registration revoke racing this approve must
-    // win. Re-read AFTER our transition — if the registration flipped, the
-    // cascade either already caught our row (later writer) or we revert it
-    // here (we were the later writer). Either interleaving converges on
-    // revoked.
-    let reg_now = fluidbox_db::get_github_app_registration(&state.pool, scope, reg.id).await?;
-    if reg_now.map(|r| r.status != "active").unwrap_or(true) {
-        fluidbox_db::set_connection_status(
-            &state.pool,
-            scope,
-            conn.id,
-            "revoked",
-            &["active", "suspended"],
-        )
-        .await
-        .ok();
-        crate::oauth::invalidate_access(&state, conn.id).await;
-        return Err(ApiError::Conflict(
-            "the github app registration was revoked during approval".into(),
-        ));
-    }
-    let mut reload_tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
-    let row = fluidbox_db::get_connection(&mut *reload_tx, scope, row.id)
-        .await?
-        .ok_or_else(|| ApiError::Conflict("connection changed state underneath".into()))?;
-    reload_tx.commit().await?;
     Ok(Json(json!({ "connection": row })))
 }
 

--- a/crates/fluidbox-server/src/github_app.rs
+++ b/crates/fluidbox-server/src/github_app.rs
@@ -367,28 +367,6 @@ pub(crate) fn installation_metadata(
     })
 }
 
-/// Upsert the ONE live connection row for a verified installation.
-/// Scoped one-shot connection read for the reconcile paths. `get_connection` is
-/// executor-generic (Task 6), so under FORCE RLS its caller must supply a GUC'd
-/// executor; the tenant is known here (the registration/row scope), so open+commit
-/// a `scoped_tx`. Keeps the three reconcile reads from repeating the tx boilerplate.
-async fn reconcile_get_connection(
-    state: &AppState,
-    scope: fluidbox_db::TenantScope,
-    id: Uuid,
-) -> Result<Option<IntegrationConnectionRow>, String> {
-    let mut tx = fluidbox_db::scoped_tx(&state.pool, scope)
-        .await
-        .map_err(|e| format!("connection lookup failed: {e}"))?;
-    let row = fluidbox_db::get_connection(&mut *tx, scope, id)
-        .await
-        .map_err(|e| format!("connection lookup failed: {e}"))?;
-    tx.commit()
-        .await
-        .map_err(|e| format!("connection lookup failed: {e}"))?;
-    Ok(row)
-}
-
 /// `activate` distinguishes admin-intent paths (setup with a valid flow,
 /// sync) from discovery (installation.created webhook → pending). Revoked
 /// rows are never revived here — that is the explicit approve path — and a
@@ -415,77 +393,109 @@ async fn apply_verified_installation(
     // connection mutation here (works for both admin setup and unauthenticated
     // webhook/discovery callers, which resolve the registration first).
     let scope = fluidbox_db::TenantScope::assume(reg.tenant_id);
-    // Two attempts: losing the unique-index insert race re-enters the
-    // existing-row path so the surviving row still gets FULL custody
-    // validation and the caller's desired transition (e.g. a webhook's
-    // pending insert landing just before an admin setup's activate).
-    for attempt in 0..2 {
-        let existing = fluidbox_db::get_github_app_connection_by_installation(
-            &state.pool,
-            scope,
-            installation_id,
-        )
+    // issue #16: one scoped_tx holds the registration + installation advisory
+    // locks (fixed order: registration ABOVE installation) across the whole
+    // read-check-write. The installation lock makes the insert race impossible
+    // (so the old 0..2 retry loop is gone), and the registration lock — the same
+    // one revoke_github_app_registration takes — plus the in-tx registration
+    // re-check below stop a live child landing under a just-revoked registration
+    // (the "import landing just after a registration revoke" skew, design §7.5).
+    let mut tx = fluidbox_db::scoped_tx(&state.pool, scope)
         .await
         .map_err(|e| format!("connection lookup failed: {e}"))?;
-        if let Some(row) = existing {
-            if row.status == "revoked" {
-                return Err(
-                    "this installation was revoked in fluidbox — revive it from the dashboard (approve), or uninstall and reinstall on GitHub".into(),
-                );
-            }
-            if row.registration_id != Some(reg.id) {
-                return Err(
-                    "this installation is already connected through another fluidbox connection"
-                        .into(),
-                );
-            }
-            fluidbox_db::refresh_connection_metadata(
-                &state.pool,
-                scope,
-                row.id,
-                &display,
-                &metadata,
-            )
-            .await
-            .map_err(|e| format!("metadata refresh failed: {e}"))?;
-            // Unfiltered reads by design: github_app lifecycle reconciliation is
-            // driven by a verified webhook / registration JWT (no request
-            // principal), and github_app connections are always org-owned — no
-            // owner-visibility filter applies.
-            let updated = if row.status == desired {
-                reconcile_get_connection(state, scope, row.id).await?
-            } else {
-                let from: &[&str] = match desired {
-                    // Discovery never demotes an already-live row.
-                    "pending" => &[],
-                    "suspended" => &["active", "pending", "error"],
-                    _ => &["pending", "suspended", "error"],
-                };
-                if from.is_empty() {
-                    reconcile_get_connection(state, scope, row.id).await?
-                } else {
-                    fluidbox_db::set_connection_status(&state.pool, scope, row.id, desired, from)
-                        .await
-                        .map_err(|e| format!("status transition failed: {e}"))?
-                        .or(reconcile_get_connection(state, scope, row.id).await?)
-                }
-            };
-            if desired == "suspended" {
-                // Suspend/unsuspend reconciliation evicts the cached installation
-                // token but does NOT bump the authorization generation: the
-                // installation id is a positively proven stable identity, so the
-                // logical account is unchanged and in-flight bindings stay valid
-                // (unlike an OAuth reconnect, which may change the account).
-                crate::oauth::invalidate_access(state, row.id).await;
-            }
-            return updated.ok_or_else(|| "connection changed state underneath".into());
+    fluidbox_db::acquire_github_app_registration_lock(&mut tx, reg.id)
+        .await
+        .map_err(|e| format!("registration lock failed: {e}"))?;
+    fluidbox_db::acquire_installation_lock(&mut tx, reg.tenant_id, installation_id)
+        .await
+        .map_err(|e| format!("installation lock failed: {e}"))?;
+
+    // Re-read the registration status THROUGH the locked tx: a revoke that
+    // committed before we took the registration lock is now visible, so refuse
+    // rather than reviving/creating a live child under a revoked registration.
+    let reg_status = fluidbox_db::github_app_registration_status_in_tx(&mut *tx, scope, reg.id)
+        .await
+        .map_err(|e| format!("registration lookup failed: {e}"))?;
+    if matches!(reg_status.as_deref(), Some("revoked") | None) {
+        return Err(
+            "this GitHub App registration was revoked in fluidbox — reconnect it from the dashboard".into(),
+        );
+    }
+
+    // Unfiltered reads by design: github_app lifecycle reconciliation is driven
+    // by a verified webhook / registration JWT (no request principal), and
+    // github_app connections are always org-owned — no owner-visibility filter.
+    let existing = fluidbox_db::get_github_app_connection_by_installation_in_tx(
+        &mut *tx,
+        scope,
+        installation_id,
+    )
+    .await
+    .map_err(|e| format!("connection lookup failed: {e}"))?;
+    let (result_row, evict_conn): (IntegrationConnectionRow, Option<Uuid>) = if let Some(row) =
+        existing
+    {
+        if row.status == "revoked" {
+            return Err(
+                "this installation was revoked in fluidbox — revive it from the dashboard (approve), or uninstall and reinstall on GitHub".into(),
+            );
         }
-        // The never-existed check rides INSIDE the insert statement, so a
-        // fresh row can never land just behind a concurrent revoke (F‑6:
-        // revoked rows revive only via approve). None ⇒ some row appeared
-        // (any status) — loop back through the existing-row path above.
-        match fluidbox_db::create_github_app_connection_if_absent(
-            &state.pool,
+        if row.registration_id != Some(reg.id) {
+            return Err(
+                "this installation is already connected through another fluidbox connection".into(),
+            );
+        }
+        fluidbox_db::refresh_connection_metadata_in_tx(
+            &mut *tx, scope, row.id, &display, &metadata,
+        )
+        .await
+        .map_err(|e| format!("metadata refresh failed: {e}"))?;
+        let updated = if row.status == desired {
+            fluidbox_db::get_connection(&mut *tx, scope, row.id)
+                .await
+                .map_err(|e| format!("connection lookup failed: {e}"))?
+        } else {
+            let from: &[&str] = match desired {
+                // Discovery never demotes an already-live row.
+                "pending" => &[],
+                "suspended" => &["active", "pending", "error"],
+                _ => &["pending", "suspended", "error"],
+            };
+            if from.is_empty() {
+                fluidbox_db::get_connection(&mut *tx, scope, row.id)
+                    .await
+                    .map_err(|e| format!("connection lookup failed: {e}"))?
+            } else {
+                match fluidbox_db::set_connection_status_in_tx(
+                    &mut *tx, scope, row.id, desired, from,
+                )
+                .await
+                .map_err(|e| format!("status transition failed: {e}"))?
+                {
+                    Some(r) => Some(r),
+                    None => fluidbox_db::get_connection(&mut *tx, scope, row.id)
+                        .await
+                        .map_err(|e| format!("connection lookup failed: {e}"))?,
+                }
+            }
+        };
+        let updated = updated.ok_or_else(|| "connection changed state underneath".to_string())?;
+        // Suspend/unsuspend reconciliation evicts the cached installation token
+        // but does NOT bump the authorization generation: the installation id is
+        // a positively proven stable identity, so the logical account is
+        // unchanged and in-flight bindings stay valid (unlike an OAuth reconnect,
+        // which may change the account). Evicted AFTER commit, below.
+        let evict = if desired == "suspended" {
+            Some(row.id)
+        } else {
+            None
+        };
+        (updated, evict)
+    } else {
+        // No row and we hold the installation lock, so the insert cannot race a
+        // concurrent import; it returns the new row directly.
+        let created = fluidbox_db::create_github_app_connection_if_absent_in_tx(
+            &mut *tx,
             scope,
             installation_id,
             &display,
@@ -494,15 +504,17 @@ async fn apply_verified_installation(
             reg.id,
         )
         .await
-        {
-            Ok(Some(row)) => return Ok(row),
-            Ok(None) if attempt == 0 => continue,
-            Ok(None) => {}
-            Err(sqlx::Error::Database(e)) if e.is_unique_violation() && attempt == 0 => continue,
-            Err(e) => return Err(format!("connection create failed: {e}")),
-        }
+        .map_err(|e| format!("connection create failed: {e}"))?
+        .ok_or_else(|| "connection race did not settle — retry".to_string())?;
+        (created, None)
+    };
+    tx.commit()
+        .await
+        .map_err(|e| format!("connection commit failed: {e}"))?;
+    if let Some(id) = evict_conn {
+        crate::oauth::invalidate_access(state, id).await;
     }
-    Err("connection race did not settle — retry".into())
+    Ok(result_row)
 }
 
 // ─── Admin API ────────────────────────────────────────────────────────────
@@ -1361,6 +1373,28 @@ pub async fn app_ingress(
     }
 }
 
+/// A guarded status CAS for the webhook lifecycle handler, taken UNDER the
+/// (tenant, installation) advisory lock (issue #16) so it serializes against a
+/// concurrent import/approve on the same installation. The top-of-handler read
+/// stays advisory; this guarded CAS (its `allowed_from` set) is the authority,
+/// and the lock is what stops it interleaving with apply/approve's read+CAS.
+async fn locked_lifecycle_cas(
+    state: &AppState,
+    scope: fluidbox_db::TenantScope,
+    tenant: Uuid,
+    installation_id: &str,
+    id: Uuid,
+    status: &str,
+    allowed_from: &[&str],
+) -> sqlx::Result<Option<IntegrationConnectionRow>> {
+    let mut tx = fluidbox_db::scoped_tx(&state.pool, scope).await?;
+    fluidbox_db::acquire_installation_lock(&mut tx, tenant, installation_id).await?;
+    let out =
+        fluidbox_db::set_connection_status_in_tx(&mut *tx, scope, id, status, allowed_from).await?;
+    tx.commit().await?;
+    Ok(out)
+}
+
 async fn handle_lifecycle(
     state: &AppState,
     reg: &GithubAppRegistrationRow,
@@ -1432,9 +1466,11 @@ async fn handle_lifecycle(
         }
         L::Deleted { .. } => match owned {
             Some(c) => {
-                let done = match fluidbox_db::set_connection_status(
-                    &state.pool,
+                let done = match locked_lifecycle_cas(
+                    state,
                     scope,
+                    reg.tenant_id,
+                    &iid_str,
                     c.id,
                     "revoked",
                     &["active", "pending", "suspended", "error"],
@@ -1467,9 +1503,11 @@ async fn handle_lifecycle(
                         } else {
                             ("active", &["suspended"])
                         };
-                        let changed = match fluidbox_db::set_connection_status(
-                            &state.pool,
+                        let changed = match locked_lifecycle_cas(
+                            state,
                             scope,
+                            reg.tenant_id,
+                            &iid_str,
                             c.id,
                             to,
                             from,
@@ -1486,9 +1524,11 @@ async fn handle_lifecycle(
                     }
                     Ok(None) => {
                         // Installation vanished under us — treat as deleted.
-                        if let Err(e) = fluidbox_db::set_connection_status(
-                            &state.pool,
+                        if let Err(e) = locked_lifecycle_cas(
+                            state,
                             scope,
+                            reg.tenant_id,
+                            &iid_str,
                             c.id,
                             "revoked",
                             &["active", "pending", "suspended", "error"],
@@ -1503,9 +1543,11 @@ async fn handle_lifecycle(
                     Err(e) => {
                         if action == "suspend" {
                             // GitHub unreachable: fail toward closed.
-                            if let Err(db) = fluidbox_db::set_connection_status(
-                                &state.pool,
+                            if let Err(db) = locked_lifecycle_cas(
+                                state,
                                 scope,
+                                reg.tenant_id,
+                                &iid_str,
                                 c.id,
                                 "suspended",
                                 &["active"],


### PR DESCRIPTION
## What & why

Closes #16 (launch-blocker BLK-16). Implements the follow-up the design itself prescribes.

The GitHub App lifecycle runs read-check-write sequences across separate transactions. `docs/plans/2026-07-11-github-seamless-connect-design.md` §7.5 records the two skews that remain under READ COMMITTED:

> another import's commit+revoke landing inside one INSERT's snapshot, or an import landing just after a registration revoke

and prescribes the fix:

> `pg_advisory_xact_lock(hash(tenant, installation_id))` around apply/approve/revoke plus a registration lock in approve, with barrier-controlled interleaving tests.

The concrete hole: `create_github_app_connection_if_absent`'s `where not exists` (`fluidbox-db/src/lib.rs`) checks only for an existing **connection row**, never the registration's status. So an import that commits just after `revoke_github_app_registration`'s cascade snapshots the child set leaves a **live connection under a revoked registration**. The installation lock alone can't close this — the registration cascade is registration-wide and takes no per-installation lock.

## The locks

Two transaction-scoped advisory locks, always acquired **registration → installation** (fixed order, no cycle):

| Path | Locks |
|---|---|
| `apply_verified_installation` (import; no HTTP) | registration + installation |
| `approve` | registration + installation |
| `handle_lifecycle` Deleted / Suspend / Unsuspend | installation |
| `revoke_github_app_registration` | registration |
| `connections::revoke` (github_app) | registration + installation |
| `sync` | none directly — delegates to the locked `apply` |

Each critical section opens **one** `scoped_tx` (RLS GUC set once), takes the lock(s), and runs read → CAS/insert → metadata through that single pooled connection via new executor-generic `_in_tx` helpers — the same one-connection discipline `get_connection` / `oauth.rs` already use to avoid the fixed-pool deadlock. Outbound GitHub calls (`verify_installation`, `fetch_installation`) stay **outside** the lock.

`apply` re-reads the registration status **inside** the lock and refuses if it is revoked; that plus the shared registration lock is what closes the import-vs-revoke skew. With it in place, `apply` drops its `0..2` insert-retry loop and `approve` drops its compensating re-read/revert (`connections.rs`).

Key derivation follows the crate's conventions (`registration_lock_key`'s sha256-fold). The registration lock hashes the **full** uuid rather than folding the leading 8 bytes like `oauth_lock_key`: registration ids are UUIDv7, whose head is a millisecond timestamp, so a head-fold would make two registrations created in the same ms share a key and needlessly serialize their lifecycles (a test caught exactly this).

## Testing

New tests in `fluidbox-db` (self-skip without `DATABASE_URL`, per the crate's convention):

- `installation_lock_serializes_same_key` — hold/free semantics, and that the same installation id under a different tenant is a distinct key.
- `github_app_registration_lock_key_is_stable_and_distinct`.
- `github_app_import_refused_after_registration_revoke` — order A: revoke commits first, a later import observes the revoked status under the shared lock and refuses.
- `github_app_registration_revoke_wins_over_concurrent_import` — order B (import then revoke cascades over it) **plus** a concurrent `tokio::spawn` race over 8 fresh registrations; asserts no live child ever survives under a revoked registration in either interleaving.

The interleaving tests mirror `apply`'s locked critical section (the production section lives in the server crate). Verified against a local Postgres 16:

- Full suites green: `fluidbox-db` 147 passed, `fluidbox-server` 434 passed.
- `cargo clippy --all-targets -D warnings` and `cargo fmt --check` clean on both crates.
- **Negative control**: removing the registration lock from `revoke_github_app_registration` makes the concurrent test fail (a live child survives under a revoked registration), confirming the test detects the real race and the lock closes it.

I could not run `just e2e` (its GitHub phase needs the full Docker stack); CI's `workflow_dispatch` `e2e` job covers that.

## Scope & backstops

One logical change: the lifecycle locking + the executor-generic `_in_tx` helpers that enable it. No schema/migration (advisory locks are schema-free). The existing backstops are kept and unchanged: the partial unique index on live installation rows, the guarded `allowed_from` CAS, and the active-only credential readers. The failure modes were visible/fail-closed (not attacker-drivable, per the design), so this is a correctness/robustness fix ahead of multi-admin concurrency.
