### PR TITLE
fix(web): close the network-grant UI review findings

### DIFF
--- a/apps/web/app/app/agents/page.tsx
+++ b/apps/web/app/app/agents/page.tsx
@@ -29,11 +29,11 @@ import {
   specToDraft,
   draftToInput,
 } from "../../components/WorkspacePicker";
-import { TargetRuleEditor } from "../../components/TargetRuleEditor";
+import { NetworkRequestEditor } from "../../components/NetworkRequestEditor";
 import {
   MODE_LABEL,
-  MODE_ORDER,
   networkOf,
+  requestForWire,
   requestOf,
   summarizeRequest,
 } from "../../lib/network";
@@ -372,7 +372,10 @@ function AddRevision({
     JSON.stringify(workspace) !== JSON.stringify(specToDraft(current?.default_workspace)) ||
     JSON.stringify(pins) !== JSON.stringify(current?.capability_bundles ?? []) ||
     JSON.stringify(requirements) !== JSON.stringify(current?.connection_requirements ?? []) ||
-    JSON.stringify(network) !==
+    // Compare what would actually be SENT: targets typed under `approved` are
+    // kept in state across a mode toggle, and a declaration that sends none is
+    // not an edit just because they are still held.
+    JSON.stringify(requestForWire(network)) !==
       JSON.stringify(current?.network ?? { mode: "offline", targets: [], duration_secs: null });
 
   const submit = async () => {
@@ -402,7 +405,11 @@ function AddRevision({
         // `current` revision (still loading / failed load) `network` is the
         // offline default, and sending it would OVERWRITE the agent's real
         // declaration — the server inherits only when the field is ABSENT.
-        ...(current ? { network } : {}),
+        // `requestForWire` decides what the mode is allowed to carry: core
+        // REFUSES public+targets, and ACCEPTS offline+targets — which would
+        // store authority the editor stopped showing the moment the mode left
+        // `approved`.
+        ...(current ? { network: requestForWire(network) } : {}),
       });
       onAdded();
     } catch (e) {
@@ -486,35 +493,7 @@ function AddRevision({
         <strong>{ceiling ? MODE_LABEL[ceiling] : "unknown"}</strong>
         {ceiling ? null : " — could not read the policy; a run will still enforce it."}
       </p>
-      <label className="field">
-        <span className="lab">Mode</span>
-        <select
-          className="inp"
-          value={network.mode}
-          onChange={(e) => {
-            const mode = e.target.value as NetworkGrantMode;
-            setNetwork({ ...network, mode, targets: mode === "public" ? [] : network.targets });
-          }}
-        >
-          {MODE_ORDER.map((m) => (
-            <option key={m} value={m}>
-              {MODE_LABEL[m]}
-            </option>
-          ))}
-        </select>
-      </label>
-      {network.mode === "approved" && (
-        <TargetRuleEditor
-          value={network.targets}
-          onChange={(targets) => setNetwork({ ...network, targets })}
-        />
-      )}
-      {network.mode === "public" && (
-        <p className="helper">
-          A public declaration carries no targets — core refuses that pairing, because listing
-          targets beside &ldquo;everything&rdquo; reads as a narrowing the datapath would not apply.
-        </p>
-      )}
+      <NetworkRequestEditor value={network} onChange={setNetwork} />
       {err && <div className="err">{err}</div>}
       <div className="spread" style={{ marginTop: 14 }}>
         <span className="helper">Inherits image · budgets.</span>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -11,6 +11,7 @@ import {
   Session,
   workspaceLabel,
 } from "../lib/api";
+import { ApprovalActions } from "../components/ApprovalActions";
 import { AutomationPanel } from "../components/AutomationPanel";
 import { ResourceOverview } from "../components/ResourceOverview";
 import { AddServerWizard } from "./capabilities/AddServerWizard";
@@ -177,23 +178,10 @@ export default function Runs() {
                     </Link>
                   </div>
                 </div>
-                <div className="acts">
-                  {/* A parked network grant is inherently per-run, so "Whole
-                      session" is meaningless for it — the same collapse the
-                      session timeline makes. Presentation only: the decision
-                      value stays `approved_once`. */}
-                  <button className="btn human sm" type="button" onClick={() => decide(approval.id, "approved_once")}>
-                    {approval.tool === "network.grant" ? "Authorize" : "Approve once"}
-                  </button>
-                  {approval.tool !== "network.grant" && (
-                    <button className="btn sm" type="button" onClick={() => decide(approval.id, "approved_session")}>
-                      Whole session
-                    </button>
-                  )}
-                  <button className="btn sm ghost danger" type="button" onClick={() => decide(approval.id, "denied")}>
-                    Deny
-                  </button>
-                </div>
+                <ApprovalActions
+                  tool={approval.tool}
+                  onDecide={(decision) => decide(approval.id, decision)}
+                />
               </div>
             ))}
           </div>

--- a/apps/web/app/app/sessions/[id]/page.tsx
+++ b/apps/web/app/app/sessions/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
   EventRow,
   workspaceLabel,
 } from "../../../lib/api";
+import { ApprovalActions } from "../../../components/ApprovalActions";
 import { Pill, AutoPill, DiffView, LoadingRows, short } from "../../../components/bits";
 import { useSmartPolling } from "../../../lib/useSmartPolling";
 
@@ -241,55 +242,11 @@ export default function SessionDetail({ params }: { params: Promise<{ id: string
               </p>
             )}
           </div>
-          <div className="acts">
-            {a.tool === "network.grant" ? (
-              <>
-                <button
-                  className="btn human sm"
-                  type="button"
-                  disabled={actingOn === a.id}
-                  onClick={() => decide(a.id, "approved_once")}
-                >
-                  Authorize
-                </button>
-                <button
-                  className="btn sm ghost danger"
-                  type="button"
-                  disabled={actingOn === a.id}
-                  onClick={() => decide(a.id, "denied")}
-                >
-                  Deny
-                </button>
-              </>
-            ) : (
-              <>
-                <button
-                  className="btn human sm"
-                  type="button"
-                  disabled={actingOn === a.id}
-                  onClick={() => decide(a.id, "approved_once")}
-                >
-                  Approve once
-                </button>
-                <button
-                  className="btn sm"
-                  type="button"
-                  disabled={actingOn === a.id}
-                  onClick={() => decide(a.id, "approved_session")}
-                >
-                  Whole session
-                </button>
-                <button
-                  className="btn sm ghost danger"
-                  type="button"
-                  disabled={actingOn === a.id}
-                  onClick={() => decide(a.id, "denied")}
-                >
-                  Deny
-                </button>
-              </>
-            )}
-          </div>
+          <ApprovalActions
+            tool={a.tool}
+            busy={actingOn === a.id}
+            onDecide={(decision) => decide(a.id, decision)}
+          />
         </div>
       ))}
 

