### PR TITLE
feat(web): make an agent's declared egress visible, and declarable at creation

### DIFF
--- a/apps/web/app/app/agents/page.tsx
+++ b/apps/web/app/app/agents/page.tsx
@@ -30,7 +30,13 @@ import {
   draftToInput,
 } from "../../components/WorkspacePicker";
 import { TargetRuleEditor } from "../../components/TargetRuleEditor";
-import { MODE_LABEL, MODE_ORDER, networkOf } from "../../lib/network";
+import {
+  MODE_LABEL,
+  MODE_ORDER,
+  networkOf,
+  requestOf,
+  summarizeRequest,
+} from "../../lib/network";
 
 export default function AgentsPage() {
   return (
@@ -79,6 +85,27 @@ function Agents() {
     const first = window.setTimeout(() => void load(), 0);
     return () => clearTimeout(first);
   }, [load]);
+
+  // Warm the revisions for every agent so the collapsed row can state what the
+  // agent DECLARES. `GET /agents` carries only id/name/description, so without
+  // this the declaration is invisible until you expand — which is how an agent
+  // silently sat offline. O(agents) cached GETs on mount; a failure is
+  // deliberately silent because the row renders nothing rather than guessing.
+  useEffect(() => {
+    let live = true;
+    for (const a of agents) {
+      if (revs[a.id]) continue;
+      void loadRevs(a.id).catch(() => {
+        if (!live) return;
+      });
+    }
+    return () => {
+      live = false;
+    };
+    // `revs` is intentionally absent: including it would re-run on every load
+    // and re-request agents already in flight.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agents, loadRevs]);
 
   const toggle = async (id: string) => {
     if (open === id) {
@@ -194,7 +221,18 @@ function Agents() {
                     <span className="mono" style={{ fontSize: 12.5, color: "var(--accent)" }}>
                       {a.name}
                     </span>
-                    <span className="task mut">{a.description || "—"}</span>
+                    <span className="task mut">
+                      {a.description || "—"}
+                      {/* The current revision's declaration, stated where an
+                          operator actually looks. Rendered only once the
+                          revisions are known — an unknown declaration shows
+                          nothing rather than claiming "Offline". */}
+                      {revs[a.id]?.[0] && (
+                        <span className="chip" style={{ marginLeft: 8 }}>
+                          network <b>{summarizeRequest(requestOf(revs[a.id][0].network))}</b>
+                        </span>
+                      )}
+                    </span>
                   </button>
                   {open === a.id && (
                     <div
@@ -235,6 +273,9 @@ function Agents() {
                               bundles <b>{bundleRefsLabel(r.capability_bundles)}</b>
                             </span>
                           )}
+                          <span className="chip">
+                            network <b>{summarizeRequest(requestOf(r.network))}</b>
+                          </span>
                           <span className="chip">image {short(r.runner_image, 24)}</span>
                         </div>
                       ))}

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -11,13 +11,15 @@ import {
   ConnectionRequirement,
   connectionMatchesConnector,
   isToolConnection,
+  NetworkGrantMode,
   NetworkRequest,
   ownerBadge,
   PolicySummary,
   Revision,
   TriggerSubscription,
 } from "../lib/api";
-import { MODE_LABEL } from "../lib/network";
+import { MODE_LABEL, MODE_ORDER, OFFLINE_REQUEST } from "../lib/network";
+import { TargetRuleEditor } from "./TargetRuleEditor";
 import { AddServerWizard } from "../app/capabilities/AddServerWizard";
 import { defaultModelFor, modelsFor, useHarnesses } from "../lib/harnesses";
 import { CopyBlock, TemplateChips } from "./AutomationContract";
@@ -85,6 +87,9 @@ interface RunComposerDraft {
   /** The per-run "offline only" narrowing; optional so pre-narrowing drafts
    *  still validate (no `version` bump, no validator requirement). */
   offlineOnly?: boolean;
+  /** The new agent's declared egress. Optional for the same reason as
+   *  `offlineOnly`: drafts stored before this field must still validate. */
+  agentNetwork?: NetworkRequest;
 }
 
 function isRunComposerDraft(value: unknown): value is RunComposerDraft {
@@ -162,6 +167,11 @@ export function RunComposer({
   // shreds the revision into the fields above (see the revision effect).
   const [offlineOnly, setOfflineOnly] = useState(false);
   const [declaredNetwork, setDeclaredNetwork] = useState<NetworkRequest | null>(null);
+  // The NEW agent's declaration. Distinct from `declaredNetwork` above, which
+  // is what an EXISTING agent already declares: this one is authored here,
+  // because agent creation had no way to declare egress and a created agent
+  // therefore started offline with nothing on screen saying so.
+  const [agentNetwork, setAgentNetwork] = useState<NetworkRequest>(OFFLINE_REQUEST);
 
   const [newAgentName, setNewAgentName] = useState("");
   const [description, setDescription] = useState("");
@@ -262,13 +272,14 @@ export function RunComposer({
       pubCheck,
       capabilityKeepList,
       offlineOnly,
+      agentNetwork,
     }),
     [
       mode, task, autonomous, agentChoice, selectedAgentName, revisionTouched, newAgentName,
       description, harness, model, systemPrompt, policyName, policyOverride, workspace, pins, requirements, bindings, kind,
       automationName, allowTask, allowWorkspace, callbackUrl, concurrency, cron, timezone,
       missedPolicy, connection, repositories, evOpened, evReopened, evSync, pubComment, pubCheck,
-      capabilityKeepList, offlineOnly,
+      capabilityKeepList, offlineOnly, agentNetwork,
     ]
   );
   // Loading an existing revision is not user input. Only persist agent fields
@@ -305,6 +316,7 @@ export function RunComposer({
     !pubComment ||
     pubCheck ||
     offlineOnly ||
+    agentNetwork.mode !== "offline" ||
     capabilityKeepList.trim().length > 0;
   const restoreDraft = useCallback((saved: RunComposerDraft) => {
     if (!isRunComposerDraft(saved)) return;
@@ -343,6 +355,7 @@ export function RunComposer({
     setPubCheck(saved.pubCheck);
     setCapabilityKeepList(saved.capabilityKeepList);
     setOfflineOnly(saved.offlineOnly ?? false);
+    setAgentNetwork(saved.agentNetwork ?? OFFLINE_REQUEST);
   }, []);
   const clearDraft = useSessionDraft({
     key: draftKey,
@@ -680,6 +693,10 @@ export function RunComposer({
           // embedded add-server flow); the server revalidates each. Omitted when
           // empty so plain agents are unaffected.
           ...(requirements.length > 0 ? { connection_requirements: requirements } : {}),
+          // WYSIWYG, like the fields above: an omitted `network` means offline
+          // server-side, so sending it explicitly is what makes the control on
+          // screen the thing that actually takes effect.
+          network: agentNetwork,
         });
         createdAgent = response.agent;
         runAgentName = response.agent.name;
@@ -1568,6 +1585,55 @@ export function RunComposer({
                 </details>
               )}
             </>
+          </ComposerSection>
+        )}
+
+        {agentOnly && agentChoice === "new" && (
+          <ComposerSection
+            index={5}
+            title="Network access"
+            hint="Where sandboxes running this agent may reach."
+          >
+            <p className="helper" style={{ marginBottom: 6 }}>
+              This is the agent&rsquo;s <strong>declaration</strong>. The governing policy caps it,
+              and a single run may narrow it further — never widen it. Left at Offline, the agent
+              has no egress at all.
+            </p>
+            <label className="field">
+              <span className="lab">Mode</span>
+              <select
+                className="inp"
+                value={agentNetwork.mode}
+                onChange={(e) => {
+                  const nextMode = e.target.value as NetworkGrantMode;
+                  // A public declaration must carry NO targets — core refuses
+                  // that pairing as a narrowing the datapath would not apply.
+                  setAgentNetwork({
+                    ...agentNetwork,
+                    mode: nextMode,
+                    targets: nextMode === "public" ? [] : agentNetwork.targets,
+                  });
+                }}
+              >
+                {MODE_ORDER.map((m) => (
+                  <option key={m} value={m}>
+                    {MODE_LABEL[m]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {agentNetwork.mode === "approved" && (
+              <TargetRuleEditor
+                value={agentNetwork.targets}
+                onChange={(targets) => setAgentNetwork({ ...agentNetwork, targets })}
+              />
+            )}
+            {agentNetwork.mode === "public" && (
+              <p className="helper">
+                A public declaration carries no targets — it reaches everything the
+                deployment&rsquo;s deny wall permits.
+              </p>
+            )}
           </ComposerSection>
         )}
 

--- a/apps/web/app/lib/network.test.ts
+++ b/apps/web/app/lib/network.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { PolicyContent, TargetRule } from "./api";
+import { NetworkRequest, PolicyContent, TargetRule } from "./api";
 import {
   describeTarget,
   MODE_ORDER,
   networkOf,
   OFFLINE_NETWORK,
+  OFFLINE_REQUEST,
   portsLabel,
+  requestOf,
+  summarizeRequest,
 } from "./network";
 
 const base = { name: "p" } as unknown as PolicyContent;
@@ -74,5 +77,51 @@ describe("mode ordering", () => {
     // Pinned because the selectors render in this order and a reader will
     // take the order as meaning "increasingly permissive". It does.
     expect(MODE_ORDER).toEqual(["offline", "approved", "public"]);
+  });
+});
+
+describe("requestOf", () => {
+  it("reads an absent revision declaration as offline, never as unknown", () => {
+    // The server documents `network` on a revision as "omitted means offline"
+    // (api.rs), so an absent field is a FACT, not a gap — unlike a policy read
+    // that FAILED, which must stay unknown.
+    expect(requestOf(undefined)).toEqual(OFFLINE_REQUEST);
+    expect(requestOf(null)).toEqual(OFFLINE_REQUEST);
+    expect(requestOf(OFFLINE_REQUEST).mode).toBe("offline");
+  });
+
+  it("returns the stored declaration untouched when present", () => {
+    const r: NetworkRequest = { mode: "public", targets: [], duration_secs: null };
+    expect(requestOf(r)).toBe(r);
+  });
+});
+
+describe("summarizeRequest", () => {
+  it("names the mode for offline and public, which carry no targets", () => {
+    expect(summarizeRequest({ mode: "offline", targets: [], duration_secs: null })).toBe("Offline");
+    expect(summarizeRequest({ mode: "public", targets: [], duration_secs: null })).toBe("Public");
+  });
+
+  it("counts targets under approved, singular and plural", () => {
+    const t: TargetRule = {
+      kind: "dns",
+      pattern: { kind: "exact", name: "pypi.org" },
+      ports: [{ from: 443, to: 443 }],
+      protocol: "tcp",
+    };
+    expect(summarizeRequest({ mode: "approved", targets: [t], duration_secs: null })).toBe(
+      "Approved targets · 1 target",
+    );
+    expect(summarizeRequest({ mode: "approved", targets: [t, t], duration_secs: null })).toBe(
+      "Approved targets · 2 targets",
+    );
+  });
+
+  it("says an approved declaration with no targets grants nothing", () => {
+    // Not cosmetic: approved+[] is inert, and reading it as plain "Approved
+    // targets" would suggest the agent has egress it does not have.
+    expect(summarizeRequest({ mode: "approved", targets: [], duration_secs: null })).toBe(
+      "Approved targets · none yet",
+    );
   });
 });

--- a/apps/web/app/lib/network.ts
+++ b/apps/web/app/lib/network.ts
@@ -1,7 +1,14 @@
 // Presentation helpers for sandbox network grants. Formatting and ordering
 // ONLY — what a policy MEANS is resolved server-side by /policies/preview.
 
-import { NetworkGrantMode, NetworkPolicy, PolicyContent, PortSpec, TargetRule } from "./api";
+import {
+  NetworkGrantMode,
+  NetworkPolicy,
+  NetworkRequest,
+  PolicyContent,
+  PortSpec,
+  TargetRule,
+} from "./api";
 
 /** The fail-safe section a policy has when it has never configured egress. */
 export const OFFLINE_NETWORK: NetworkPolicy = {
@@ -48,4 +55,28 @@ export function describeTarget(t: TargetRule): string {
         ? t.pattern.name
         : `*.${t.pattern.suffix}`;
   return `${where} ${t.protocol.toUpperCase()} ${portsLabel(t.ports)}`;
+}
+
+/** What a revision declares when it declares nothing. The server documents the
+ *  field as "omitted means offline" (api.rs), so an ABSENT declaration is a
+ *  known fact — unlike a policy read that FAILED, which must stay "unknown". */
+export const OFFLINE_REQUEST: NetworkRequest = {
+  mode: "offline",
+  targets: [],
+  duration_secs: null,
+};
+
+/** Every read of a revision's declaration goes through this, for the same
+ *  reason `networkOf` exists for a policy: the field is routinely absent. */
+export function requestOf(network: NetworkRequest | null | undefined): NetworkRequest {
+  return network ?? OFFLINE_REQUEST;
+}
+
+/** One line for a chip or a header row. `approved` carries its target count
+ *  because an approved declaration with NO targets grants nothing, and
+ *  rendering it as a bare "Approved targets" would imply egress it lacks. */
+export function summarizeRequest(n: NetworkRequest): string {
+  if (n.mode !== "approved") return MODE_LABEL[n.mode];
+  if (n.targets.length === 0) return `${MODE_LABEL[n.mode]} \u00b7 none yet`;
+  return `${MODE_LABEL[n.mode]} \u00b7 ${n.targets.length} target${n.targets.length === 1 ? "" : "s"}`;
 }


### PR DESCRIPTION
Three gaps that together made an agent's network declaration effectively invisible.

1. **The agents list showed no network at all.** Revision rows carried chips for harness, model, prompt, workspace, bundles and image — but not network. The declaration is now on every revision chip *and* on the collapsed agent row. `GET /agents` returns only id/name/description, so the page warms each agent's revisions on mount; until they load the row renders nothing rather than claiming "Offline" — the same fail-safe the ceiling display uses.

2. **The declaration was readable only inside "Add revision"** — a form for authoring the *next* revision. You could not read the current value without looking like you were about to change it.

3. **"New Agent" could not declare egress at all.** The section was gated `!agentOnly` and `POST /agents` sent no `network`; the server treats an omitted field as offline, so every agent created that way started offline silently, and the only remedy was Agents → Add revision afterwards. The new-agent control is a *declaration* (mode + targets), deliberately not the run's inherit-or-offline narrowing control — different question. It persists in the composer draft for the same reason `offlineOnly` does.

New helpers `requestOf` / `summarizeRequest` in `lib/network.ts`, TDD'd (5 new tests, 125 total). `summarizeRequest` renders approved-with-no-targets as "none yet" rather than a bare "Approved targets", because that pairing grants nothing and reading it as egress would be false confidence.

Verified live after deploy: collapsed row reads `network Public`; revision chips read `network Approved targets · 1 target`; New Agent shows a Mode selector with Offline / Approved targets / Public.

Dashboard-only — already shipped via `vercel deploy --prod`. No release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZJiZZsGFtGWMg6V2WgXdM