### PR TITLE
chore(web): skip the dashboard build on commits that do not touch it

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
+}


### PR DESCRIPTION
Connecting the Vercel project to git earlier today made **every** push to `main` rebuild and redeploy the dashboard — including the Rust-only commits that are most of this repo's traffic.

## The inverted exit code

`ignoreCommand` reads backwards from the usual convention:

| exit | meaning |
|---|---|
| `0` | **skip** the build |
| `1` | **build** |

So `git diff --quiet HEAD^ HEAD ./` builds exactly when the diff touched the project's Root Directory. `./` resolves against that Root Directory (`apps/web`), not the repo root, so the path never has to be restated in the config.

## Every failure mode fails toward *building*

- shallow clone with no `HEAD^` → git exits `128` → **build**
- command ever run from the repo root instead → `./` matches everything → **build**

That direction is deliberate. A wrong *skip* reproduces the exact failure this pipeline was wired up to end — merged but not deployed — and it is **silent**. A redundant build just costs a minute.

## Why it is safe to skip at all

`apps/web` is self-contained, verified before writing the rule:

- nothing under `apps/web` imports outside its own tree (no `from "../../../../../…"`)
- `next.config.ts` declares no `outputFileTracingRoot` / `transpilePackages` / external root
- the `api.ts` mirrors of `fluidbox-core` are **hand-maintained, not generated at build time**, so a core change cannot stale the bundle without also touching `apps/web`

## Placement

In `apps/web/vercel.json`, not Project Settings (`commandForIgnoringBuildStep` is still `null`), so the rule is reviewable and versioned with the code it gates.

## Test plan

- [x] Confirmed no pre-existing `vercel.json` anywhere in the repo and no dashboard-level ignore step
- [x] **This PR touches `apps/web`, so it must NOT be skipped** — merging it is the positive test of the rule
- [ ] The negative test is the next Rust-only commit to `main`, which should report `Build skipped`

Note: GitHub Actions is in a [major outage](https://www.githubstatus.com/incidents/qcvjkzcs7j74) (started 2026-08-06 15:22 UTC), so CI may not run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vv4U8UrWkMpqstBvpLTJdn