--- a/apps/web/app/components/ApprovalActions.tsx
+++ b/apps/web/app/components/ApprovalActions.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+// The buttons a human is offered for a parked approval.
+//
+// One home for the tool -> buttons rule. Overview and the session timeline both
+// render pending approvals, and both had grown their own copy of "which tools
+// relabel Approve and drop Whole session" — with different structure, so the
+// same approval could read differently depending on where you found it.
+
+export type ApprovalDecision = "approved_once" | "approved_session" | "denied";
+
+/** Tools whose authority is inherently PER-RUN. "Whole session" is meaningless
+ *  for these (the grant expires with the run), and the affirmative verb is
+ *  "Authorize" rather than "Approve". Presentation only — the decision value
+ *  stays `approved_once`, which is what the server records. */
+const PER_RUN_TOOLS = new Set(["network.grant"]);
+
+export function ApprovalActions({
+  tool,
+  busy = false,
+  onDecide,
+}: {
+  tool: string;
+  busy?: boolean;
+  onDecide: (decision: ApprovalDecision) => void;
+}) {
+  const perRun = PER_RUN_TOOLS.has(tool);
+  return (
+    <div className="acts">
+      <button
+        className="btn human sm"
+        type="button"
+        disabled={busy}
+        onClick={() => onDecide("approved_once")}
+      >
+        {perRun ? "Authorize" : "Approve once"}
+      </button>
+      {!perRun && (
+        <button
+          className="btn sm"
+          type="button"
+          disabled={busy}
+          onClick={() => onDecide("approved_session")}
+        >
+          Whole session
+        </button>
+      )}
+      <button
+        className="btn sm ghost danger"
+        type="button"
+        disabled={busy}
+        onClick={() => onDecide("denied")}
+      >
+        Deny
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/components/NetworkRequestEditor.tsx
+++ b/apps/web/app/components/NetworkRequestEditor.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+// The egress a revision DECLARES, authored in one place.
+//
+// This shape is edited from two screens — Agents › Add revision, and the run
+// composer's new-agent path — which held byte-similar copies of the same
+// select, the same target editor and the same helper text. They had already
+// drifted, and the rule about which modes carry targets lived in both onChange
+// handlers. One editor, one rule.
+//
+// What LEAVES the browser is `lib/network.ts::requestForWire`, not this: the
+// caller applies it at submit. Targets typed under `approved` therefore SURVIVE
+// a toggle to offline or public (nothing is destroyed while you decide) while
+// the payload still carries only what the mode is allowed to carry.
+
+import { NetworkGrantMode, NetworkRequest } from "../lib/api";
+import { MODE_LABEL, MODE_ORDER } from "../lib/network";
+import { TargetRuleEditor } from "./TargetRuleEditor";
+
+export function NetworkRequestEditor({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: NetworkRequest;
+  onChange: (next: NetworkRequest) => void;
+  disabled?: boolean;
+}) {
+  const keptTargets = value.mode !== "approved" ? value.targets.length : 0;
+  return (
+    <>
+      <label className="field">
+        <span className="lab">Mode</span>
+        <select
+          className="inp"
+          disabled={disabled}
+          value={value.mode}
+          onChange={(e) => onChange({ ...value, mode: e.target.value as NetworkGrantMode })}
+        >
+          {MODE_ORDER.map((m) => (
+            <option key={m} value={m}>
+              {MODE_LABEL[m]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {value.mode === "approved" && (
+        <TargetRuleEditor
+          value={value.targets}
+          disabled={disabled}
+          onChange={(targets) => onChange({ ...value, targets })}
+        />
+      )}
+
+      {value.mode === "public" && (
+        <p className="helper">
+          A public declaration carries no targets: it reaches everything the deployment&rsquo;s deny
+          wall permits, and core refuses the pairing outright because listing targets beside
+          &ldquo;everything&rdquo; reads as a narrowing the datapath would not apply.
+        </p>
+      )}
+
+      {keptTargets > 0 && (
+        // Say so rather than leaving it as hidden state: the targets are held
+        // for a switch back, and are NOT part of what this declaration grants.
+        <p className="helper">
+          {keptTargets} target{keptTargets === 1 ? "" : "s"} kept for if you switch back to{" "}
+          {MODE_LABEL.approved} — a {MODE_LABEL[value.mode].toLowerCase()} declaration sends none.
+        </p>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/components/PolicyLimits.tsx
+++ b/apps/web/app/components/PolicyLimits.tsx
@@ -22,7 +22,14 @@ import {
   TargetRule,
 } from "../lib/api";
 import { coerceCap, coerceTtlSecs } from "../lib/policy-caps";
-import { MODE_HINT, MODE_LABEL, MODE_ORDER, networkOf } from "../lib/network";
+import {
+  MODE_HINT,
+  MODE_LABEL,
+  MODE_ORDER,
+  OFFLINE_NETWORK,
+  isCeilingOptionAllowed,
+  networkOf,
+} from "../lib/network";
 import { useHarnesses } from "../lib/harnesses";
 import { VERB } from "./PermissionMatrix";
 import { TargetRuleEditor } from "./TargetRuleEditor";
@@ -235,8 +242,17 @@ export function PolicyLimits({
 
       {(() => {
         const net = networkOf(content);
-        const setNet = (patch: Partial<NetworkPolicy>) =>
-          set({ network: { ...net, ...patch } });
+        const setNet = (patch: Partial<NetworkPolicy>) => {
+          const next = { ...net, ...patch };
+          // The server OMITS this section when it is at its default, so writing
+          // the synthesized default back would make the draft differ from the
+          // wire form and light up "unsaved changes" for an edit that reverted
+          // to exactly what is stored. `undefined` drops out of JSON.stringify,
+          // which is what the governance page compares.
+          const isDefault = JSON.stringify(next) === JSON.stringify(OFFLINE_NETWORK);
+          set({ network: isDefault ? undefined : next });
+        };
+        const supportsGrants = network === null || network.supports_egress_grants;
         return (
           <>
             <div className="sectitle">Where a sandbox may reach</div>
@@ -249,7 +265,6 @@ export function PolicyLimits({
               <select
                 className="inp"
                 value={net.max_mode}
-                disabled={network !== null && !network.supports_egress_grants}
                 onChange={(e) => {
                   const max_mode = e.target.value as NetworkGrantMode;
                   // Change ONLY the ceiling — the catalog stays. Core checks an
@@ -262,8 +277,12 @@ export function PolicyLimits({
                   setNet({ max_mode });
                 }}
               >
+                {/* Without an enforcer a ceiling may only be LOWERED. Disabling
+                    the whole control also blocked bringing a too-permissive
+                    stored ceiling back down — locking an admin out of the one
+                    remediation this guard exists to make possible. */}
                 {MODE_ORDER.map((m) => (
-                  <option key={m} value={m}>
+                  <option key={m} value={m} disabled={!isCeilingOptionAllowed(m, net.max_mode, supportsGrants)}>
                     {MODE_LABEL[m]}
                   </option>
                 ))}
@@ -272,8 +291,8 @@ export function PolicyLimits({
             {network !== null && !network.supports_egress_grants && (
               <p className="helper warn">
                 This deployment has no network enforcer ({network.enforcer}), so any ceiling above
-                Offline would be refused when a run is created. Install Cilium and set
-                FLUIDBOX_NETWORK_ENFORCER to enable it.
+                Offline would be refused when a run is created — you can still LOWER this one.
+                Install Cilium and set FLUIDBOX_NETWORK_ENFORCER to enable it.
               </p>
             )}
             <p className="helper">{MODE_HINT[net.max_mode]}</p>
@@ -314,18 +333,17 @@ export function PolicyLimits({
                   timeline for approval before it gets any egress.
                 </p>
 
-                <label className="field">
-                  <span className="lab">Max grant lifetime (seconds)</span>
-                  <input
-                    className="inp"
-                    type="number"
-                    value={net.max_grant_secs ?? ""}
-                    placeholder="default"
-                    onChange={(e) =>
-                      setNet({ max_grant_secs: e.target.value === "" ? null : Number(e.target.value) })
-                    }
-                  />
-                </label>
+                {/* A CapField for the reason every other numeric knob here is
+                    one: a raw type=number reports "" for `-`, `1e` and `1.`
+                    alike, and `Number()` turns a half-typed entry into a value
+                    the u64 parser rejects with an opaque 400. */}
+                <CapField
+                  label="Max grant lifetime (seconds)"
+                  hint={net.max_grant_secs == null ? "default" : duration(net.max_grant_secs)}
+                  value={net.max_grant_secs}
+                  integer
+                  onChange={(max_grant_secs) => setNet({ max_grant_secs })}
+                />
               </>
             )}
           </>

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -11,15 +11,20 @@ import {
   ConnectionRequirement,
   connectionMatchesConnector,
   isToolConnection,
-  NetworkGrantMode,
   NetworkRequest,
   ownerBadge,
   PolicySummary,
   Revision,
   TriggerSubscription,
 } from "../lib/api";
-import { MODE_LABEL, MODE_ORDER, OFFLINE_REQUEST } from "../lib/network";
-import { TargetRuleEditor } from "./TargetRuleEditor";
+import {
+  MODE_LABEL,
+  OFFLINE_REQUEST,
+  agentSelectionChanged,
+  requestForWire,
+  runNetworkOverride,
+} from "../lib/network";
+import { NetworkRequestEditor } from "./NetworkRequestEditor";
 import { AddServerWizard } from "../app/capabilities/AddServerWizard";
 import { defaultModelFor, modelsFor, useHarnesses } from "../lib/harnesses";
 import { CopyBlock, TemplateChips } from "./AutomationContract";
@@ -167,6 +172,10 @@ export function RunComposer({
   // shreds the revision into the fields above (see the revision effect).
   const [offlineOnly, setOfflineOnly] = useState(false);
   const [declaredNetwork, setDeclaredNetwork] = useState<NetworkRequest | null>(null);
+  /** Which agent `declaredNetwork` (and the narrowing chosen against it)
+   *  belongs to. A ref, not state: it decides what the load effect below may
+   *  reset without being a reason to re-run it. */
+  const loadedDeclarationFor = useRef<string | null>(null);
   // The NEW agent's declaration. Distinct from `declaredNetwork` above, which
   // is what an EXISTING agent already declares: this one is authored here,
   // because agent creation had no way to declare egress and a created agent
@@ -355,6 +364,11 @@ export function RunComposer({
     setPubCheck(saved.pubCheck);
     setCapabilityKeepList(saved.capabilityKeepList);
     setOfflineOnly(saved.offlineOnly ?? false);
+    // The restored narrowing belongs to the restored agent. Recording that here
+    // is what lets the load effect fetch this agent's declaration WITHOUT
+    // reading the restore as a change of selection — which is precisely how a
+    // reload used to throw the operator's "offline only" choice away.
+    loadedDeclarationFor.current = saved.selectedAgentName || null;
     setAgentNetwork(saved.agentNetwork ?? OFFLINE_REQUEST);
   }, []);
   const clearDraft = useSessionDraft({
@@ -406,8 +420,16 @@ export function RunComposer({
     // Reset before the load: a pending/failed load must never show the previous
     // agent's declaration, and a per-run narrowing must never carry to a
     // different agent. The fetch below reinstates the real declaration.
-    setDeclaredNetwork(null);
-    setOfflineOnly(false);
+    //
+    // Only when the selection ACTUALLY MOVED, though. This effect also re-runs
+    // when the agent list arrives and when a draft is restored, and resetting
+    // then silently discarded the operator's "offline only" choice — the run
+    // launched with the agent's full declared egress and nothing said so.
+    if (agentSelectionChanged(loadedDeclarationFor.current, selectedAgentName)) {
+      setDeclaredNetwork(null);
+      setOfflineOnly(false);
+    }
+    loadedDeclarationFor.current = selectedAgentName;
     let active = true;
     const start = window.setTimeout(() => {
       setRevisionLoading(true);
@@ -696,7 +718,7 @@ export function RunComposer({
           // WYSIWYG, like the fields above: an omitted `network` means offline
           // server-side, so sending it explicitly is what makes the control on
           // screen the thing that actually takes effect.
-          network: agentNetwork,
+          network: requestForWire(agentNetwork),
         });
         createdAgent = response.agent;
         runAgentName = response.agent.name;
@@ -731,12 +753,13 @@ export function RunComposer({
         const explicit = Object.fromEntries(
           Object.entries(bindings).filter(([, connId]) => connId)
         );
+        // Narrow-only: the sole network override this UI can send is offline.
+        const narrowing = runNetworkOverride(offlineOnly);
         const body: Record<string, unknown> = {
           agent: runAgentName,
           task: task.trim(),
           autonomous,
-          // Narrow-only: the sole network override this UI can send is offline.
-          ...(offlineOnly ? { network: { mode: "offline", targets: [], duration_secs: null } } : {}),
+          ...(narrowing ? { network: narrowing } : {}),
         };
         if (Object.keys(explicit).length > 0) body.bindings = explicit;
         await apiPost("/sessions", body);
@@ -1588,58 +1611,32 @@ export function RunComposer({
           </ComposerSection>
         )}
 
-        {agentOnly && agentChoice === "new" && (
+        {/* ONE network section, because a given run has only one question to
+            answer. Creating an agent (either path) DECLARES; running an
+            existing one may only NARROW what that agent already declared.
+            Gating the declaration editor on `agentOnly` meant the inline
+            new-agent path created the agent offline and then told the operator
+            to "add a declaration on the agent" — which that flow cannot do. */}
+        {(agentChoice === "new" || (!agentOnly && mode === "once")) && (
           <ComposerSection
-            index={5}
+            index={agentOnly ? 3 : 5}
             title="Network access"
-            hint="Where sandboxes running this agent may reach."
+            hint={
+              agentChoice === "new"
+                ? "Where sandboxes running this agent may reach."
+                : "Where this run may reach."
+            }
           >
-            <p className="helper" style={{ marginBottom: 6 }}>
-              This is the agent&rsquo;s <strong>declaration</strong>. The governing policy caps it,
-              and a single run may narrow it further — never widen it. Left at Offline, the agent
-              has no egress at all.
-            </p>
-            <label className="field">
-              <span className="lab">Mode</span>
-              <select
-                className="inp"
-                value={agentNetwork.mode}
-                onChange={(e) => {
-                  const nextMode = e.target.value as NetworkGrantMode;
-                  // A public declaration must carry NO targets — core refuses
-                  // that pairing as a narrowing the datapath would not apply.
-                  setAgentNetwork({
-                    ...agentNetwork,
-                    mode: nextMode,
-                    targets: nextMode === "public" ? [] : agentNetwork.targets,
-                  });
-                }}
-              >
-                {MODE_ORDER.map((m) => (
-                  <option key={m} value={m}>
-                    {MODE_LABEL[m]}
-                  </option>
-                ))}
-              </select>
-            </label>
-            {agentNetwork.mode === "approved" && (
-              <TargetRuleEditor
-                value={agentNetwork.targets}
-                onChange={(targets) => setAgentNetwork({ ...agentNetwork, targets })}
-              />
-            )}
-            {agentNetwork.mode === "public" && (
-              <p className="helper">
-                A public declaration carries no targets — it reaches everything the
-                deployment&rsquo;s deny wall permits.
-              </p>
-            )}
-          </ComposerSection>
-        )}
-
-        {!agentOnly && mode === "once" && (
-          <ComposerSection index={5} title="Network access" hint="Where this run may reach.">
-            {!declaredNetwork || declaredNetwork.mode === "offline" ? (
+            {agentChoice === "new" ? (
+              <>
+                <p className="helper" style={{ marginBottom: 6 }}>
+                  This is the agent&rsquo;s <strong>declaration</strong>. The governing policy caps
+                  it, and a single run may narrow it further — never widen it. Left at Offline, the
+                  agent has no egress at all.
+                </p>
+                <NetworkRequestEditor value={agentNetwork} onChange={setAgentNetwork} />
+              </>
+            ) : !declaredNetwork || declaredNetwork.mode === "offline" ? (
               <p className="helper">
                 This agent declares no network access, so the run is offline. Add a declaration on
                 the agent to change that.

--- a/apps/web/app/components/TargetRuleEditor.tsx
+++ b/apps/web/app/components/TargetRuleEditor.tsx
@@ -5,12 +5,20 @@
 // target is REACHABLE is resolved server-side.
 
 import { FqdnPattern, L4Protocol, TargetRule } from "../lib/api";
-import { describeTarget } from "../lib/network";
+import {
+  DEFAULT_PORT,
+  MAX_PORT,
+  MIN_PORT,
+  describeTarget,
+  portsLabel,
+  singleRange,
+  withPortEdge,
+} from "../lib/network";
 
 export const EMPTY_TARGET: TargetRule = {
   kind: "dns",
   pattern: { kind: "wildcard", suffix: "" },
-  ports: [{ from: 443, to: 443 }],
+  ports: [{ from: DEFAULT_PORT, to: DEFAULT_PORT }],
   protocol: "tcp",
 };
 
@@ -41,10 +49,11 @@ export function TargetRuleEditor({
       )}
 
       {value.map((t, i) => {
-        // This editor authors a single port range; a rule that arrived via the
-        // API with several ranges is shown read-only so an edit cannot silently
-        // discard the extra ranges (it would rewrite `ports` to just ports[0]).
-        const multiRange = t.ports.length > 1;
+        // This editor authors a single port range. A rule it cannot represent
+        // — SEVERAL ranges, or NONE at all (which means "any port") — is shown
+        // read-only and blank, because rendering either as a concrete pair
+        // both misstates the rule and narrows it on the first keystroke.
+        const range = singleRange(t.ports);
         return (
         <div className="agent-creator-grid" key={i}>
           <label className="field">
@@ -103,12 +112,14 @@ export function TargetRuleEditor({
             <input
               className="inp"
               type="number"
-              disabled={disabled || multiRange}
-              value={t.ports[0]?.from ?? 443}
-              onChange={(e) => {
-                const from = Number(e.target.value);
-                patch(i, { ...t, ports: [{ from, to: Math.max(from, t.ports[0]?.to ?? from) }] });
-              }}
+              min={MIN_PORT}
+              max={MAX_PORT}
+              disabled={disabled || range === null}
+              value={range?.from ?? ""}
+              placeholder={portsLabel(t.ports)}
+              onChange={(e) =>
+                patch(i, { ...t, ports: withPortEdge(t.ports, "from", e.target.value) })
+              }
             />
           </label>
 
@@ -117,16 +128,22 @@ export function TargetRuleEditor({
             <input
               className="inp"
               type="number"
-              disabled={disabled || multiRange}
-              value={t.ports[0]?.to ?? 443}
+              min={MIN_PORT}
+              max={MAX_PORT}
+              disabled={disabled || range === null}
+              value={range?.to ?? ""}
+              placeholder={portsLabel(t.ports)}
               onChange={(e) =>
-                patch(i, { ...t, ports: [{ from: t.ports[0]?.from ?? 443, to: Number(e.target.value) }] })
+                patch(i, { ...t, ports: withPortEdge(t.ports, "to", e.target.value) })
               }
             />
           </label>
 
-          {multiRange && (
-            <p className="helper">Multiple port ranges — shown read-only; edit via the API.</p>
+          {range === null && (
+            <p className="helper">
+              {t.ports.length === 0 ? "Any port" : "Multiple port ranges"} — shown read-only; edit
+              via the API.
+            </p>
           )}
 
           <button type="button" className="btn ghost" disabled={disabled} onClick={() => remove(i)}>

--- a/apps/web/app/lib/network.test.ts
+++ b/apps/web/app/lib/network.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { NetworkRequest, PolicyContent, TargetRule } from "./api";
+import { NetworkRequest, PolicyContent, PortSpec, TargetRule } from "./api";
 import {
+  agentSelectionChanged,
   describeTarget,
+  isCeilingOptionAllowed,
+  MAX_PORT,
+  MIN_PORT,
   MODE_ORDER,
   networkOf,
   OFFLINE_NETWORK,
   OFFLINE_REQUEST,
   portsLabel,
+  requestForWire,
   requestOf,
+  runNetworkOverride,
+  singleRange,
   summarizeRequest,
+  withPortEdge,
 } from "./network";
 
 const base = { name: "p" } as unknown as PolicyContent;
@@ -123,5 +131,165 @@ describe("summarizeRequest", () => {
     expect(summarizeRequest({ mode: "approved", targets: [], duration_secs: null })).toBe(
       "Approved targets · none yet",
     );
+  });
+});
+
+const dns = (name: string, ports: PortSpec[]): TargetRule => ({
+  kind: "dns",
+  pattern: { kind: "exact", name },
+  ports,
+  protocol: "tcp",
+});
+
+describe("singleRange", () => {
+  it("returns the one range a two-box editor can represent", () => {
+    expect(singleRange([{ from: 80, to: 443 }])).toEqual({ from: 80, to: 443 });
+  });
+
+  it("returns null for a rule that names no ports", () => {
+    // `[]` MEANS "any port" (portsLabel says so). An editor that answered 443
+    // here rendered an any-port grant as 443-only, contradicting the very
+    // description printed beside it, and narrowed the rule on first keystroke.
+    expect(singleRange([])).toBeNull();
+  });
+
+  it("returns null for several ranges, which one pair of boxes cannot hold", () => {
+    expect(singleRange([{ from: 80, to: 80 }, { from: 443, to: 443 }])).toBeNull();
+  });
+});
+
+describe("withPortEdge", () => {
+  const one: PortSpec[] = [{ from: 443, to: 443 }];
+
+  it("carries `to` up when `from` is raised past it", () => {
+    expect(withPortEdge(one, "from", "8443")).toEqual([{ from: 8443, to: 8443 }]);
+  });
+
+  it("carries `from` down when `to` is lowered past it", () => {
+    // The bug this pins: only the `from` handler clamped, so typing 80 into
+    // `to` on a 443 rule built the inverted range 443-80 and the whole save
+    // failed server-side with a raw 4xx.
+    expect(withPortEdge(one, "to", "80")).toEqual([{ from: 80, to: 80 }]);
+  });
+
+  it("widens without disturbing the other edge", () => {
+    expect(withPortEdge([{ from: 80, to: 80 }], "to", "443")).toEqual([{ from: 80, to: 443 }]);
+  });
+
+  it("leaves the range alone while the field is empty", () => {
+    // `Number("")` is 0, and port 0 is refused by core — so an empty field
+    // must mean "mid-edit", never "port zero".
+    expect(withPortEdge(one, "from", "")).toEqual(one);
+    expect(withPortEdge(one, "to", "  ")).toEqual(one);
+  });
+
+  it("leaves the range alone for something that is not a number", () => {
+    expect(withPortEdge(one, "to", "http")).toEqual(one);
+  });
+
+  it("clamps to the range the wire can carry", () => {
+    expect(withPortEdge(one, "from", "0")).toEqual([{ from: MIN_PORT, to: 443 }]);
+    expect(withPortEdge(one, "to", "70000")).toEqual([{ from: 443, to: MAX_PORT }]);
+    expect(withPortEdge(one, "to", "-5")).toEqual([{ from: MIN_PORT, to: MIN_PORT }]);
+  });
+
+  it("floors a fractional entry rather than sending one to a u16", () => {
+    expect(withPortEdge(one, "to", "8443.9")).toEqual([{ from: 443, to: 8443 }]);
+  });
+
+  it("seeds a range for a rule that had none rather than editing in place", () => {
+    // An any-port rule is read-only in the editor, but the function must still
+    // answer sanely if it is ever handed one.
+    expect(withPortEdge([], "from", "80")).toEqual([{ from: 80, to: 80 }]);
+  });
+
+  it("does not mutate the ports it was given", () => {
+    const before: PortSpec[] = [{ from: 443, to: 443 }];
+    withPortEdge(before, "to", "80");
+    expect(before).toEqual([{ from: 443, to: 443 }]);
+  });
+});
+
+describe("requestForWire", () => {
+  const t = dns("pypi.org", [{ from: 443, to: 443 }]);
+
+  it("keeps targets under approved, the one mode that carries them", () => {
+    expect(requestForWire({ mode: "approved", targets: [t], duration_secs: 900 })).toEqual({
+      mode: "approved",
+      targets: [t],
+      duration_secs: 900,
+    });
+  });
+
+  it("drops targets from an offline declaration the editor never showed", () => {
+    // Switching approved -> offline hid the target editor but kept the targets
+    // in the payload. Core accepts offline+targets (only public+targets is
+    // refused), so the stored declaration disagreed with what was approved.
+    expect(requestForWire({ mode: "offline", targets: [t], duration_secs: null })).toEqual({
+      mode: "offline",
+      targets: [],
+      duration_secs: null,
+    });
+  });
+
+  it("drops targets from a public declaration, which core refuses outright", () => {
+    expect(requestForWire({ mode: "public", targets: [t], duration_secs: null }).targets).toEqual([]);
+  });
+
+  it("does not mutate its argument, so a mode toggle keeps the typed work", () => {
+    const draft: NetworkRequest = { mode: "offline", targets: [t], duration_secs: null };
+    requestForWire(draft);
+    expect(draft.targets).toEqual([t]);
+  });
+});
+
+describe("runNetworkOverride", () => {
+  it("sends offline, the sole narrowing a run may ask for", () => {
+    expect(runNetworkOverride(true)).toEqual(OFFLINE_REQUEST);
+  });
+
+  it("sends nothing when the run inherits what the agent declared", () => {
+    expect(runNetworkOverride(false)).toBeUndefined();
+  });
+});
+
+describe("agentSelectionChanged", () => {
+  it("is false when the same agent is selected again", () => {
+    // THE regression this file exists for: the revision-load effect re-runs
+    // when the agent list arrives or a draft is restored, not only when the
+    // selection moves. Resetting THEN discarded the operator's "offline only"
+    // choice and launched the run with the agent's full declared egress.
+    expect(agentSelectionChanged("triage-bot", "triage-bot")).toBe(false);
+  });
+
+  it("is true when the selection moves to another agent", () => {
+    // A narrowing chosen against one declaration means nothing against another.
+    expect(agentSelectionChanged("triage-bot", "release-bot")).toBe(true);
+  });
+
+  it("is true for the first selection, when nothing is loaded yet", () => {
+    expect(agentSelectionChanged(null, "triage-bot")).toBe(true);
+  });
+});
+
+describe("isCeilingOptionAllowed", () => {
+  it("allows every ceiling when the provider enforces egress", () => {
+    for (const m of MODE_ORDER) expect(isCeilingOptionAllowed(m, "offline", true)).toBe(true);
+  });
+
+  it("allows LOWERING a stored ceiling with no enforcer present", () => {
+    // Disabling the whole control locked an admin out of remediating a
+    // too-permissive ceiling — the opposite of what the guard is for.
+    expect(isCeilingOptionAllowed("offline", "public", false)).toBe(true);
+    expect(isCeilingOptionAllowed("approved", "public", false)).toBe(true);
+  });
+
+  it("allows keeping the ceiling exactly where it is", () => {
+    expect(isCeilingOptionAllowed("public", "public", false)).toBe(true);
+  });
+
+  it("refuses to widen a ceiling the deployment cannot enforce", () => {
+    expect(isCeilingOptionAllowed("public", "offline", false)).toBe(false);
+    expect(isCeilingOptionAllowed("approved", "offline", false)).toBe(false);
   });
 });

--- a/apps/web/app/lib/network.ts
+++ b/apps/web/app/lib/network.ts
@@ -72,6 +72,98 @@ export function requestOf(network: NetworkRequest | null | undefined): NetworkRe
   return network ?? OFFLINE_REQUEST;
 }
 
+/** The port a fresh target starts on, and the range the wire can carry: a
+ *  `PortSpec` is a pair of `u16`s server-side and core refuses port 0
+ *  outright, so both ends of an edit have to land inside this. */
+export const DEFAULT_PORT = 443;
+export const MIN_PORT = 1;
+export const MAX_PORT = 65535;
+
+export type PortEdge = "from" | "to";
+
+/** The one range a two-box editor can represent. `null` for a rule naming NO
+ *  ports (which means "any port", not 443) and for one naming SEVERAL, because
+ *  showing either as a concrete pair misstates the rule and editing it would
+ *  silently rewrite `ports` to just the pair on screen. */
+export function singleRange(ports: PortSpec[]): PortSpec | null {
+  return ports.length === 1 ? ports[0] : null;
+}
+
+/** What a typed port MEANS, or `null` for "the field is mid-edit". Kept apart
+ *  from the edit below for the reason `policy-caps.ts` exists: `Number("")` is
+ *  `0`, and 0 is a port core refuses — so an empty field must never reach the
+ *  model as a value. Anything usable is clamped into the wire's range and
+ *  floored, never rounded. */
+function parsePort(raw: string): number | null {
+  const t = raw.trim();
+  if (t === "") return null;
+  const n = Number(t);
+  if (!Number.isFinite(n)) return null;
+  return Math.min(Math.max(Math.floor(n), MIN_PORT), MAX_PORT);
+}
+
+/** Immutable single-range edit that cannot produce a range the server will
+ *  reject: raising `from` carries `to` up with it and lowering `to` carries
+ *  `from` down, so the pair can never invert, and an unusable entry leaves the
+ *  range untouched. Both edges go through this — having only one of them clamp
+ *  is how `443-80` reached the API and failed the whole save. */
+export function withPortEdge(ports: PortSpec[], edge: PortEdge, raw: string): PortSpec[] {
+  const value = parsePort(raw);
+  if (value === null) return ports;
+  const current = singleRange(ports) ?? { from: value, to: value };
+  return [
+    edge === "from"
+      ? { from: value, to: Math.max(value, current.to) }
+      : { from: Math.min(value, current.from), to: value },
+  ];
+}
+
+/** What actually leaves the browser. ONLY `approved` carries targets: core
+ *  refuses public+targets outright, and it ACCEPTS offline+targets — which is
+ *  worse, because the editor hides the target list for offline, so the stored
+ *  declaration would keep authority nobody saw or approved.
+ *
+ *  Deliberately applied at submit rather than on the mode select, so toggling
+ *  modes while deciding does not destroy the targets already typed. */
+export function requestForWire(n: NetworkRequest): NetworkRequest {
+  return { ...n, targets: n.mode === "approved" ? n.targets : [] };
+}
+
+/** The per-run override, whose whole authority is to NARROW: offline is the
+ *  only thing this UI can ask for, and `undefined` means "inherit whatever the
+ *  agent declared". */
+export function runNetworkOverride(offlineOnly: boolean): NetworkRequest | undefined {
+  return offlineOnly ? OFFLINE_REQUEST : undefined;
+}
+
+/** Whether the composer must drop the declaration on screen AND the per-run
+ *  narrowing chosen against it.
+ *
+ *  TRUE only when the selection actually moved to a DIFFERENT agent. The
+ *  revision-load effect also re-runs when the agent list arrives or a draft is
+ *  restored; resetting on those re-runs silently discarded the operator's
+ *  "offline only" choice and launched the run with the agent's full declared
+ *  egress — a widening nothing on screen reported. A narrowing is meaningless
+ *  against a declaration it was never chosen against, which is why the agent
+ *  identity, not the effect firing, is what decides. */
+export function agentSelectionChanged(loadedFor: string | null, selected: string): boolean {
+  return loadedFor !== selected;
+}
+
+/** Whether a ceiling is selectable. A deployment whose provider cannot enforce
+ *  egress must not be able to RAISE the ceiling — but it must always be able
+ *  to LOWER one it already carries (set via the API, or left behind when an
+ *  enforcer was removed). Disabling the control outright locked an admin out
+ *  of remediating exactly the too-permissive policy it meant to guard. */
+export function isCeilingOptionAllowed(
+  option: NetworkGrantMode,
+  current: NetworkGrantMode,
+  supportsEgressGrants: boolean,
+): boolean {
+  if (supportsEgressGrants) return true;
+  return MODE_ORDER.indexOf(option) <= MODE_ORDER.indexOf(current);
+}
+
 /** One line for a chip or a header row. `approved` carries its target count
  *  because an approved declaration with NO targets grants nothing, and
  *  rendering it as a bare "Approved targets" would imply egress it lacks. */


### PR DESCRIPTION
A max-effort review of the network-grant feature on `main` (the `feat/cloud-m1` merges) turned up twelve frontend defects. One silently **widened** egress; the rest either sent state the operator never saw, or failed a save with an opaque 4xx. The backend hunk (`api.rs`) reviewed clean and is untouched.

The decidable rules move into `lib/network.ts` and are tested there. The repo has no component-test harness, so that extraction is what makes a regression test possible at all — each new test was watched failing before its fix existed.

## Correctness

| | |
|---|---|
| **Per-run "Offline only" was silently discarded** | The composer's revision-load effect reset the narrowing on *every* re-run, not only when the selected agent changed. A reload — or the agent list simply arriving — threw the operator's choice away and launched the run with the agent's **full declared egress**, with nothing on screen saying so. The reset is now keyed on agent identity (`agentSelectionChanged`), and a restored draft records which agent its narrowing belongs to. |
| **approved → offline kept targets in the payload** | Core refuses `public`+targets but *accepts* `offline`+targets, so the stored declaration disagreed with the editor, which hides targets for offline. `requestForWire` now decides what each mode may carry, applied at submit so a mode toggle no longer destroys typed work — and the retained targets are stated on screen instead of being hidden state. |
| **Inverted and port-0 ranges reached the API** | "Ports (to)" had no clamp its sibling had, and both read an empty field as `Number("") === 0`. `443-80` and port `0` failed the *whole* save. `withPortEdge` clamps both edges into `[1, 65535]`, carries the other edge along, and treats an unusable entry as mid-edit. |
| **`ports: []` ("any port") rendered as an editable 443** | It contradicted its own description on the same row and narrowed the rule on first keystroke. Only a genuine single range is editable now. |
| **Ceiling select blocked *lowering* a wide ceiling** | Disabled outright without an enforcer, which locked an admin out of the one remediation it exists for. Widening is refused per-option; lowering is always allowed. |
| **Inline new-agent flow had no egress editor** | It was gated on the agent-only path, yet the UI told the operator to "add a declaration on the agent" — impossible in that flow. Both creation paths declare now, and the two Network sections merged into one, which also fixes the step badges reading 1, 2, 5. |

## Robustness

- **Max grant lifetime** used a raw `type=number` + `Number()`, bypassing the `CapField` every sibling knob uses; `-5` and `3.5` reached serde's `u64` as an opaque 400.
- Touching and reverting any network control **marked an untouched policy dirty**, because the synthesized offline default was written back where the server sends no key at all.

## Cleanup

- `NetworkRequestEditor` and `ApprovalActions` replace copy-paste that had **already drifted** in wording and structure between two files each.
- The default port `443` was a bare literal in five places.

## Test plan

- [x] `pnpm test` — **150/150** (25 new; each watched failing first, all `not a function` → feature missing, not typos)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — compiles
- [x] `pnpm lint` — **one fewer error than the pre-change baseline, zero new** (lint is already red on `main`; diffed against a stashed baseline rather than trusting the total)
- [ ] Not run: DB-backed / e2e suites — no Rust changed, so nothing in this diff reaches them

## Deliberately not fixed

The `O(agents)` revision fan-out on the Agents list. The real fix is a backend change (fold the current-revision network summary into `GET /agents`), which needs a new DB row type and query I cannot verify without running the DB-backed suite. It is documented in-code, cached and bounded — shipping unverified SQL is the worse trade. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vv4U8UrWkMpqstBvpLTJdn