### PR TITLE
fix(chart): the controlled resolver could not exec — grant it NET_BIND_SERVICE

### DIFF
--- a/deploy/helm/chart-assertions.sh
+++ b/deploy/helm/chart-assertions.sh
@@ -100,6 +100,18 @@ if render -f test-values/assert.yaml --set-string sandbox.nodeSelector.pool="a=b
 fi
 
 # ---------------------------------------------------------------------------
+# The controlled resolver must keep NET_BIND_SERVICE. Without it the container
+# cannot even exec (file capabilities + NO_NEW_PRIVS), so every granted run
+# loses DNS and `helm upgrade --wait` hangs. A render assertion is the only
+# cheap guard: the kind job's runtime does not reproduce the exec failure.
+dns="$(render --set networkGrants.enabled=true \
+  --set networkGrants.dnsClusterIP=172.20.0.53 -s templates/netgrant.yaml)"
+grep -qF 'add: ["NET_BIND_SERVICE"]' <<<"$dns" \
+  || fail "sandbox-dns lost NET_BIND_SERVICE — the resolver will fail to exec"
+grep -qF 'allowPrivilegeEscalation: false' <<<"$dns" \
+  || fail "sandbox-dns must keep allowPrivilegeEscalation: false"
+
+# ---------------------------------------------------------------------------
 # Every preset must lint and render.
 helm lint "$CHART" >/dev/null || fail "helm lint (default values)"
 for preset in "$CHART"/values/*.yaml; do

--- a/deploy/helm/fluidbox/templates/netgrant.yaml
+++ b/deploy/helm/fluidbox/templates/netgrant.yaml
@@ -215,6 +215,23 @@ spec:
             runAsUser: 65532
             capabilities:
               drop: ["ALL"]
+              # NET_BIND_SERVICE is REQUIRED, not hardening slack. The resolver
+              # binds :53 — a privileged port — as uid 65532, which the image
+              # supports by shipping /coredns with the `cap_net_bind_service`
+              # FILE capability. Dropping ALL while `allowPrivilegeEscalation:
+              # false` sets NO_NEW_PRIVS makes the kernel refuse to exec a
+              # binary carrying file capabilities at all: the container dies
+              # instantly with `exec /coredns: operation not permitted`, every
+              # granted run loses DNS, and `helm upgrade --wait` hangs until it
+              # times out. Observed on EKS/AL2023 arm64 2026-08-04; the kind
+              # job does not reproduce it, so the render assertion below is
+              # what keeps it fixed.
+              #
+              # This does NOT weaken the sandbox: the capability lets a process
+              # bind a low port, nothing more, and it is added to the RESOLVER
+              # — a forward-only CoreDNS in the control-plane namespace — never
+              # to a sandbox. allowPrivilegeEscalation stays false.
+              add: ["NET_BIND_SERVICE"]
           livenessProbe:
             httpGet: { path: /health, port: 8080 }
             initialDelaySeconds: 10


### PR DESCRIPTION
Found while bringing up governed network access on the live Fluidbox Cloud EKS
cluster (Cilium, AL2023 arm64) on 2026-08-04.

## The failure

`networkGrants.enabled=true` renders the controlled CoreDNS resolver. On a real
cluster it never starts:

```
exec /coredns: operation not permitted
```

CrashLoopBackOff on every replica, and because the resolver is in the release,
`helm upgrade --wait` hangs until its timeout. Every granted run would have lost
DNS.

## Why

CoreDNS binds `:53`, a privileged port, as uid 65532. The image supports that by
shipping `/coredns` with the `cap_net_bind_service` **file capability**. The pod
dropped `ALL` capabilities while `allowPrivilegeEscalation: false` sets
`NO_NEW_PRIVS` — and the kernel refuses to exec a binary carrying file
capabilities under that combination. The process never got as far as binding.

## The fix

`add: ["NET_BIND_SERVICE"]`, which is what upstream CoreDNS manifests do.

This does not weaken the sandbox. The capability permits binding a low port and
nothing else; it is added to the **resolver** — a forward-only CoreDNS in the
control-plane namespace, with no `kubernetes` plugin — never to a sandbox; and
`allowPrivilegeEscalation` stays `false`.

## Why the guard is a render assertion

The kind job does not reproduce the exec refusal — it depends on the runtime and
kernel underneath. So `deploy/helm/chart-assertions.sh` now asserts both that the
capability is present and that `allowPrivilegeEscalation` stays false. I verified
it is not decorative by deleting the line and watching the assertion fail, then
restoring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjQauzNGJ6fhXdodTc7DgB