### PR TITLE
fix(web): gate the design scales, fix four user-visible defects, and close three high-severity findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,18 @@ jobs:
           cache: pnpm
           cache-dependency-path: apps/web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
+      # The CSS gate (stylelint.config.mjs). Its own step, deliberately NOT
+      # `pnpm lint`: eslint has a pre-existing red baseline (15 errors, 11 of
+      # them react-hooks/set-state-in-effect in the run composer and policy
+      # editor) that is a runtime-behaviour problem, and enforcing the design
+      # scales must not wait on greening it.
+      #
+      # Every stylelint rule reports at `warning` and the script carries a
+      # --max-warnings ceiling equal to today's count. Existing violations
+      # block nobody; ONE new raw hex, off-scale radius, fourth breakpoint or
+      # duplicate selector pushes the count over the ceiling and fails here.
+      # Lower the ceiling in package.json as each migration lands.
+      - run: pnpm lint:css
       - run: pnpm build
       # Proxy-auth + sso-route unit tests (vitest) — the credential-boundary logic
       # (webMode strictness, cookie allowlist, no-bearer forward, Set-Cookie

--- a/apps/web/app/(site)/components/SiteFooter.tsx
+++ b/apps/web/app/(site)/components/SiteFooter.tsx
@@ -9,7 +9,9 @@ const COLUMNS: { title: string; links: { href: string; label: string; external?:
       { href: "/product", label: "Overview" },
       { href: "/pricing", label: "Pricing" },
       { href: "/changelog", label: "Changelog" },
-      { href: "/app", label: "Dashboard" },
+      // No Dashboard entry here: the boundary invariant is ONE visible route
+      // back to /app when signed in (the header CTA) and ZERO signed out —
+      // this unconditional link was both violations at once.
     ],
   },
   {

--- a/apps/web/app/(site)/components/SiteHeader.tsx
+++ b/apps/web/app/(site)/components/SiteHeader.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { ThemeToggle } from "../../components/ThemeToggle";
+import { APP_HOME } from "../../lib/auth-gate";
 
 const REPO = "https://github.com/hrishikeshdkakkad/fluidbox";
 
@@ -87,10 +88,20 @@ export function SiteHeader() {
               </Link>
             ))}
             <div className="site-nav-mobile-actions">
-              <Link href="/sign-in" className="btn sm" onNavigate={close}>
+              {/* Both variants render; CSS shows the one matching data-session
+                  (stamped before paint by lib/session-hint). Rendering both is
+                  what keeps these pages statically generated. */}
+              <Link href={APP_HOME} className="btn sm primary site-when-in" onNavigate={close}>
+                Dashboard
+              </Link>
+              <Link href="/sign-in" className="btn sm site-when-out" onNavigate={close}>
                 Log In
               </Link>
-              <Link href="/docs/getting-started" className="btn sm primary" onNavigate={close}>
+              <Link
+                href="/docs/getting-started"
+                className="btn sm primary site-when-out"
+                onNavigate={close}
+              >
                 Get Started
               </Link>
             </div>
@@ -107,11 +118,20 @@ export function SiteHeader() {
             >
               <GitHubMark />
             </a>
-            <Link href="/docs/getting-started" className="btn sm primary site-getstarted">
+            <Link
+              href="/docs/getting-started"
+              className="btn sm primary site-getstarted site-when-out"
+            >
               Get Started
             </Link>
-            <Link href="/sign-in" className="btn sm site-signin">
+            <Link href="/sign-in" className="btn sm site-signin site-when-out">
               Log In
+            </Link>
+            {/* The door home. A signed-in reader who lands here from search or
+                a shared link must never be offered "Log In", and must never
+                have to hunt the footer to get back to their workspace. */}
+            <Link href={APP_HOME} className="btn sm primary site-dashboard site-when-in">
+              Dashboard <span aria-hidden="true">→</span>
             </Link>
             <button
               className="site-menu-btn"

--- a/apps/web/app/(site)/docs/CopyButton.tsx
+++ b/apps/web/app/(site)/docs/CopyButton.tsx
@@ -2,10 +2,29 @@
 
 import { useEffect, useRef, useState } from "react";
 
-// Copy-to-clipboard for docs code blocks. The copied state resets itself so
-// the button reads "Copy" again after a beat.
+type CopyState = "idle" | "copied" | "failed";
+
+const LABEL: Record<CopyState, string> = {
+  idle: "Copy",
+  copied: "Copied",
+  failed: "Select it",
+};
+
+/**
+ * Copy-to-clipboard for docs code blocks. The state resets itself so the
+ * button reads "Copy" again after a beat.
+ *
+ * `navigator.clipboard` is only defined in a secure context, so on a plain-http
+ * origin — a self-hosted docs mirror, a LAN preview — reading `.writeText` off
+ * it throws a TypeError. It can also reject with NotAllowedError when the
+ * document is not focused or the permission is denied. The previous version
+ * had a bare `.then()`, so all three failed silently: the label never changed
+ * and the reader believed they had copied the command. Now the failure is
+ * reported AND the code is selected, so the keyboard shortcut still works.
+ */
 export function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
+  const [state, setState] = useState<CopyState>("idle");
+  const button = useRef<HTMLButtonElement | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -14,20 +33,47 @@ export function CopyButton({ text }: { text: string }) {
     };
   }, []);
 
+  const settle = (next: CopyState) => {
+    setState(next);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setState("idle"), 2400);
+  };
+
+  /** Last resort: put the code under the user's selection so Cmd/Ctrl+C works. */
+  const selectCode = () => {
+    const code = button.current?.closest(".docs-code")?.querySelector("pre");
+    const selection = window.getSelection();
+    if (!code || !selection) return;
+    const range = document.createRange();
+    range.selectNodeContents(code);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  };
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      settle("copied");
+    } catch {
+      selectCode();
+      settle("failed");
+    }
+  };
+
   return (
     <button
+      ref={button}
       type="button"
       className="docs-copy"
-      aria-label="Copy code"
-      onClick={() => {
-        navigator.clipboard.writeText(text).then(() => {
-          setCopied(true);
-          if (timer.current) clearTimeout(timer.current);
-          timer.current = setTimeout(() => setCopied(false), 1600);
-        });
-      }}
+      data-state={state}
+      aria-label={
+        state === "failed"
+          ? "Copy failed — the code is selected, press Cmd or Ctrl + C"
+          : "Copy code"
+      }
+      onClick={() => void copy()}
     >
-      {copied ? "Copied" : "Copy"}
+      <span aria-live="polite">{LABEL[state]}</span>
     </button>
   );
 }

--- a/apps/web/app/(site)/not-found.tsx
+++ b/apps/web/app/(site)/not-found.tsx
@@ -1,0 +1,18 @@
+import { StateNotFound } from "../components/state";
+
+// The boundary the live `notFound()` calls in the docs actually reach —
+// docs/[slug]/page.tsx and docs/api/page.tsx both call it, and without a
+// not-found inside this route group they escaped to the root one, losing the
+// marketing/docs chrome that (site)/layout.tsx provides.
+export default function SiteNotFound() {
+  return (
+    <main className="main">
+      <StateNotFound
+        title="page not found"
+        body="That page does not exist. It may have been renamed, or the link may be out of date."
+        href="/docs"
+        label="Back to docs"
+      />
+    </main>
+  );
+}

--- a/apps/web/app/app/activity/layout.tsx
+++ b/apps/web/app/app/activity/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Activity",
+  description: "Manual and automated runs on one timeline, and the automations that start them.",
+};
+
+export default function ActivityLayout({ children }: LayoutProps<"/app/activity">) {
+  return children;
+}

--- a/apps/web/app/app/activity/page.tsx
+++ b/apps/web/app/app/activity/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { apiGet, Session } from "../../lib/api";
+import { AutomationPanel } from "../../components/AutomationPanel";
+import { RunHistory } from "../../components/RunHistory";
+import {
+  MintedAutomation,
+  RunComposer,
+  RunMode,
+  ShowAutomationSecrets,
+} from "../../components/RunComposer";
+import { LoadingRows, PageHead } from "../../components/bits";
+import { useSmartPolling } from "../../lib/useSmartPolling";
+
+// The activity workbench (2026-08-14 navigation-boundary design): run history
+// and automations as a real place — what the masthead's `activity` points at
+// and what sessions/* and automations/* breadcrumb back to. Overview keeps the
+// operations summary; the list itself is the shared RunHistory component, so
+// the two surfaces cannot drift.
+export default function ActivityPage() {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [composerMode, setComposerMode] = useState<RunMode | null>(null);
+  const [minted, setMinted] = useState<MintedAutomation | null>(null);
+  const [automationRefresh, setAutomationRefresh] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [hasSnapshot, setHasSnapshot] = useState(false);
+  const [offline, setOffline] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const response = await apiGet<{ sessions: Session[] }>("/sessions?limit=50");
+      setSessions(response.sessions);
+      setHasSnapshot(true);
+      setOffline(false);
+    } catch {
+      // Keep the last good snapshot, but never present a failed first read as
+      // real zero activity.
+      setOffline(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useSmartPolling(load, 2500);
+
+  return (
+    <>
+      <PageHead
+        title="Activity"
+        sub="Manual and automated runs share one timeline."
+        right={
+          <button className="btn primary" type="button" onClick={() => setComposerMode("once")}>
+            New Run
+          </button>
+        }
+      />
+
+      <section className="operate-view" aria-labelledby="activity-runs-heading">
+        <div className="section-heading recent-heading">
+          <div>
+            <span className="section-kicker">Every invocation</span>
+            <h2 id="activity-runs-heading">Run history</h2>
+          </div>
+          <span className="section-note">Runs open their live timeline and diff.</span>
+        </div>
+        <div className="run-list">
+          {loading ? (
+            <LoadingRows />
+          ) : offline && !hasSnapshot ? (
+            <div className="launch-empty">
+              <div>
+                <h3>Control plane unavailable.</h3>
+                <p>Run history could not be loaded. Your browser will keep retrying in the background.</p>
+              </div>
+              <div className="empty-actions">
+                <button className="btn" type="button" onClick={() => void load()}>
+                  Retry now
+                </button>
+              </div>
+            </div>
+          ) : sessions.length === 0 ? (
+            <div className="launch-empty">
+              <div>
+                <h3>No runs yet.</h3>
+                <p>Configure a run once, or save it as an automation below.</p>
+              </div>
+              <div className="empty-actions">
+                <button className="btn primary" type="button" onClick={() => setComposerMode("once")}>
+                  Configure a run
+                </button>
+              </div>
+            </div>
+          ) : (
+            <RunHistory sessions={sessions} />
+          )}
+        </div>
+      </section>
+
+      <section className="operate-view" aria-labelledby="automations-heading">
+        <AutomationPanel
+          onNew={() => setComposerMode("automation")}
+          refreshKey={automationRefresh}
+        />
+      </section>
+
+      {composerMode && (
+        <RunComposer
+          initialMode={composerMode}
+          onClose={() => setComposerMode(null)}
+          onRunCreated={() => {
+            setComposerMode(null);
+            void load();
+          }}
+          onAutomationCreated={(automation) => {
+            setComposerMode(null);
+            setMinted(automation);
+            setAutomationRefresh((current) => current + 1);
+          }}
+        />
+      )}
+
+      {minted && <ShowAutomationSecrets minted={minted} onClose={() => setMinted(null)} />}
+    </>
+  );
+}

--- a/apps/web/app/app/automations/[id]/page.tsx
+++ b/apps/web/app/app/automations/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   TriggerSubscription,
 } from "../../../lib/api";
 import { AutomationContract, CopyBlock, TemplateChips } from "../../../components/AutomationContract";
+import { Breadcrumb } from "../../../components/Breadcrumb";
 import { AutomationActivity } from "../../../components/AutomationPanel";
 import { MintedAutomation, ShowAutomationSecrets } from "../../../components/RunComposer";
 import { ScheduleBuilder } from "../../../components/ScheduleBuilder";
@@ -96,6 +97,7 @@ export default function AutomationDetail({ params }: { params: Promise<{ id: str
     <div className="automation-detail">
       <header className="automation-detail-head">
         <div>
+          <Breadcrumb leaf={sub.name} />
           <div className="automation-title-line">
             <span className="automation-kind">
               {sub.trigger_kind === "schedule" ? "Schedule" : sub.trigger_kind === "event" ? "Event" : "API"}

--- a/apps/web/app/app/capabilities/page.tsx
+++ b/apps/web/app/app/capabilities/page.tsx
@@ -41,6 +41,7 @@ import {
 import { OwnerPicker } from "../../components/OwnerPicker";
 import { useSmartPolling } from "../../lib/useSmartPolling";
 import { AddServerWizard } from "./AddServerWizard";
+import { ConfirmAction } from "../../components/ConfirmAction";
 
 type Tab = "store" | "bundles" | "connections";
 
@@ -135,7 +136,13 @@ function Capabilities() {
     <>
       <PageHead
         title="MCP"
-        sub="MCP tools your agents can call during a run. Connect a service once — every call still passes the permission gate. Attach ≠ allow."
+        // Signposts the three tabs rather than renaming them: connector,
+        // connection and bundle are genuinely different objects in the domain
+        // (a catalog entry, an authorized instance holding a credential, and
+        // stdio tools baked into the sandbox image), so collapsing them to one
+        // word would flatten a distinction the permission gate actually makes.
+        // What was missing was a sentence saying which is which.
+        sub="MCP tools your agents can call during a run. A Connection is a service the control plane calls on the agent's behalf, holding your credential outside the sandbox; a Bundle is tools packaged inside the sandbox image, with no credential at all. Connect once — every call still passes the permission gate. Attach ≠ allow."
       />
 
       <div className="tabs">
@@ -591,9 +598,13 @@ function ToolConnections({
                     Tools
                   </button>
                   {c.status === "active" ? (
-                    <button className="btn ghost sm danger" onClick={() => onRevoke(c.id)}>
-                      Revoke
-                    </button>
+                    <ConfirmAction
+                      label="Revoke"
+                      title="Revoke this connection?"
+                      body="The stored credential is destroyed and every agent that requires this connection fails closed from now on. Runs already frozen keep their tool snapshots, and history is untouched. Reconnecting later re-runs the authorization."
+                      confirmLabel="Revoke connection"
+                      onConfirm={() => onRevoke(c.id)}
+                    />
                   ) : c.auth_kind === "oauth" ? (
                     <button className="btn ghost sm" onClick={() => onReconnect(c.id)}>
                       Reconnect

--- a/apps/web/app/app/governance/[name]/page.tsx
+++ b/apps/web/app/app/governance/[name]/page.tsx
@@ -245,7 +245,7 @@ export default function PolicyDetailPage({ params }: { params: Promise<{ name: s
   if (!detail || !draft) {
     return (
       <>
-        <PageHead title={name} crumbs={[{ href: "/governance", label: "Governance" }]} />
+        <PageHead title={name} leaf={name} />
         {err ? (
           <div className="err" role="alert">
             {err}
@@ -289,7 +289,7 @@ export default function PolicyDetailPage({ params }: { params: Promise<{ name: s
       <PageHead
         title={detail.policy.name}
         sub={`Version ${detail.policy.version}${dirty ? " · draft in progress" : ""}`}
-        crumbs={[{ href: "/governance", label: "Governance" }]}
+        leaf={name}
       />
 
       {/* Publishing applies to every FUTURE run of every agent on this policy. */}

--- a/apps/web/app/app/integrations/page.tsx
+++ b/apps/web/app/app/integrations/page.tsx
@@ -22,6 +22,7 @@ import { useAuthMe } from "../../lib/useAuthMe";
 import { GitHubMark, LoadingRows, ModalShell, OwnerTag, PageHead } from "../../components/bits";
 import { OwnerPicker } from "../../components/OwnerPicker";
 import type { AuthMe } from "../../lib/api";
+import { ConfirmAction } from "../../components/ConfirmAction";
 
 export default function Integrations() {
   const me = useAuthMe();
@@ -250,9 +251,13 @@ export default function Integrations() {
                         </button>
                       </>
                     )}
-                    <button className="btn ghost sm danger" onClick={() => revokeReg(r.id)}>
-                      Revoke
-                    </button>
+                    <ConfirmAction
+                      label="Revoke"
+                      title="Revoke this GitHub App registration?"
+                      body="Every connection this registration custodies stops working immediately, and its sealed credentials are dropped. Run history and audit records remain — they are append-only. You can re-approve the registration later, which keeps the same connection ids."
+                      confirmLabel="Revoke registration"
+                      onConfirm={() => revokeReg(r.id)}
+                    />
                   </span>
                 </div>
               ))}
@@ -342,9 +347,13 @@ export default function Integrations() {
                     </button>
                   )}
                   {c.status === "active" && (
-                    <button className="btn ghost sm danger" onClick={() => revoke(c.id)}>
-                      Revoke
-                    </button>
+                    <ConfirmAction
+                      label="Revoke"
+                      title="Revoke this connection?"
+                      body="The stored credential is destroyed and any run that needs this connection fails closed from now on. Runs already frozen keep their snapshots, and history is untouched. Reconnecting later re-runs the authorization."
+                      confirmLabel="Revoke connection"
+                      onConfirm={() => revoke(c.id)}
+                    />
                   )}
                 </span>
               </div>

--- a/apps/web/app/app/layout.tsx
+++ b/apps/web/app/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
+import { RouteFocus } from "../components/RouteFocus";
 import { Sidebar, type WorkosSessionBadge } from "../components/Sidebar";
 import { webMode } from "../lib/proxy-auth";
 import { webAuthMode } from "../lib/web-auth";
@@ -50,8 +51,17 @@ export default async function AppLayout({ children }: LayoutProps<"/app">) {
 
   const shell = (
     <div className="shell">
+      {/* First focusable element on the page; tabIndex on main makes the
+          fragment target reliably take focus in every browser. RouteFocus
+          handles the CLIENT-navigation half of the same contract. */}
+      <a className="skip-link" href="#content">
+        Skip to content
+      </a>
       <Sidebar mode={WEB_MODE} workosSession={workosSession} signOut={signOutAction} />
-      <main className="main">{children}</main>
+      <main className="main" id="content" tabIndex={-1}>
+        <RouteFocus />
+        {children}
+      </main>
     </div>
   );
 

--- a/apps/web/app/app/loading.tsx
+++ b/apps/web/app/app/loading.tsx
@@ -1,0 +1,8 @@
+import { LoadingRows } from "../components/bits";
+
+// Suspense fallback for the dashboard segment. Reuses the hairline shimmer the
+// pages already use for their own loading states, so a navigation and an
+// in-page refresh look like the same thing rather than two different products.
+export default function Loading() {
+  return <LoadingRows rows={6} />;
+}

--- a/apps/web/app/app/not-found.tsx
+++ b/apps/web/app/app/not-found.tsx
@@ -1,0 +1,15 @@
+import { StateNotFound } from "../components/state";
+
+// Dashboard not-found. Catches `notFound()` thrown inside /app/* and renders
+// inside the dashboard shell, so the masthead stays put and the way back is a
+// dashboard route rather than the marketing home.
+export default function AppNotFound() {
+  return (
+    <StateNotFound
+      title="not found in this workspace"
+      body="This may have been deleted, or you may not have access to it."
+      href="/app"
+      label="Back to overview"
+    />
+  );
+}

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -3,17 +3,11 @@
 import { Suspense, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import {
-  apiGet,
-  apiPost,
-  Approval,
-  isTerminal,
-  Session,
-  workspaceLabel,
-} from "../lib/api";
+import { apiGet, apiPost, Approval, isTerminal, Session } from "../lib/api";
 import { ApprovalActions } from "../components/ApprovalActions";
 import { AutomationPanel } from "../components/AutomationPanel";
 import { ResourceOverview } from "../components/ResourceOverview";
+import { RunHistory } from "../components/RunHistory";
 import { AddServerWizard } from "./capabilities/AddServerWizard";
 import {
   MintedAutomation,
@@ -21,7 +15,7 @@ import {
   RunMode,
   ShowAutomationSecrets,
 } from "../components/RunComposer";
-import { AutoPill, LoadingRows, Pill, short, timeAgo } from "../components/bits";
+import { LoadingRows, short } from "../components/bits";
 import { useSmartPolling } from "../lib/useSmartPolling";
 
 type OperateView = "history" | "automations";
@@ -173,7 +167,7 @@ export default function Runs() {
                   <div className="d">
                     <b className="mono">{approval.tool}</b>{" "}
                     <span className="mono mut">{approval.summary}</span>{" "}
-                    <Link href={`/sessions/${approval.session_id}`} className="link mono approval-session-link">
+                    <Link href={`/app/sessions/${approval.session_id}`} className="link mono approval-session-link">
                       {short(approval.session_id)}
                     </Link>
                   </div>
@@ -250,28 +244,7 @@ export default function Runs() {
                 </div>
               </div>
             ) : (
-              <div className="run-rows">
-                {sessions.map((session) => (
-                  <Link key={session.id} href={`/sessions/${session.id}`} className="run-row">
-                    <span className="run-copy">
-                      <strong>{session.task}</strong>
-                      <small>
-                        <span className="mono">{short(session.id)}</span>
-                        <span>·</span>
-                        <span>{session.trigger?.kind || "manual"}</span>
-                        {session.repo_source && (
-                          <><span>·</span><span>{workspaceLabel(session.repo_source)}</span></>
-                        )}
-                      </small>
-                    </span>
-                    <span className="run-status">
-                      <Pill status={session.status} />
-                      {session.autonomy === "autonomous" && <AutoPill autonomy={session.autonomy} />}
-                    </span>
-                    <span className="run-time">{timeAgo(session.created_at)}</span>
-                  </Link>
-                ))}
-              </div>
+              <RunHistory sessions={sessions} />
             )}
           </div>
         </section>

--- a/apps/web/app/app/recipes/[slug]/page.tsx
+++ b/apps/web/app/app/recipes/[slug]/page.tsx
@@ -85,7 +85,7 @@ export default function RecipeDetailPage({
   return (
     <>
       <PageHead
-        crumbs={[{ href: "/app/recipes", label: "Recipes" }]}
+        leaf={r.name}
         title={r.name}
         sub={r.tagline}
         right={

--- a/apps/web/app/app/recipes/instances/[id]/page.tsx
+++ b/apps/web/app/app/recipes/instances/[id]/page.tsx
@@ -94,10 +94,7 @@ export default function RecipeInstancePage({
   return (
     <>
       <PageHead
-        crumbs={[
-          { href: "/app/recipes", label: "Recipes" },
-          { href: "/app/recipes?tab=deployments", label: "Deployments" },
-        ]}
+        leaf={instance.name}
         title={instance.name}
         sub={`From ${instance.recipe_slug} · v${instance.recipe_version}`}
         right={<Pill status={instance.status} />}

--- a/apps/web/app/app/resources/layout.tsx
+++ b/apps/web/app/app/resources/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Resources",
+  description: "The agents, MCP servers, and integrations every run draws from.",
+};
+
+export default function ResourcesLayout({ children }: LayoutProps<"/app/resources">) {
+  return children;
+}

--- a/apps/web/app/app/resources/page.tsx
+++ b/apps/web/app/app/resources/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { ResourceOverview } from "../../components/ResourceOverview";
+import { RunComposer } from "../../components/RunComposer";
+import { PageHead } from "../../components/bits";
+import { AddServerWizard } from "../capabilities/AddServerWizard";
+
+// The resources workbench (2026-08-14 navigation-boundary design): the index
+// of agents, MCP servers, and integrations as a real place — what the
+// masthead's `resources` points at and what agents/capabilities/integrations
+// breadcrumb back to. ResourceOverview is the same component Overview embeds,
+// so the two surfaces cannot drift; Overview stays the summary.
+export default function ResourcesPage() {
+  const [agentComposer, setAgentComposer] = useState(false);
+  const [showCapabilityWizard, setShowCapabilityWizard] = useState(false);
+  const [resourceRefresh, setResourceRefresh] = useState(0);
+
+  return (
+    <>
+      <PageHead
+        title="Resources"
+        sub="The agents, MCP servers, and integrations every run draws from."
+      />
+      <ResourceOverview
+        refreshKey={resourceRefresh}
+        onCreateAgent={() => setAgentComposer(true)}
+        onAddCapability={() => setShowCapabilityWizard(true)}
+      />
+      {agentComposer && (
+        <RunComposer
+          agentOnly
+          onClose={() => setAgentComposer(false)}
+          onRunCreated={() => {}}
+          onAutomationCreated={() => {}}
+          onAgentCreated={() => {
+            setAgentComposer(false);
+            setResourceRefresh((current) => current + 1);
+          }}
+        />
+      )}
+      {showCapabilityWizard && (
+        <AddServerWizard
+          onClose={() => {
+            setShowCapabilityWizard(false);
+            setResourceRefresh((current) => current + 1);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/app/app/sessions/[id]/page.tsx
+++ b/apps/web/app/app/sessions/[id]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { use, useEffect, useRef, useState, useCallback } from "react";
-import Link from "next/link";
 import {
   apiGet,
   apiPost,
@@ -16,6 +15,7 @@ import {
   workspaceLabel,
 } from "../../../lib/api";
 import { ApprovalActions } from "../../../components/ApprovalActions";
+import { Breadcrumb } from "../../../components/Breadcrumb";
 import { Pill, AutoPill, DiffView, LoadingRows, short } from "../../../components/bits";
 import { StateError } from "../../../components/state";
 import { useSmartPolling } from "../../../lib/useSmartPolling";
@@ -148,11 +148,7 @@ export default function SessionDetail({ params }: { params: Promise<{ id: string
     <>
       <div className="pagehead">
         <div style={{ minWidth: 0 }}>
-          <div className="crumbs">
-            <Link href="/app">Runs</Link>
-            <span>/</span>
-            <span className="mono">{short(id)}</span>
-          </div>
+          <Breadcrumb leaf={short(id)} />
           <h1
             className="title"
             title={session?.task || undefined}

--- a/apps/web/app/app/sessions/[id]/page.tsx
+++ b/apps/web/app/app/sessions/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../lib/api";
 import { ApprovalActions } from "../../../components/ApprovalActions";
 import { Pill, AutoPill, DiffView, LoadingRows, short } from "../../../components/bits";
+import { StateError } from "../../../components/state";
 import { useSmartPolling } from "../../../lib/useSmartPolling";
 
 export default function SessionDetail({ params }: { params: Promise<{ id: string }> }) {
@@ -30,6 +31,10 @@ export default function SessionDetail({ params }: { params: Promise<{ id: string
   const [loading, setLoading] = useState(true);
   const [hasSnapshot, setHasSnapshot] = useState(false);
   const [loadError, setLoadError] = useState("");
+  /** The rejection reason of the CORE /sessions/{id} read, kept as-is rather
+   *  than flattened to a string: it is what tells a deleted run (404) apart
+   *  from an outage, and offering "Retry now" for a 404 was the defect. */
+  const [coreError, setCoreError] = useState<unknown>(null);
   const [actionError, setActionError] = useState("");
   const [actingOn, setActingOn] = useState<string | null>(null);
   const [streamReconnecting, setStreamReconnecting] = useState(false);
@@ -48,8 +53,10 @@ export default function SessionDetail({ params }: { params: Promise<{ id: string
       setSession(core.value.session);
       setUsage(core.value.usage);
       setHasSnapshot(true);
+      setCoreError(null);
     } else {
       failed.push("run");
+      setCoreError(core.reason);
     }
     if (approvalResult.status === "fulfilled") {
       setApprovals(approvalResult.value.approvals);
@@ -199,30 +206,26 @@ export default function SessionDetail({ params }: { params: Promise<{ id: string
       {actionError && <div className="err" role="alert">{actionError}</div>}
 
       {!hasSnapshot ? (
-        <div className="panel">
+        <>
           {loading ? (
-            <LoadingRows />
-          ) : (
-            <div className="launch-empty">
-              <div>
-                <h3>Run detail is unavailable.</h3>
-                <p>No cost, usage, or activity assumptions were made from the failed response.</p>
-              </div>
-              <div className="empty-actions">
-                <button
-                  className="btn"
-                  type="button"
-                  onClick={() => {
-                    setLoading(true);
-                    void loadMeta();
-                  }}
-                >
-                  Retry now
-                </button>
-              </div>
+            <div className="panel">
+              <LoadingRows />
             </div>
+          ) : (
+            // Reads the status: a deleted or mistyped run id renders
+            // not-found (no Retry — retrying a 404 can never succeed), while a
+            // 5xx or a dead control plane renders the outage card that does
+            // offer one. This used to be a single hand-rolled outage card for
+            // every failure.
+            <StateError
+              error={coreError}
+              onRetry={() => {
+                setLoading(true);
+                void loadMeta();
+              }}
+            />
           )}
-        </div>
+        </>
       ) : (
       <>
       {/* Approval banners */}

--- a/apps/web/app/components/AutomationPanel.tsx
+++ b/apps/web/app/components/AutomationPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { StateError } from "./state";
 import {
   Agent,
   apiGet,
@@ -259,6 +260,8 @@ export function AutomationActivity({ id }: { id: string }) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [deliveries, setDeliveries] = useState<ResultDelivery[]>([]);
   const [invocations, setInvocations] = useState<TriggerInvocation[]>([]);
+  const [hasSnapshot, setHasSnapshot] = useState(false);
+  const [pollError, setPollError] = useState<unknown>(null);
 
   const poll = useCallback(async () => {
     try {
@@ -270,11 +273,23 @@ export function AutomationActivity({ id }: { id: string }) {
       setSessions(response.sessions);
       setDeliveries(response.deliveries);
       setInvocations(response.invocations || []);
-    } catch {
-      /* Keep the last successful activity snapshot. */
+      setHasSnapshot(true);
+      setPollError(null);
+    } catch (error) {
+      // Keeping the last good snapshot is the right call for a POLL — a blip
+      // should not blank a panel someone is watching. What was wrong is that
+      // before the FIRST success there is no snapshot to keep, so the error
+      // was swallowed and the columns fell through to their empty copy:
+      // "No runs yet." reported an outage as an automation that had never run.
+      setPollError(error);
     }
   }, [id]);
   useSmartPolling(poll, 4000);
+
+  // A failed read is never rendered as empty.
+  if (!hasSnapshot && pollError) {
+    return <StateError error={pollError} onRetry={() => void poll()} />;
+  }
 
   return (
     <div className="automation-activity">

--- a/apps/web/app/components/Breadcrumb.tsx
+++ b/apps/web/app/components/Breadcrumb.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { crumbsFor } from "../lib/nav";
+
+/**
+ * The route-derived breadcrumb trail (2026-08-14 navigation-boundary design).
+ * Reads lib/nav.ts — the same table that drives the masthead's active state —
+ * so the trail and the you-are-here highlight cannot disagree, and no page
+ * hand-maintains its own ancestry (the hand-written trails this replaced had
+ * already drifted: one linked to pre-split /governance and bounced through a
+ * 308). Renders nothing on section index pages — they ARE the top of their
+ * trail — and off the dashboard entirely.
+ *
+ * `leaf` labels a dynamic last segment (a run id, an automation name) with the
+ * human-readable form the page already shows in its heading.
+ */
+export function Breadcrumb({ leaf }: { leaf?: string }) {
+  const pathname = usePathname();
+  const crumbs = crumbsFor(pathname, { leaf });
+  if (crumbs.length === 0) return null;
+
+  return (
+    <nav className="crumbs" aria-label="Breadcrumb">
+      <ol>
+        {crumbs.map((crumb, index) => (
+          <li key={`${crumb.label}-${index}`}>
+            {index > 0 && <span aria-hidden="true">/</span>}
+            {crumb.href ? (
+              <Link href={crumb.href}>{crumb.label}</Link>
+            ) : (
+              <span aria-current="page">{crumb.label}</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/web/app/components/ConfirmAction.tsx
+++ b/apps/web/app/components/ConfirmAction.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { ModalShell } from "./bits";
+
+/**
+ * A destructive button that asks first.
+ *
+ * Revoking a credential used to fire on a single click — no confirmation, no
+ * undo, and the same visual weight as "Refresh". The product already had the
+ * right pattern (recipes/instances/[id] guards its delete with a ModalShell);
+ * it just was not applied to the one action that destroys a credential.
+ *
+ * Deliberately NOT window.confirm: two places in this codebase still use it,
+ * and it renders an OS dialog that ignores the product's voice entirely. This
+ * reuses ModalShell so a confirmation looks like the rest of the app.
+ */
+export function ConfirmAction({
+  label,
+  title,
+  body,
+  confirmLabel,
+  onConfirm,
+  className = "btn ghost sm danger",
+  disabled = false,
+}: {
+  label: string;
+  title: string;
+  body: React.ReactNode;
+  confirmLabel: string;
+  onConfirm: () => void;
+  className?: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button className={className} type="button" disabled={disabled} onClick={() => setOpen(true)}>
+        {label}
+      </button>
+      {open && (
+        <ModalShell title={title} onClose={() => setOpen(false)}>
+          {typeof body === "string" ? <p>{body}</p> : body}
+          <div className="modal-footer">
+            <button className="btn ghost" type="button" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+            <button
+              className="btn danger"
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onConfirm();
+              }}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </ModalShell>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/components/RouteFocus.tsx
+++ b/apps/web/app/components/RouteFocus.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+/** How long after a navigation a streamed-in <h1> may still claim focus. Past
+ *  this, moving focus would interrupt whatever the user has started doing. */
+const FOCUS_WINDOW_MS = 3000;
+
+/**
+ * After a CLIENT navigation, move focus to the new page's <h1> so keyboard and
+ * screen-reader users land on the content they navigated to instead of staying
+ * on the masthead link they clicked (2026-08-14 navigation-boundary design).
+ * The first render is a full document load — the browser's own focus handling
+ * is correct there and is left alone.
+ *
+ * The App Router commits the route's loading state FIRST and streams the page
+ * in after, so the h1 usually does not exist when this effect fires — a
+ * one-shot querySelector here silently did nothing. Watch for it instead,
+ * bounded by FOCUS_WINDOW_MS, and never steal focus the user has already
+ * moved into the new page themselves.
+ */
+export function RouteFocus() {
+  const pathname = usePathname();
+  const previousPathname = useRef<string | null>(null);
+
+  useEffect(() => {
+    const isInitialLoad = previousPathname.current === null;
+    if (isInitialLoad || previousPathname.current === pathname) {
+      previousPathname.current = pathname;
+      return;
+    }
+    previousPathname.current = pathname;
+
+    const focusUnclaimed = () => {
+      const current = document.activeElement;
+      // Focus is "unclaimed" while it still sits where the navigation left it:
+      // the body, or the masthead link that was clicked.
+      return current === document.body || current === null || !!current.closest(".topbar");
+    };
+    const focusHeading = (): boolean => {
+      const heading = document.querySelector<HTMLElement>("main h1");
+      if (!heading) return false;
+      if (focusUnclaimed()) {
+        // An h1 is not natively focusable; -1 lets script focus it without
+        // adding it to the tab order.
+        heading.tabIndex = -1;
+        heading.focus();
+      }
+      return true;
+    };
+
+    if (focusHeading()) return;
+    const observer = new MutationObserver(() => {
+      if (focusHeading()) observer.disconnect();
+    });
+    observer.observe(document.querySelector("main") ?? document.body, {
+      childList: true,
+      subtree: true,
+    });
+    const deadline = window.setTimeout(() => observer.disconnect(), FOCUS_WINDOW_MS);
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(deadline);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/web/app/components/RunComposer.tsx
+++ b/apps/web/app/components/RunComposer.tsx
@@ -1384,7 +1384,7 @@ export function RunComposer({
         {!agentOnly && (
           <ComposerSection
             index={4}
-            title="Guardrails"
+            title="Policy"
             hint="How much freedom this run gets. Every action is logged either way."
           >
             <>
@@ -1742,7 +1742,7 @@ export function RunComposer({
 
             {!agentOnly && (
               <SpecRow
-                label="Guardrails"
+                label="Policy"
                 value={
                   activePreset === "free"
                     ? "Free rein"

--- a/apps/web/app/components/RunHistory.tsx
+++ b/apps/web/app/components/RunHistory.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { Session, workspaceLabel } from "../lib/api";
+import { AutoPill, Pill, short, timeAgo } from "./bits";
+
+/**
+ * The run-history rows, shared by Overview and /app/activity so the two
+ * surfaces cannot drift. Data stays with the page — each has its own polling
+ * cadence and its own loading/empty states — this is only the populated list.
+ */
+export function RunHistory({ sessions }: { sessions: Session[] }) {
+  return (
+    <div className="run-rows">
+      {sessions.map((session) => (
+        <Link key={session.id} href={`/app/sessions/${session.id}`} className="run-row">
+          <span className="run-copy">
+            <strong>{session.task}</strong>
+            <small>
+              <span className="mono">{short(session.id)}</span>
+              <span>·</span>
+              <span>{session.trigger?.kind || "manual"}</span>
+              {session.repo_source && (
+                <><span>·</span><span>{workspaceLabel(session.repo_source)}</span></>
+              )}
+            </small>
+          </span>
+          <span className="run-status">
+            <Pill status={session.status} />
+            {session.autonomy === "autonomous" && <AutoPill autonomy={session.autonomy} />}
+          </span>
+          <span className="run-time">{timeAgo(session.created_at)}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/components/Sidebar.tsx
+++ b/apps/web/app/components/Sidebar.tsx
@@ -74,12 +74,6 @@ export function Sidebar({
   }, []);
   useSmartPolling(poll, 8000, true);
 
-  const resourcesActive = ["/app/agents", "/app/capabilities", "/app/integrations"].some(
-    (route) => pathname.startsWith(route)
-  );
-  const activityActive = ["/app/sessions", "/app/automations"].some(
-    (route) => pathname.startsWith(route)
-  );
   const closeMobileNav = () => setMobileOpen(false);
 
   return (
@@ -102,18 +96,15 @@ export function Sidebar({
           >
             Overview
           </Link>
-          <Link
-            className={resourcesActive ? "active" : ""}
-            href="/app#configuration"
-            onNavigate={closeMobileNav}
-          >
+          {/* Resources and Activity are jump-links to sections of the Overview
+              page, not routes. They deliberately carry no `active` class: the
+              you-are-here highlight is reserved for a page you are actually on,
+              and lighting "Resources" while the URL reads /app/agents told the
+              user something untrue. */}
+          <Link href="/app#configuration" onNavigate={closeMobileNav}>
             Resources
           </Link>
-          <Link
-            className={activityActive ? "active" : ""}
-            href="/app#operations"
-            onNavigate={closeMobileNav}
-          >
+          <Link href="/app#operations" onNavigate={closeMobileNav}>
             Activity
             {pending > 0 && <span className="masthead-count">{pending}</span>}
           </Link>
@@ -169,26 +160,22 @@ export function Sidebar({
             <span className={`signal ${online ? "" : "down"}`} />
             <span>{online ? "Operational" : "Offline"}</span>
           </div>
-          <Link className="topbar-action" href="/app?action=new-run">
-            New Run
-          </Link>
+          {/* No desktop "New Run" here. Every page that can start a run renders
+              its own primary (e.g. app/app/page.tsx), so this was a second dark
+              primary competing with it — and its 76px (90px with the gap) is
+              exactly what the header needed to stop clipping the nav. The
+              mobile dropdown keeps its own .mobile-primary-action above, where
+              no page primary is in view. */}
           <ThemeToggle />
+          {/* Classes, not inline style. An inline `display` cannot be
+              overridden by a stylesheet, so the compact-desktop rule that hides
+              the identity text below 1280px was silently a no-op while these
+              were style={{…}} — the header kept overflowing by 20px. */}
           {workosSession && (
-            <div
-              style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}
-              data-testid="workos-session-shell"
-            >
+            <div className="masthead-session" data-testid="workos-session-shell">
               <span
+                className="masthead-session-email"
                 title={`${workosSession.label} · ${workosSession.email}`}
-                style={{
-                  fontSize: 11.5,
-                  color: "var(--ds-gray-800)",
-                  fontFamily: "var(--font-mono)",
-                  maxWidth: 150,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
               >
                 {workosSession.email}
               </span>
@@ -202,25 +189,11 @@ export function Sidebar({
             </div>
           )}
           {mode === "sso" && me?.user && (
-            <div
-              style={{ display: "flex", alignItems: "center", gap: 10 }}
-              data-testid="session-shell"
-            >
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  lineHeight: 1.15,
-                  textAlign: "right",
-                }}
-              >
-                <span style={{ fontSize: 12, color: "var(--ds-gray-1000)", fontWeight: 500 }}>
-                  {me.org?.display_name ?? me.org?.slug ?? ""}
-                </span>
-                <span style={{ fontSize: 11, color: "var(--ds-gray-800)" }}>
-                  {me.user.email}
-                </span>
-              </div>
+            <div className="masthead-session" data-testid="session-shell">
+              <span className="masthead-session-id">
+                <strong>{me.org?.display_name ?? me.org?.slug ?? ""}</strong>
+                <small>{me.user.email}</small>
+              </span>
               <button className="btn sm ghost" onClick={() => void logout()}>
                 Log out
               </button>

--- a/apps/web/app/components/Sidebar.tsx
+++ b/apps/web/app/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { apiGet, apiGetCached, AuthMe, logout } from "../lib/api";
+import { NAV, sectionFor } from "../lib/nav";
 import { useSmartPolling } from "../lib/useSmartPolling";
 import { ThemeToggle } from "./ThemeToggle";
 
@@ -75,6 +76,7 @@ export function Sidebar({
   useSmartPolling(poll, 8000, true);
 
   const closeMobileNav = () => setMobileOpen(false);
+  const activeSection = sectionFor(pathname);
 
   return (
     <header className="topbar">
@@ -89,48 +91,32 @@ export function Sidebar({
           id="primary-navigation"
           aria-label="Primary navigation"
         >
-          <Link
-            className={pathname === "/app" ? "active" : ""}
-            href="/app"
-            onNavigate={closeMobileNav}
-          >
-            Overview
-          </Link>
-          {/* Resources and Activity are jump-links to sections of the Overview
-              page, not routes. They deliberately carry no `active` class: the
-              you-are-here highlight is reserved for a page you are actually on,
-              and lighting "Resources" while the URL reads /app/agents told the
-              user something untrue. */}
-          <Link href="/app#configuration" onNavigate={closeMobileNav}>
-            Resources
-          </Link>
-          <Link href="/app#operations" onNavigate={closeMobileNav}>
-            Activity
-            {pending > 0 && <span className="masthead-count">{pending}</span>}
-          </Link>
-          <Link
-            className={pathname.startsWith("/app/recipes") ? "active" : ""}
-            href="/app/recipes"
-            onNavigate={closeMobileNav}
-          >
-            Recipes
-          </Link>
-          <Link
-            className={pathname.startsWith("/app/governance") ? "active" : ""}
-            href="/app/governance"
-            onNavigate={closeMobileNav}
-          >
-            Governance
-          </Link>
+          {/* The six sections come from lib/nav's NAV table — the same table
+              the breadcrumb walks — and you-are-here is sectionFor(pathname),
+              so a route can never light two items, or none while the trail
+              claims an ancestor. Resources and Activity are REAL routes since
+              the 2026-08-14 navigation pass, not #hash jumps onto Overview
+              (which lit nothing and left deep pages with no parent). */}
+          {NAV.map((item) => (
+            <Link
+              key={item.id}
+              className={activeSection === item.id ? "active" : ""}
+              href={item.href}
+              onNavigate={closeMobileNav}
+            >
+              {item.label}
+              {item.id === "activity" && pending > 0 && (
+                <span className="masthead-count">{pending}</span>
+              )}
+            </Link>
+          ))}
+          {/* Docs deliberately sits outside NAV: it LEAVES the dashboard for
+              the public surface, and the marker says so before the click. */}
           <Link href="/docs" onNavigate={closeMobileNav}>
             Docs
-          </Link>
-          <Link
-            className={pathname === "/app/settings" ? "active" : ""}
-            href="/app/settings"
-            onNavigate={closeMobileNav}
-          >
-            Settings
+            <span className="masthead-ext" aria-hidden="true">
+              ↗
+            </span>
           </Link>
           <Link
             className="mobile-primary-action"

--- a/apps/web/app/components/bits.tsx
+++ b/apps/web/app/components/bits.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React, { useEffect, useId, useRef } from "react";
-import Link from "next/link";
 import { Connection, ownerBadge } from "../lib/api";
+import { Breadcrumb } from "./Breadcrumb";
 
 export function Pill({ status }: { status: string }) {
   const label = status.replace(/_/g, " ");
@@ -50,26 +50,19 @@ export function PageHead({
   title,
   sub,
   right,
-  crumbs,
+  leaf,
 }: {
   title: string;
   sub?: string;
   right?: React.ReactNode;
-  crumbs?: { href: string; label: string }[];
+  /** Human label for a dynamic trailing segment — see Breadcrumb. The trail
+   *  itself derives from the route (lib/nav.ts); pages no longer hand it in. */
+  leaf?: string;
 }) {
   return (
     <div className="pagehead">
       <div style={{ minWidth: 0 }}>
-        {crumbs && crumbs.length > 0 && (
-          <div className="crumbs">
-            {crumbs.map((c) => (
-              <React.Fragment key={c.href}>
-                <Link href={c.href}>{c.label}</Link>
-                <span aria-hidden>/</span>
-              </React.Fragment>
-            ))}
-          </div>
-        )}
+        <Breadcrumb leaf={leaf} />
         <h1 className="title">{title}</h1>
         {sub && <div className="sub">{sub}</div>}
       </div>

--- a/apps/web/app/components/state.tsx
+++ b/apps/web/app/components/state.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import Link from "next/link";
+import { ApiError, errorDetail } from "../lib/api";
+
+// The shared not-found / empty / error surfaces.
+//
+// They deliberately reuse `.launch-empty` — the card the dashboard already
+// uses for "Agents are unavailable." — so these introduce no new CSS and
+// inherit the kernel identity (flat, hairline, lowercase chrome voice) for
+// free. Marked "use client" for the same reason bits.tsx is: it is the
+// convention for shared presentational components here, and StateError takes
+// an onRetry callback.
+
+function StateCard({
+  code,
+  title,
+  body,
+  children,
+  alert = false,
+}: {
+  /** A machine value (404, 500). Mono, per the type rule for generated data. */
+  code?: string;
+  title: string;
+  body: string;
+  children?: React.ReactNode;
+  alert?: boolean;
+}) {
+  return (
+    <div className="panel launch-empty" {...(alert ? { role: "alert" } : {})}>
+      <div>
+        {code && <p className="mono">{code}</p>}
+        <h3>{title}</h3>
+        <p>{body}</p>
+      </div>
+      {children && <div className="empty-actions">{children}</div>}
+    </div>
+  );
+}
+
+/** A fulfilled read that returned nothing. Never render this for a FAILED
+ *  read — that is the defect this component exists to make hard to write. */
+export function StateEmpty({
+  title,
+  body,
+  action,
+}: {
+  title: string;
+  body: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <StateCard title={title} body={body}>
+      {action}
+    </StateCard>
+  );
+}
+
+/** The thing was asked for by name and does not exist. No Retry: retrying a
+ *  404 can never succeed, and offering it was the original defect. */
+export function StateNotFound({
+  title = "not found",
+  body = "This may have been deleted, or the address may be wrong.",
+  href = "/app",
+  label = "Back to overview",
+}: {
+  title?: string;
+  body?: string;
+  href?: string;
+  label?: string;
+}) {
+  return (
+    <StateCard code="404" title={title} body={body}>
+      <Link className="btn" href={href}>
+        {label}
+      </Link>
+    </StateCard>
+  );
+}
+
+/**
+ * A read that failed. Reads `ApiError.kind` so the copy matches what actually
+ * happened; a 404 delegates to StateNotFound rather than offering a Retry that
+ * cannot work. Never renders `String(error)` at a user.
+ */
+export function StateError({
+  error,
+  onRetry,
+  body,
+  notFoundHref = "/app",
+}: {
+  error: unknown;
+  onRetry?: () => void;
+  /** Overrides the derived copy. Use it where the underlying message is not
+   *  fit to show a person — a Server Component error is replaced by a generic
+   *  framework string in production. */
+  body?: string;
+  notFoundHref?: string;
+}) {
+  const kind = error instanceof ApiError ? error.kind : "error";
+
+  if (kind === "notFound") {
+    return <StateNotFound href={notFoundHref} />;
+  }
+
+  if (kind === "denied") {
+    return (
+      <StateCard
+        alert
+        code="401"
+        title="your session expired"
+        body="Sign in again to continue. Nothing was lost."
+      >
+        <Link className="btn" href="/login">
+          Sign in
+        </Link>
+      </StateCard>
+    );
+  }
+
+  const unreachable = kind === "unreachable";
+  return (
+    <StateCard
+      alert
+      code={error instanceof ApiError ? String(error.status) : undefined}
+      title={unreachable ? "the control plane is unreachable" : "that request failed"}
+      body={
+        body ??
+        (unreachable
+          ? "A failed read is not treated as empty — nothing below was assumed from it."
+          : errorDetail(error))
+      }
+    >
+      {onRetry && (
+        <button className="btn" type="button" onClick={onRetry}>
+          Retry now
+        </button>
+      )}
+    </StateCard>
+  );
+}

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { StateError } from "./components/state";
+
+/**
+ * The root error boundary. Catches an uncaught render error anywhere below the
+ * root layout, which previously fell to Next's built-in page.
+ *
+ * Next 16 renamed the recovery prop. `unstable_retry()` re-fetches AND
+ * re-renders the segment; `reset()` only clears the error state "without
+ * re-fetching the contents" (file-conventions/error.md), which is the wrong
+ * behaviour for a failed read — the same content would simply throw again.
+ * Both are accepted here and `unstable_retry` preferred, so if the `unstable_`
+ * prefix is dropped in a later release this button degrades rather than
+ * silently becoming inert.
+ *
+ * The body copy is fixed rather than taken from `error.message`: errors thrown
+ * in a Server Component are replaced with a generic string plus a digest in
+ * production, so rendering the message would show a person framework text.
+ */
+export default function AppError({
+  error,
+  unstable_retry,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry?: () => void;
+  reset?: () => void;
+}) {
+  return (
+    <main className="main">
+      <StateError
+        error={error}
+        body="This page failed to render. Retrying re-fetches it; if it keeps failing the digest below identifies it in the server logs."
+        onRetry={unstable_retry ?? reset}
+      />
+      {error.digest && (
+        <p className="mono faint" style={{ marginTop: 12 }}>
+          digest {error.digest}
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import "./globals.css";
+import "./kernel.css";
+import { THEME_INIT_SCRIPT } from "./lib/theme";
+
+/**
+ * Replaces the ROOT LAYOUT when the layout itself throws, so per the Next 16
+ * docs it must render its own <html>/<body> and pull in its own global styles —
+ * nothing above it survives to provide them.
+ *
+ * Two consequences worth knowing:
+ *  - next/font is not available here, so type falls back to the system stack.
+ *    Deliberate: this page has to render precisely when the app cannot.
+ *  - metadata exports are unsupported in global-error, so the title is the
+ *    React <title> element instead.
+ *
+ * The theme-init script still runs, so a dark-mode user does not get flashed a
+ * beige page at the worst possible moment.
+ */
+export default function GlobalError({
+  error,
+  unstable_retry,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry?: () => void;
+  reset?: () => void;
+}) {
+  const retry = unstable_retry ?? reset;
+  return (
+    <html lang="en" data-theme="light" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+      </head>
+      <body>
+        <title>Something broke · fluidbox</title>
+        <main className="main">
+          <div className="panel launch-empty" role="alert">
+            <div>
+              <p className="mono">500</p>
+              <h3>something broke</h3>
+              <p>
+                The dashboard could not render at all. Reloading usually clears it. Nothing
+                you were running was affected — runs live in the control plane, not here.
+              </p>
+            </div>
+            <div className="empty-actions">
+              <button className="btn" type="button" onClick={() => retry?.()}>
+                Reload
+              </button>
+            </div>
+          </div>
+          {error.digest && <p className="mono faint">digest {error.digest}</p>}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -8,6 +8,10 @@
   appears only where it identifies a resource or communicates live state.
 */
 
+/* stylelint-disable color-no-hex, scale-unlimited/declaration-strict-value --
+   The token layer is the ONE place a raw colour literal may appear. Every
+   other rule in this file must reach a colour through a custom property;
+   the gate enforces that, and this comment is the visible boundary. */
 :root {
   /* Warm paper scale: beige canvas, charcoal ink (kernel.sh palette). */
   --bg: #f2f0e7;
@@ -65,7 +69,12 @@
   --radius-lg: 8px;
   --hairline: 0.5px;
 }
+/* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
+/* stylelint-disable color-no-hex, scale-unlimited/declaration-strict-value --
+   The token layer is the ONE place a raw colour literal may appear. Every
+   other rule in this file must reach a colour through a custom property;
+   the gate enforces that, and this comment is the visible boundary. */
 html[data-theme="dark"] {
   /* kernel.sh's dark sections: charcoal, not black. */
   --bg: #191a1c;
@@ -110,6 +119,7 @@ html[data-theme="dark"] {
   --skeleton-a: #26282c;
   --skeleton-b: #2f3237;
 }
+/* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
 * {
   box-sizing: border-box;
@@ -448,7 +458,9 @@ select,
   padding: 0 56px;
   margin: 0 auto;
   display: grid;
-  /* The NAV is the column that flexes; brand and actions size to their content.
+  /* The ACTIONS cluster is the column that yields; the nav takes max-content
+   * and cannot clip. See kernel.css .topbar-inner for the fit arithmetic —
+   * kernel loads second and is the value that actually applies.
    *
    * This used to be `minmax(180px, 1fr) auto minmax(180px, 1fr)`, which looks
    * symmetric but inverts the shrink behaviour: the middle track was `auto`, so
@@ -463,7 +475,7 @@ select,
    * `auto minmax(0, 1fr) auto` gives actions the width it actually needs and
    * lets the nav shrink (and scroll) instead. This is the same shape the
    * <=860px breakpoint already used, so the desktop rule was the outlier. */
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto max-content minmax(0, 1fr);
   align-items: center;
   gap: 20px;
 }
@@ -490,33 +502,33 @@ select,
 .masthead-nav {
   display: flex;
   align-items: center;
-  /* min-width:0 is what actually lets the 1fr track shrink — a grid item's
-   * automatic minimum size is its content, so without this the nav would still
-   * refuse to yield and we would be back to overlapping. Overflow scrolls
-   * rather than spilling over the actions cluster. */
-  min-width: 0;
-  overflow-x: auto;
-  justify-content: center;
-  scrollbar-width: none;
+  flex-wrap: nowrap;
   gap: 3px;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: 9px;
-  background: rgba(255, 254, 250, 0.64);
-}
-.masthead-nav::-webkit-scrollbar {
-  display: none;
+  /* `overflow-x: auto`, `justify-content: center`, `scrollbar-width: none` and
+   * the ::-webkit-scrollbar suppressor used to live here. Together they made
+   * the nav a hidden-scrollbar strip: centre justification splits any overflow
+   * across BOTH ends, so the first and last items lost equal slices and the
+   * scrollbar that would have revealed it was hidden. The nav column is now
+   * max-content (kernel.css) and cannot overflow, so all four are gone.
+   * The padding/border/border-radius/background that were also here were
+   * already reset to 0/transparent by kernel.css:250 — dead declarations,
+   * removed with them (they carried the only off-scale 9px radius here). */
 }
 /* The org name + email is the widest thing in the actions cluster and is
- * user-controlled, so it must never be allowed to set the header's width. */
-.masthead-actions [data-testid="session-shell"],
-.masthead-actions [data-testid="workos-session-shell"] {
+ * user-controlled, so it must never be allowed to set the header's width.
+ *
+ * These used to select on `[data-testid]`, which is a test hook rather than a
+ * styling hook — and at specificity 0,2,1 they quietly out-ranked every
+ * class-based rule, so the media query that hides this text on a narrow
+ * desktop was a silent no-op. Now that Sidebar.tsx carries real classes, they
+ * select on those. */
+.masthead-session {
   max-width: 170px;
   min-width: 0;
 }
-.masthead-actions [data-testid="session-shell"] span,
-.masthead-actions [data-testid="workos-session-shell"] span {
-  display: block;
+.masthead-session-id strong,
+.masthead-session-id small,
+.masthead-session-email {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2215,19 +2227,28 @@ a.row:hover,
   padding: 0 16px;
   white-space: pre;
 }
+/* Diff ink. These four sat on raw literals or on the base accent/amber, and
+   the panel they sit on is --raised (kernel.css re-declares `.diff` and wins),
+   NOT --surface. Measured against that real background the old values were
+   1.97:1 and 2.10:1 in dark — below even the 3:1 non-text floor, on the screen
+   where a person reviews what an agent changed.
+   The -dim step is used rather than --green/--red because those measure
+   3.91:1 and 4.17:1 here in light: the tinted row is darker than the canvas
+   the base tokens are tuned for. lib/theme-contrast.test.ts holds all eight
+   cells (add/del/hdr/at x light/dark) at >= 4.5:1. */
 .diff .add {
   background: rgba(76, 183, 130, 0.09);
-  color: #1f6b49;
+  color: var(--green-dim);
 }
 .diff .del {
   background: rgba(229, 83, 75, 0.09);
-  color: #a33d36;
+  color: var(--red-dim);
 }
 .diff .hdr {
-  color: var(--accent);
+  color: var(--accent-dim);
 }
 .diff .at {
-  color: var(--amber);
+  color: var(--amber-dim);
 }
 
 /* ─── Forms ──────────────────────────────────────────────────────────── */
@@ -2962,9 +2983,10 @@ pre.token {
   max-width: 1240px;
   min-height: 64px;
   padding: 0 40px;
-  /* Same correction as the base rule above — this override was re-introducing
-   * the non-shrinking middle track and would have undone the fix. */
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  /* Kept in step with the base rule and with kernel.css: the nav column is
+   * max-content, the actions column yields. A stale value here would win over
+   * globals' base rule and silently reinstate the clip. */
+  grid-template-columns: auto max-content minmax(0, 1fr);
 }
 .masthead-brand {
   gap: 10px;
@@ -4833,7 +4855,13 @@ html[data-theme="light"] .cap-row.blocked {
   background: var(--red-tint);
 }
 
-@media (max-width: 760px) {
+/* The masthead collapses to the vertical dropdown here. Raised from 760 to
+   900: .masthead-menu (the hamburger) is display:none at base and only becomes
+   visible inside this block, so 761-860px was a band with full desktop chrome
+   and NO dropdown fallback — and by the fit arithmetic in kernel.css the
+   desktop header cannot fit below ~1165px, let alone 800. A vertical stack
+   cannot clip horizontally, so 900 is where the guarantee has to start. */
+@media (max-width: 900px) {
   .topbar-inner {
     min-height: 60px;
     padding: 0 14px;
@@ -4853,7 +4881,9 @@ html[data-theme="light"] .cap-row.blocked {
   }
   .masthead-state,
   .topbar-action,
-  .masthead-actions [data-testid="session-shell"] {
+  .masthead-session {
+    /* !important because kernel.css loads after this file and sets
+       `.masthead-session { display: flex }` at the same specificity. */
     display: none !important;
   }
   .theme-toggle {
@@ -5621,28 +5651,53 @@ html[data-theme="light"] .docs-body .shiki,
 html[data-theme="light"] .docs-body .shiki span {
   color: var(--shiki-light) !important;
 }
+/* The copy affordance is ALWAYS visible.
+   It used to be opacity:0 until :hover or :focus-visible. Neither fires on a
+   touch tap (:focus-visible is keyboard-gated), so on a phone or tablet the
+   button was permanently invisible — and because opacity:0 does not disable
+   pointer events, it was also blind-tappable. That is precisely the device
+   someone follows a quickstart on. A hover-only reveal cannot be rescued with
+   `@media (hover: none)` either: a touchscreen laptop reports hover:hover.
+   So it sits quietly at reduced opacity and comes forward on interaction. */
 .docs-copy {
   position: absolute;
   top: 8px;
   right: 8px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  padding: 3px 8px;
+  min-height: 24px;
+  padding: 4px 9px;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--surface);
   color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 120ms ease;
+  opacity: 0.62;
+  transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease;
 }
 .docs-code:hover .docs-copy,
-.docs-copy:focus-visible {
+.docs-copy:focus-visible,
+.docs-copy:hover {
   opacity: 1;
 }
 .docs-copy:hover {
   color: var(--ink);
   border-color: var(--border-strong);
+}
+/* A failed copy is reported, not swallowed. */
+.docs-copy[data-state="failed"] {
+  opacity: 1;
+  border-color: var(--red);
+  color: var(--red);
+}
+/* Where the pointer is a finger, meet the 44px target. */
+@media (pointer: coarse) {
+  .docs-copy {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0 12px;
+    opacity: 1;
+  }
 }
 
 .docs-mermaid {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -6245,6 +6245,24 @@ html[data-theme="light"] .docs-body .shiki span {
   text-decoration-thickness: 1px;
   text-underline-offset: 6px;
 }
+/* Session-aware chrome.
+   BOTH variants ship in the HTML — that is what lets the marketing pages stay
+   statically generated while still showing a signed-in reader the way home.
+   `data-session` is stamped on <html> before first paint (lib/session-hint),
+   so the right one is visible from the very first frame; there is no swap.
+   The default is signed-OUT, so a browser with JS disabled, or a stamp that
+   never ran, offers "Log In" rather than a dashboard link a stranger cannot
+   use. Failing toward the public state is the safe direction. */
+.site-when-in {
+  display: none;
+}
+html[data-session="in"] .site-when-in {
+  display: inline-flex;
+}
+html[data-session="in"] .site-when-out {
+  display: none;
+}
+
 .site-actions {
   display: flex;
   align-items: center;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -703,6 +703,22 @@ h1.title {
 .crumbs a:hover {
   color: var(--ink);
 }
+/* The route-derived trail (components/Breadcrumb) is an <ol> for AT ordering;
+   the list chrome comes off and the flex layout moves onto it. */
+.crumbs ol {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.crumbs li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
 
 /* ─── Cards & panels ─────────────────────────────────────────────────── */
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -30,7 +30,7 @@
      darkened pair for contrast on beige. */
   --flood: #81b300;
   --flood-ink: #1c2024;
-  --accent: #567a00;
+  --accent: #517200;
   --accent-dim: #486700;
   --accent-tint: rgba(129, 179, 0, 0.14);
   --amber: #8a6d1c;
@@ -281,7 +281,7 @@ select,
 .brand .mark {
   width: 25px;
   height: 25px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: grid;
   grid-template-columns: repeat(2, 5px);
   grid-template-rows: repeat(2, 5px);
@@ -296,7 +296,7 @@ select,
   width: 5px;
   height: 5px;
   border: 1px solid rgba(255, 255, 255, 0.88);
-  border-radius: 1px;
+  border-radius: 999px;
 }
 .brand .name {
   display: block;
@@ -310,7 +310,7 @@ select,
   width: 34px;
   height: 34px;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: var(--radius);
   background: transparent;
   color: var(--ink-2);
   align-items: center;
@@ -334,14 +334,14 @@ select,
   padding: 10px;
   margin: 0 2px 22px;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: rgba(255, 254, 250, 0.72);
   box-shadow: 0 1px 2px rgba(39, 35, 30, 0.03);
 }
 .workspace-avatar {
   width: 27px;
   height: 27px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   background: #dedbd2;
   color: var(--ink);
   display: grid;
@@ -385,7 +385,7 @@ select,
   align-items: center;
   gap: 10px;
   padding: 7px 10px;
-  border-radius: 7px;
+  border-radius: var(--radius);
   color: var(--ink-2);
   font-size: 13px;
   transition: background 0.12s, color 0.12s;
@@ -415,8 +415,8 @@ select,
   font-size: 10.5px;
   font-variant-numeric: tabular-nums;
   background: var(--gold);
-  color: #1c2024;
-  border-radius: 4px;
+  color: var(--flood-ink);
+  border-radius: var(--radius);
   min-width: 18px;
   text-align: center;
   padding: 1px 5px;
@@ -539,7 +539,7 @@ select,
   display: flex;
   align-items: center;
   gap: 7px;
-  border-radius: 6px;
+  border-radius: var(--radius);
   color: var(--ink-2);
   font-size: 11.5px;
   font-weight: 500;
@@ -552,9 +552,9 @@ select,
 .masthead-count {
   min-width: 17px;
   padding: 0 4px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--gold);
-  color: #1c2024;
+  color: var(--flood-ink);
   font-family: var(--font-mono);
   font-size: 9px;
   text-align: center;
@@ -788,7 +788,7 @@ h1.title {
 .run-list {
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   background: rgba(255, 254, 250, 0.72);
   box-shadow: 0 12px 40px rgba(48, 43, 36, 0.035);
   animation: enter 0.5s 0.14s ease both;
@@ -816,7 +816,7 @@ h1.title {
 .run-glyph {
   width: 34px;
   height: 34px;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   display: grid;
   place-items: center;
   color: var(--ink-3);
@@ -903,7 +903,7 @@ h1.title {
   display: grid;
   place-items: center;
   border: 1px solid var(--border);
-  border-radius: 15px;
+  border-radius: var(--radius-lg);
   background: var(--raised);
   color: var(--ink-2);
 }
@@ -943,7 +943,7 @@ h1.title {
   min-height: 36px;
   padding: 7px 10px;
   border: 1px solid var(--border);
-  border-radius: 9px;
+  border-radius: var(--radius);
   background: var(--raised);
   display: flex;
   align-items: center;
@@ -960,7 +960,7 @@ h1.title {
   width: 100%;
   padding: 13px 14px;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: rgba(245, 244, 240, 0.62);
 }
 .mode-card.on {
@@ -1024,7 +1024,7 @@ h1.title {
   align-items: center;
   gap: 10px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   background: rgba(255, 254, 250, 0.66);
 }
 .readiness.needs-setup .signal {
@@ -1049,14 +1049,14 @@ h1.title {
 .configuration-loading {
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: var(--surface);
 }
 .resource-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   background: rgba(255, 254, 250, 0.68);
   box-shadow: 0 16px 44px rgba(48, 43, 36, 0.035);
@@ -1127,7 +1127,7 @@ h1.title {
   padding: 3px 7px;
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: var(--bg);
   color: var(--ink-2);
   font-family: var(--font-mono);
@@ -1194,7 +1194,7 @@ h1.title {
   align-items: center;
   gap: 0;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: rgba(245, 244, 240, 0.58);
   color: var(--ink-2);
   font-family: var(--font-sans);
@@ -1219,7 +1219,7 @@ h1.title {
   flex: 0 0 auto;
   display: grid;
   place-items: center;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   background: var(--surface);
   color: var(--ink-3);
   box-shadow: inset 0 0 0 1px var(--border);
@@ -1245,7 +1245,7 @@ h1.title {
   justify-content: space-between;
   gap: 18px;
   border: 1px solid rgba(166, 106, 18, 0.3);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: var(--amber-tint);
 }
 .setup-required strong {
@@ -1273,7 +1273,7 @@ h1.title {
   margin-bottom: 2px;
   padding: 16px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: rgba(255, 254, 250, 0.55);
 }
 .automation-setup .field {
@@ -1300,7 +1300,7 @@ h1.title {
   padding: 16px 16px 2px;
   margin-bottom: 14px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: rgba(255, 254, 250, 0.55);
 }
 .automation-grid-span {
@@ -1310,7 +1310,7 @@ h1.title {
   padding: 16px;
   margin-bottom: 14px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: rgba(255, 254, 250, 0.55);
 }
 .event-options {
@@ -1326,7 +1326,7 @@ h1.title {
 .advanced-config {
   margin-top: 12px;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: rgba(245, 244, 240, 0.45);
 }
 .advanced-config summary {
@@ -1418,7 +1418,7 @@ h1.title {
   margin-top: 2px;
   padding: 3px 6px;
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius);
   color: var(--ink-3);
   font-family: var(--font-mono);
   font-size: 9.5px;
@@ -1626,7 +1626,7 @@ h1.title {
   align-items: flex-start;
   gap: 4px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: rgba(245, 244, 240, 0.58);
   color: var(--ink);
   font-family: var(--font-sans);
@@ -1659,7 +1659,7 @@ h1.title {
   justify-content: space-between;
   gap: 16px;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: rgba(245, 244, 240, 0.62);
 }
 .catalog-state > div,
@@ -1721,7 +1721,7 @@ h1.title {
   min-width: 0;
   padding: 15px;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: rgba(245, 244, 240, 0.58);
 }
 .review-card > span,
@@ -1962,7 +1962,7 @@ a.row:hover,
   font-weight: 500;
   height: 36px;
   padding: 0 14px;
-  border-radius: 9px;
+  border-radius: var(--radius);
   border: 1px solid var(--border-strong);
   background: transparent;
   color: var(--ink);
@@ -1986,7 +1986,7 @@ a.row:hover,
 }
 .btn.primary {
   background: var(--ink);
-  color: #fffefa;
+  color: var(--flood-ink);
   border-color: transparent;
 }
 .btn.primary:hover {
@@ -1994,7 +1994,7 @@ a.row:hover,
 }
 .btn.human {
   background: var(--amber);
-  color: #fffefa;
+  color: var(--flood-ink);
   border-color: transparent;
 }
 .btn.human:hover {
@@ -2062,7 +2062,7 @@ a.row:hover,
   bottom: -1px;
   height: 2px;
   background: var(--ink);
-  border-radius: 2px;
+  border-radius: 999px;
 }
 .tab .n {
   color: var(--ink-3);
@@ -2207,7 +2207,7 @@ a.row:hover,
   background: var(--raised);
   border: 1px solid var(--border);
   padding: 1px 5px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   color: var(--accent);
 }
 
@@ -2355,7 +2355,7 @@ textarea.inp.code {
   display: inline-flex;
   background: var(--bg);
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 2px;
   gap: 2px;
 }
@@ -2368,7 +2368,7 @@ textarea.inp.code {
   font-family: var(--font-sans);
   font-size: 12.5px;
   padding: 5px 11px;
-  border-radius: 6px;
+  border-radius: var(--radius);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -2401,7 +2401,7 @@ fieldset.seg {
   appearance: none;
   background: transparent;
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--radius);
   cursor: pointer;
 }
 fieldset.seg:disabled label,
@@ -2466,7 +2466,7 @@ fieldset.seg:disabled label {
   color: var(--ink-3);
   cursor: pointer;
   padding: 2px;
-  border-radius: 6px;
+  border-radius: var(--radius);
   display: grid;
   place-items: center;
 }
@@ -2538,7 +2538,7 @@ fieldset.seg:disabled label {
   text-align: left;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   padding: 17px;
   cursor: pointer;
   color: inherit;
@@ -2562,7 +2562,7 @@ fieldset.seg:disabled label {
 .store-icon {
   width: 36px;
   height: 36px;
-  border-radius: 9px;
+  border-radius: var(--radius-lg);
   background: var(--raised);
   border: 1px solid var(--border);
   display: grid;
@@ -2623,7 +2623,7 @@ fieldset.seg:disabled label {
   gap: 16px;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   padding: 20px 22px;
   margin-bottom: 18px;
   flex-wrap: wrap;
@@ -2631,7 +2631,7 @@ fieldset.seg:disabled label {
 .feature-card .fi {
   width: 44px;
   height: 44px;
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: var(--raised);
   border: 1px solid var(--border);
   display: grid;
@@ -2687,7 +2687,7 @@ fieldset.seg:disabled label {
   flex-direction: column;
   gap: 12px;
 }
-@media (max-width: 1000px) {
+@media (max-width: 900px) {
   .composer {
     grid-template-columns: 1fr;
   }
@@ -2742,7 +2742,7 @@ fieldset.seg:disabled label {
   text-align: left;
   background: var(--bg);
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 10px 12px;
   cursor: pointer;
   color: var(--ink-2);
@@ -2802,7 +2802,7 @@ fieldset.seg:disabled label {
   gap: 10px;
   padding: 9px 12px;
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   background: var(--bg);
   cursor: pointer;
   transition: border-color 0.12s, background 0.12s;
@@ -2868,7 +2868,7 @@ fieldset.seg:disabled label {
   font-size: 11px;
   color: var(--ink-2);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 2px 7px;
   background: var(--bg);
   white-space: nowrap;
@@ -2936,7 +2936,7 @@ fieldset.seg:disabled label {
   height: 9px;
   width: min(100%, 360px);
   border-radius: 999px;
-  background: linear-gradient(90deg, #ece9e2 20%, #e2ded5 48%, #ece9e2 76%);
+  background: linear-gradient(90deg, var(--skeleton-a) 20%, var(--skeleton-b) 48%, var(--skeleton-a) 76%);
   background-size: 200% 100%;
   animation: shimmer 1.45s linear infinite;
 }
@@ -2966,7 +2966,7 @@ pre.token {
   margin: 0;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: var(--radius);
   padding: 10px 12px;
 }
 
@@ -2998,7 +2998,7 @@ pre.token {
   display: inline-block;
   flex: 0 0 auto;
   border: var(--hairline) solid var(--border-strong);
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--surface);
   box-shadow: none;
 }
@@ -3062,7 +3062,7 @@ pre.token {
   align-items: center;
   justify-content: center;
   border: 1px solid var(--primary-bg);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   background: var(--primary-bg);
   color: var(--primary-ink);
   font-size: 11.5px;
@@ -3146,7 +3146,7 @@ h1.title {
   padding: 17px 18px;
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: var(--surface-soft);
 }
 .ops-metric::before {
@@ -3226,7 +3226,7 @@ a.row:hover,
   position: relative;
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: var(--surface-soft);
   transition: border-color 0.16s ease, background 0.16s ease, transform 0.16s ease;
 }
@@ -3270,7 +3270,7 @@ a.row:hover,
   display: grid;
   place-items: center;
   border: 1px solid currentColor;
-  border-radius: 9px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, currentColor 11%, transparent);
 }
 .resource-glyph svg {
@@ -3347,7 +3347,7 @@ a.row:hover,
   background: var(--primary-hover);
 }
 .btn.human {
-  color: #11100d;
+  color: var(--flood-ink);
 }
 .tab.active::after {
   background: var(--accent);
@@ -3413,7 +3413,7 @@ select.inp {
   justify-content: space-between;
   gap: 14px;
   border: 1px solid color-mix(in srgb, var(--amber) 34%, var(--border));
-  border-radius: 9px;
+  border-radius: var(--radius-lg);
   background: var(--amber-tint);
 }
 .context-switch-confirm strong,
@@ -3433,7 +3433,7 @@ select.inp {
 .embedded-discard {
   margin: 0 0 14px;
   border: 1px solid color-mix(in srgb, var(--amber) 34%, var(--border));
-  border-radius: 9px;
+  border-radius: var(--radius-lg);
 }
 .skeleton {
   background: linear-gradient(90deg, var(--skeleton-a) 20%, var(--skeleton-b) 48%, var(--skeleton-a) 76%);
@@ -3496,7 +3496,7 @@ select.inp {
   gap: 13px;
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: var(--surface-soft);
   color: var(--ink);
   font: inherit;
@@ -3534,7 +3534,7 @@ select.inp {
   gap: 8px;
   padding: 12px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--surface) 60%, transparent);
 }
 .mcp-catalogue-head {
@@ -3598,7 +3598,7 @@ select.inp {
   padding: 7px 14px;
   border: 1px solid var(--accent, var(--ink));
   border-top: 0;
-  border-radius: 0 0 11px 11px;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   background: var(--surface-hover);
   color: var(--ink-2);
   font-size: 11px;
@@ -3624,7 +3624,7 @@ select.inp {
   gap: 12px;
   padding: 13px 15px;
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: var(--radius-lg);
   background: var(--surface-soft);
 }
 .rc-quick-setup-copy {
@@ -3670,38 +3670,38 @@ select.inp {
   place-items: center;
   flex: 0 0 auto;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 10px;
-  background: #20242b;
-  color: #ffffff;
+  border-radius: var(--radius-lg);
+  background: var(--brand-github);
+  color: var(--brand-mark-ink);
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0;
   box-shadow: none;
 }
 .connector-mark-atlassian {
-  background: linear-gradient(145deg, #2684ff, #0754bb);
+  background: linear-gradient(145deg, var(--brand-atlassian-from), var(--brand-atlassian-to));
 }
 .connector-mark-github {
-  background: #20242b;
+  background: var(--brand-github);
 }
 .connector-mark-linear {
-  background: linear-gradient(145deg, #8a7cff, #4c3bcf);
+  background: linear-gradient(145deg, var(--brand-linear-from), var(--brand-linear-to));
 }
 .connector-mark-notion {
-  background: #f3f3f2;
-  color: #111214;
+  background: var(--brand-notion);
+  color: var(--brand-notion-ink);
 }
 .connector-mark-sentry {
-  background: linear-gradient(145deg, #8a68d5, #4f2d91);
+  background: linear-gradient(145deg, var(--brand-sentry-from), var(--brand-sentry-to));
 }
 .connector-mark-stripe {
-  background: linear-gradient(145deg, #7767ff, #5142d8);
+  background: linear-gradient(145deg, var(--brand-stripe-from), var(--brand-stripe-to));
 }
 .connector-mark-workspace {
-  background: linear-gradient(145deg, #36cba8, #187e96);
+  background: linear-gradient(145deg, var(--brand-workspace-from), var(--brand-workspace-to));
 }
 .connector-mark-custom {
-  background: linear-gradient(145deg, #ef7c63, #a74169);
+  background: linear-gradient(145deg, var(--brand-custom-from), var(--brand-custom-to));
 }
 .connector-card-copy,
 .connector-card-title,
@@ -3748,7 +3748,7 @@ select.inp {
   color: var(--amber);
 }
 
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .session-detail-grid {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -4142,7 +4142,7 @@ select.inp {
   }
 }
 
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .topbar-inner {
     grid-template-columns: auto minmax(0, 1fr) auto;
     gap: 14px;
@@ -4294,7 +4294,7 @@ select.inp {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 .matrix-row {
@@ -4344,7 +4344,7 @@ select.inp {
   white-space: nowrap;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 640px) {
   .matrix-row {
     grid-template-columns: minmax(0, 1fr);
     gap: 8px;
@@ -4652,7 +4652,7 @@ select.inp {
   color: var(--ink-3);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius);
   padding: 2px 7px;
 }
 
@@ -4700,7 +4700,7 @@ select.inp {
   color: var(--ink);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius);
   padding: 1px 5px;
 }
 .contract-var {
@@ -4768,7 +4768,7 @@ select.inp {
   justify-content: center;
   gap: 7px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   background: var(--interactive-subtle);
   color: var(--ink-2);
   font: inherit;
@@ -4789,12 +4789,12 @@ select.inp {
   border-color: rgba(33, 34, 37, 0.4);
   background: transparent;
   color: #43474d;
-  border-radius: 4px;
+  border-radius: var(--radius);
 }
 .site-header .theme-toggle:hover {
-  border-color: #81b300;
-  background: #81b300;
-  color: #1c2024;
+  border-color: var(--flood);
+  background: var(--flood);
+  color: var(--st-ink);
 }
 .theme-toggle svg,
 .masthead-menu svg {
@@ -4843,7 +4843,7 @@ html[data-theme="light"] .brand-symbol {
   box-shadow: 0 0 22px var(--accent-tint);
 }
 html[data-theme="light"] .connector-mark-github {
-  background: #292b2f;
+  background: var(--brand-github-light);
 }
 html[data-theme="light"] .connector-mark-notion {
   border-color: var(--border-strong);
@@ -4917,7 +4917,7 @@ html[data-theme="light"] .cap-row.blocked {
     gap: 3px;
     overflow-y: auto;
     border: 1px solid var(--border-strong);
-    border-radius: 12px;
+    border-radius: var(--radius-lg);
     background: var(--surface);
     box-shadow: var(--modal-shadow);
   }
@@ -4929,7 +4929,7 @@ html[data-theme="light"] .cap-row.blocked {
     min-height: 44px;
     padding: 9px 12px;
     justify-content: space-between;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     font-size: 13px;
   }
   .mobile-session {
@@ -5057,7 +5057,7 @@ html[data-theme="light"] .cap-row.blocked {
   width: 20px;
   height: 20px;
   border: 1px solid var(--border-strong);
-  border-radius: 5px;
+  border-radius: var(--radius);
   font-size: 11px;
   color: var(--ink-2);
 }
@@ -5410,7 +5410,7 @@ html[data-theme="light"] .cap-row.blocked {
   font-size: 0.9em;
   background: var(--surface-soft);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius);
   padding: 1px 5px;
 }
 .docs-body pre {
@@ -5521,7 +5521,7 @@ html[data-theme="light"] .cap-row.blocked {
   font-weight: 500;
   letter-spacing: 0.04em;
   padding: 2px 7px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   flex-shrink: 0;
   min-width: 52px;
   text-align: center;
@@ -5574,7 +5574,7 @@ html[data-theme="light"] .cap-row.blocked {
   align-items: baseline;
 }
 
-@media (max-width: 980px) {
+@media (max-width: 900px) {
   .docs-shell {
     grid-template-columns: 1fr;
   }
@@ -5750,7 +5750,7 @@ html[data-theme="light"] .docs-body .shiki span {
   background: var(--surface);
   border: 1px solid var(--border);
   border-bottom-width: 2px;
-  border-radius: 4px;
+  border-radius: var(--radius);
 }
 
 .docs-search-overlay {
@@ -5870,6 +5870,13 @@ html[data-theme="light"] .docs-body .shiki span {
    pages wrapped in `.st` (and the shared header/footer, which pin their
    own colors) opt into this system. */
 
+/* stylelint-disable color-no-hex, scale-unlimited/declaration-strict-value --
+   The marketing token layer. Same contract as the dashboard scale above:
+   this is a token-DEFINITION block, which is the one sanctioned home for a
+   raw literal. Every `.st` rule below must reach colour through one of
+   these names. (Per foundation-spec these should eventually alias the
+   dashboard semantics rather than restate them — but marketing pins itself
+   always-light, so that is a scoped design change, not a sweep.) */
 :root {
   --st-bg: #f2f0e7;
   --st-panel: #faf9f2;
@@ -5892,14 +5899,13 @@ html[data-theme="light"] .docs-body .shiki span {
   --st-charcoal-body: #b3b7bc;
   --st-article: #efe5d7;
   --st-indigo: #8a6d1c;
-  --st-code-bg: #212225;
+  --st-code-bg: var(--term-film-cover);
   --st-mono: var(--font-mono);
   --st-sans: var(--font-sans);
   --st-jp: var(--font-jp);
   --st-sc: var(--font-sc);
-  --st-radius: 4px;
-  --st-radius-lg: 8px;
 }
+/* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
 .skip-link {
   position: absolute;
@@ -5959,6 +5965,16 @@ html[data-theme="light"] .docs-body .shiki span {
      theme-dependent page background. 74px = bar 58 + padding. */
   margin-top: -74px;
   padding-top: 74px;
+  /* stylelint-disable color-no-hex, scale-unlimited/declaration-strict-value --
+     Marketing is deliberately ALWAYS LIGHT, so it re-pins the semantic layer to
+     the light values rather than inheriting tokens that flip. That makes this a
+     token-definition block like the two above — and the one place a literal may
+     appear inside a `.st` rule.
+     The cost of restating rather than aliasing is drift: --accent sat at
+     #567a00 here long after the dashboard token moved, so the marketing site
+     kept a 4.40:1 accent that the dashboard had already fixed. It is now
+     asserted in lib/theme-contrast.test.ts, which fails the build if this
+     scope and the dashboard scale disagree again. */
   --bg: #f2f0e7;
   --surface: #faf9f2;
   --raised: #eae7db;
@@ -5969,8 +5985,9 @@ html[data-theme="light"] .docs-body .shiki span {
   --ink: #1c2024;
   --ink-2: #4c5157;
   --ink-3: #60646c;
-  --accent: #567a00;
+  --accent: #517200;
   --accent-tint: rgba(129, 179, 0, 0.14);
+  /* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 }
 .st ::selection {
   background: rgba(129, 179, 0, 0.25);
@@ -5994,7 +6011,7 @@ html[data-theme="light"] .docs-body .shiki span {
   align-items: center;
   gap: 9px;
   border: 0.5px solid var(--st-ink);
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   background: transparent;
   color: var(--st-ink);
   font-family: var(--st-sans);
@@ -6077,7 +6094,7 @@ html[data-theme="light"] .docs-body .shiki span {
   text-transform: lowercase;
 }
 .site-announce a {
-  color: #9ccf1f;
+  color: var(--term-accent);
   text-decoration: none;
   font-weight: 400;
 }
@@ -6148,7 +6165,7 @@ html[data-theme="light"] .docs-body .shiki span {
 }
 .st-mark i {
   display: block;
-  border-radius: 1px;
+  border-radius: 999px;
   background: var(--st-ink);
 }
 .st-mark i:nth-child(2) {
@@ -6172,7 +6189,7 @@ html[data-theme="light"] .docs-body .shiki span {
 }
 .site-nav a {
   padding: 8px 12px;
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   font-size: 15px;
   font-weight: 400;
   color: var(--st-dim);
@@ -6201,7 +6218,7 @@ html[data-theme="light"] .docs-body .shiki span {
   justify-content: center;
   width: 38px;
   height: 38px;
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   color: var(--st-dim);
   transition: color 0.12s, background 0.12s;
 }
@@ -6223,7 +6240,7 @@ html[data-theme="light"] .docs-body .shiki span {
   align-items: center;
   justify-content: center;
   border: 0.5px solid var(--st-line);
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   background: transparent;
   color: var(--st-ink);
   cursor: pointer;
@@ -6475,7 +6492,7 @@ html[data-theme="light"] .docs-body .shiki span {
   justify-content: center;
   padding: 4px 8px;
   border: 0.5px solid var(--st-ink);
-  border-radius: 4px;
+  border-radius: var(--radius);
   font-size: 15px;
   font-weight: 400;
   letter-spacing: 0;
@@ -6535,9 +6552,9 @@ html[data-theme="light"] .docs-body .shiki span {
 .st-stage-card {
   position: absolute;
   z-index: 2;
-  background: #26282c;
+  background: var(--term-bg);
   border: 0.5px solid rgba(237, 238, 240, 0.24);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 18px 50px rgba(28, 32, 36, 0.35);
   padding: 14px 16px;
 }
@@ -6564,7 +6581,7 @@ html[data-theme="light"] .docs-body .shiki span {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #ffce6a;
+  background: var(--term-gold);
   flex-shrink: 0;
 }
 .st-stage-head .ttl {
@@ -6576,7 +6593,7 @@ html[data-theme="light"] .docs-body .shiki span {
 .st-stage-tool {
   font-family: var(--st-mono);
   font-size: 12px;
-  color: #ecedf3;
+  color: var(--term-ink);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -6595,11 +6612,11 @@ html[data-theme="light"] .docs-body .shiki span {
   display: inline-flex;
   align-items: center;
   padding: 6px 13px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   border: 0.5px solid rgba(237, 238, 240, 0.35);
   font-size: 12px;
   font-weight: 400;
-  color: #edeef0;
+  color: var(--term-ink-strong);
   text-transform: lowercase;
 }
 .st-chipbtn.approve {
@@ -6612,7 +6629,7 @@ html[data-theme="light"] .docs-body .shiki span {
   font-family: var(--st-mono);
   font-size: 11px;
   line-height: 1.65;
-  color: #b0b1c0;
+  color: var(--term-muted);
   white-space: pre;
 }
 .st-stage-label {
@@ -6623,7 +6640,7 @@ html[data-theme="light"] .docs-body .shiki span {
   color: var(--st-faint);
   margin-bottom: 8px;
 }
-@media (max-width: 1120px) {
+@media (max-width: 1280px) {
   .st-stage-approval {
     right: 8px;
     top: -26px;
@@ -6633,7 +6650,7 @@ html[data-theme="light"] .docs-body .shiki span {
     bottom: -22px;
   }
 }
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .st-stage {
     display: flex;
     flex-direction: column;
@@ -6649,7 +6666,7 @@ html[data-theme="light"] .docs-body .shiki span {
 .st-film-body {
   position: relative;
   aspect-ratio: 16 / 9;
-  background: #191a1c;
+  background: var(--term-film-body);
 }
 .st-film-body video {
   display: block;
@@ -6666,7 +6683,7 @@ html[data-theme="light"] .docs-body .shiki span {
   gap: 14px;
   border: 0;
   cursor: pointer;
-  background: #212225;
+  background: var(--term-film-cover);
   color: var(--st-ink);
   font-family: var(--st-sans);
 }
@@ -6705,7 +6722,7 @@ html[data-theme="light"] .docs-body .shiki span {
 .st-window {
   background: var(--st-code-bg);
   border: 0.5px solid rgba(237, 238, 240, 0.2);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 24px 60px rgba(28, 32, 36, 0.22);
   overflow: hidden;
 }
@@ -6726,18 +6743,18 @@ html[data-theme="light"] .docs-body .shiki span {
   border-radius: 50%;
 }
 .st-dots i:nth-child(1) {
-  background: #ff5f57;
+  background: var(--term-red);
 }
 .st-dots i:nth-child(2) {
-  background: #febc2e;
+  background: var(--term-amber);
 }
 .st-dots i:nth-child(3) {
-  background: #2ac840;
+  background: var(--term-green);
 }
 .st-window-title {
   font-family: var(--st-mono);
   font-size: 12px;
-  color: #85869a;
+  color: var(--term-meta);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -6769,7 +6786,7 @@ html[data-theme="light"] .docs-body .shiki span {
   min-width: 0;
   flex: 1;
   font-size: 12px;
-  color: #85869a;
+  color: var(--term-meta);
 }
 .ledger-dot {
   width: 8px;
@@ -6804,12 +6821,12 @@ html[data-theme="light"] .docs-body .shiki span {
   animation-delay: var(--d, 0s);
 }
 .lr-seq {
-  color: #5c5d6e;
+  color: var(--term-faint);
   text-align: right;
   font-size: 11px;
 }
 .lr-type {
-  color: #ecedf3;
+  color: var(--term-ink);
   font-weight: 500;
   font-size: 12px;
 }
@@ -6824,22 +6841,22 @@ html[data-theme="light"] .docs-body .shiki span {
 }
 .lr-chip.allow,
 .lr-chip.ok {
-  color: #6ef0c0;
+  color: var(--term-teal);
   background: rgba(70, 220, 160, 0.11);
   border-color: rgba(70, 220, 160, 0.32);
 }
 .lr-chip.approve {
-  color: #ffce6a;
+  color: var(--term-gold);
   background: rgba(255, 190, 80, 0.11);
   border-color: rgba(255, 190, 80, 0.32);
 }
 .lr-chip.deny {
-  color: #ff8d84;
+  color: var(--term-salmon);
   background: rgba(255, 110, 100, 0.11);
   border-color: rgba(255, 110, 100, 0.32);
 }
 .lr-detail {
-  color: #9d9eae;
+  color: var(--term-detail);
   font-size: 11.5px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -6848,7 +6865,7 @@ html[data-theme="light"] .docs-body .shiki span {
 .lr-pause {
   display: block;
   text-align: center;
-  color: #ffce6a;
+  color: var(--term-gold);
   font-size: 11px;
   padding: 8px 12px;
 }
@@ -6857,7 +6874,7 @@ html[data-theme="light"] .docs-body .shiki span {
   margin: 8px 12px 0;
   padding: 9px 2px 0;
   border-top: 1px dashed rgba(255, 255, 255, 0.14);
-  color: #85869a;
+  color: var(--term-meta);
   font-size: 11px;
 }
 .lr-tail {
@@ -6955,7 +6972,7 @@ html[data-theme="light"] .docs-body .shiki span {
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   border: 0.5px solid var(--st-ink);
   background: transparent;
   color: var(--st-ink);
@@ -7074,7 +7091,7 @@ html[data-theme="light"] .docs-body .shiki span {
   padding: 26px 26px 22px;
   background: var(--st-panel);
   border: 1px solid var(--st-line);
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   transition: border-color 0.16s, background 0.16s;
 }
 .feature:hover {
@@ -7110,11 +7127,11 @@ html[data-theme="light"] .docs-body .shiki span {
   padding: 13px 15px;
   background: var(--st-code-bg);
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--radius);
   font-family: var(--st-mono);
   font-size: 11.5px;
   line-height: 1.65;
-  color: #b0b1c0;
+  color: var(--term-muted);
   white-space: pre-wrap;
   overflow-x: auto;
 }
@@ -7129,7 +7146,7 @@ html[data-theme="light"] .docs-body .shiki span {
   text-decoration: underline;
   text-underline-offset: 3px;
 }
-@media (min-width: 961px) {
+@media (min-width: 901px) {
   .feature-wide {
     grid-column: 1 / -1;
     display: grid;
@@ -7163,7 +7180,7 @@ html[data-theme="light"] .docs-body .shiki span {
   padding: 26px 26px 24px;
   background: var(--st-panel);
   border: 1px solid var(--st-line);
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   color: inherit;
   text-decoration: none;
   transition: border-color 0.16s, background 0.16s, transform 0.16s;
@@ -7214,19 +7231,19 @@ a.st-use:hover p {
   color: var(--st-charcoal-body);
 }
 .st-day .site-kicker {
-  color: #83888f;
+  color: var(--term-kicker);
 }
 .st-day .site-h2 {
   color: var(--st-charcoal-ink);
 }
 .st-day .tt {
-  color: #9ccf1f;
+  color: var(--term-accent);
 }
 .st-day .site-lead {
   color: var(--st-charcoal-body);
 }
 .st-day .st-use {
-  background: #26282c;
+  background: var(--term-bg);
   border-color: rgba(237, 238, 240, 0.16);
 }
 .st-day a.st-use:hover {
@@ -7261,7 +7278,7 @@ a.st-use:hover p {
   padding: 24px 24px 22px;
   background: var(--st-panel);
   border: 1px solid var(--st-line);
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   color: inherit;
   text-decoration: none;
   transition: border-color 0.16s, background 0.16s, transform 0.16s;
@@ -7345,7 +7362,7 @@ a.st-use:hover p {
   padding: 32px 34px 28px;
   background: var(--st-panel);
   border: 1px solid var(--st-line);
-  border-radius: var(--st-radius-lg);
+  border-radius: var(--radius-lg);
   color: var(--st-body);
 }
 .st-quote-glyph {
@@ -7427,7 +7444,7 @@ a.st-use:hover p {
   height: 44px;
   padding: 0 21px;
   border: 0.5px solid var(--st-ink);
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   background: transparent;
   color: var(--st-ink);
   font-family: var(--st-sans);
@@ -7451,7 +7468,7 @@ a.st-use:hover p {
   font-size: 13px;
   color: var(--st-ink);
   border: 0.5px solid var(--st-ink);
-  border-radius: 4px;
+  border-radius: var(--radius);
   padding: 5px 10px;
   text-transform: lowercase;
 }
@@ -7462,7 +7479,7 @@ a.st-use:hover p {
   padding: clamp(12px, 2vw, 28px);
   background: var(--st-panel);
   border: 1px solid var(--st-line);
-  border-radius: var(--st-radius);
+  border-radius: var(--radius);
   overflow-x: auto;
 }
 .arch {
@@ -7472,23 +7489,23 @@ a.st-use:hover p {
   height: auto;
 }
 .arch-box {
-  fill: #faf9f2;
+  fill: var(--st-panel);
   stroke: rgba(33, 34, 37, 0.55);
   stroke-width: 1;
 }
 .arch-box-main {
-  fill: #eae7db;
+  fill: var(--st-panel-2);
 }
 .arch-sandbox {
   stroke-dasharray: 5 4;
 }
 .arch-inner {
-  fill: #f2f0e7;
+  fill: var(--st-bg);
   stroke: rgba(33, 34, 37, 0.3);
   stroke-width: 1;
 }
 .arch-db {
-  fill: #faf9f2;
+  fill: var(--st-panel);
 }
 .arch-title {
   font-family: var(--st-mono);
@@ -7639,7 +7656,7 @@ a.st-use:hover p {
   padding: 30px 30px 26px;
   background: var(--st-panel);
   border: 1px solid var(--st-line);
-  border-radius: var(--st-radius-lg);
+  border-radius: var(--radius-lg);
 }
 .price-card:last-child {
   border-color: var(--st-flood);
@@ -7778,7 +7795,7 @@ a.st-use:hover p {
   text-transform: lowercase;
 }
 .site-footer ul a:hover {
-  color: #9ccf1f;
+  color: var(--term-accent);
 }
 .site-footer-bottom {
   display: flex;
@@ -7797,14 +7814,14 @@ a.st-use:hover p {
   text-decoration: none;
 }
 .site-footer-bottom a:hover {
-  color: #9ccf1f;
+  color: var(--term-accent);
 }
 
 /* ── Product screenshot frame ── */
 .shot-frame {
   margin-top: 44px;
   border: 0.5px solid rgba(237, 238, 240, 0.2);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   background: var(--st-code-bg);
   box-shadow: 0 24px 60px rgba(28, 32, 36, 0.22);
@@ -7823,7 +7840,7 @@ a.st-use:hover p {
 }
 
 /* ── Responsive ── */
-@media (max-width: 1060px) {
+@media (max-width: 1280px) {
   .st-cases {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -7831,7 +7848,7 @@ a.st-use:hover p {
     min-height: 240px;
   }
 }
-@media (max-width: 960px) {
+@media (max-width: 900px) {
   .st-narr {
     grid-template-columns: 1fr;
     gap: 36px;
@@ -7873,7 +7890,7 @@ a.st-use:hover p {
     display: none;
   }
 }
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .site-nav {
     position: fixed;
     inset: 86px 12px auto 12px;
@@ -7895,7 +7912,7 @@ a.st-use:hover p {
   .site-nav a {
     padding: 12px 14px;
     font-size: 15.5px;
-    border-radius: 4px;
+    border-radius: var(--radius);
   }
   .site-nav-mobile-actions {
     display: flex;
@@ -7966,7 +7983,7 @@ a.st-use:hover p {
 }
 .recipe-card {
   display: flex; flex-direction: column; gap: 12px;
-  padding: 18px; border: 1px solid var(--border); border-radius: var(--radius-lg, 12px);
+  padding: 18px; border: 1px solid var(--border); border-radius: var(--radius-lg);
   background: var(--surface); color: inherit; text-decoration: none;
   transition: border-color 120ms ease, transform 120ms ease;
 }
@@ -7976,7 +7993,7 @@ a.st-use:hover p {
 .recipe-card-title h3 { margin: 0 0 2px; font-size: 15px; }
 .recipe-card-title p { margin: 0; font-size: 12.5px; color: var(--ink-2); }
 .recipe-mark {
-  width: 34px; height: 34px; border-radius: 9px; flex: none;
+  width: 34px; height: 34px; border-radius: var(--radius-lg); flex: none;
   display: grid; place-items: center;
   font-family: var(--font-display, var(--font-sans)); font-weight: 500; font-size: 15px;
   background: var(--raised); border: 1px solid var(--border); color: var(--accent);
@@ -7998,7 +8015,7 @@ a.st-use:hover p {
 .recipe-choice input { margin-right: 6px; accent-color: var(--accent); }
 .recipe-choice.on { border-color: var(--accent); color: var(--ink); }
 .recipe-update-banner { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .recipe-detail-grid { grid-template-columns: 1fr; }
   .recipe-row { grid-template-columns: minmax(0, 1fr) 100px; }
   .recipe-row span:nth-child(2), .recipe-row span:nth-child(4), .recipe-row span:nth-child(5) { display: none; }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -68,6 +68,35 @@
   --radius: 4px;
   --radius-lg: 8px;
   --hairline: 0.5px;
+  /*
+   folded in from a duplicate `:root` block below 
+*/
+  --st-bg: #f2f0e7;
+  --st-panel: #faf9f2;
+  --st-panel-2: #eae7db;
+  --st-ink: #1c2024;
+  --st-body: #3d4147;
+  --st-dim: #60646c;
+  --st-faint: #82868e;
+  --st-line: rgba(33, 34, 37, 0.4);
+  --st-line-2: rgba(33, 34, 37, 0.72);
+  --st-hairline: rgba(33, 34, 37, 0.26);
+  --st-accent: #567a00;
+  --st-accent-dim: #486700;
+  --st-accent-tint: rgba(129, 179, 0, 0.14);
+  --st-flood: #81b300;
+  --st-flood-ink: #1c2024;
+  --st-gold: #cab168;
+  --st-charcoal: #212225;
+  --st-charcoal-ink: #edeef0;
+  --st-charcoal-body: #b3b7bc;
+  --st-article: #efe5d7;
+  --st-indigo: #8a6d1c;
+  --st-code-bg: var(--term-film-cover);
+  --st-mono: var(--font-mono);
+  --st-sans: var(--font-sans);
+  --st-jp: var(--font-jp);
+  --st-sc: var(--font-sc);
 }
 /* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
@@ -118,6 +147,10 @@ html[data-theme="dark"] {
   --modal-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
   --skeleton-a: #26282c;
   --skeleton-b: #2f3237;
+  /*
+   folded in from a duplicate `html[data-theme="dark"]` block below 
+*/
+  color-scheme: dark;
 }
 /* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
@@ -135,9 +168,6 @@ html {
   color-scheme: light;
   background: var(--bg);
   scrollbar-gutter: stable;
-}
-html[data-theme="dark"] {
-  color-scheme: dark;
 }
 
 body {
@@ -450,6 +480,12 @@ select,
   border-bottom: 1px solid var(--border);
   background: rgba(245, 244, 240, 0.92);
   backdrop-filter: blur(18px);
+  /*
+   folded in from a duplicate `.topbar` block below 
+*/
+  background: var(--chrome-bg);
+  border-bottom-color: var(--border);
+  backdrop-filter: blur(22px) saturate(130%);
 }
 .topbar-inner {
   width: 100%;
@@ -478,14 +514,35 @@ select,
   grid-template-columns: auto max-content minmax(0, 1fr);
   align-items: center;
   gap: 20px;
+  /*
+   folded in from a duplicate `.topbar-inner` block below 
+*/
+  max-width: 1240px;
+  min-height: 64px;
+  padding: 0 40px;
+  /* Kept in step with the base rule and with kernel.css: the nav column is
+   * max-content, the actions column yields. A stale value here would win over
+   * globals' base rule and silently reinstate the clip. */
+  grid-template-columns: auto max-content minmax(0, 1fr);
 }
 .masthead-brand {
   padding: 0;
   gap: 9px;
   width: fit-content;
+  /*
+   folded in from a duplicate `.masthead-brand` block below 
+*/
+  gap: 10px;
 }
 .wordmark {
   font-size: 15px;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  /*
+   folded in from a duplicate `.wordmark` block below 
+*/
+  font-size: 14px;
   font-weight: 400;
   letter-spacing: 0.02em;
   text-transform: lowercase;
@@ -498,6 +555,10 @@ select,
   font-weight: 500;
   letter-spacing: 0.01em;
   text-transform: lowercase;
+  /*
+   folded in from a duplicate `.product-label` block below 
+*/
+  color: var(--ink-3);
 }
 .masthead-nav {
   display: flex;
@@ -513,6 +574,11 @@ select,
    * The padding/border/border-radius/background that were also here were
    * already reset to 0/transparent by kernel.css:250 — dead declarations,
    * removed with them (they carried the only off-scale 9px radius here). */
+  /*
+   folded in from a duplicate `.masthead-nav` block below 
+*/
+  border-color: var(--border);
+  background: var(--interactive-subtle);
 }
 /* The org name + email is the widest thing in the actions cluster and is
  * user-controlled, so it must never be allowed to set the header's width.
@@ -543,10 +609,19 @@ select,
   color: var(--ink-2);
   font-size: 11.5px;
   font-weight: 500;
+  /*
+   folded in from a duplicate `.masthead-nav a` block below 
+*/
+  color: var(--ink-2);
 }
 .masthead-nav a:hover,
 .masthead-nav a.active {
   background: var(--raised);
+  color: var(--ink);
+  /*
+   folded in from a duplicate `.masthead-nav a:hover, .masthead-nav a.active` block below 
+*/
+  background: var(--interactive-hover);
   color: var(--ink);
 }
 .masthead-count {
@@ -586,6 +661,10 @@ select,
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 34px;
+  /*
+   folded in from a duplicate `.pagehead` block below 
+*/
+  margin-bottom: 28px;
 }
 .page-actions {
   display: flex;
@@ -600,6 +679,11 @@ h1.title {
   line-height: 1.02;
   letter-spacing: 0.015em;
   margin: 0;
+  /*
+   folded in from a duplicate `h1.title` block below 
+*/
+  font-size: clamp(30px, 3vw, 38px);
+  letter-spacing: 0.015em;
 }
 .sub {
   color: var(--ink-2);
@@ -670,9 +754,20 @@ h1.title {
   gap: 40px;
   border-bottom: 1px solid var(--border);
   animation: enter 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  /*
+   folded in from a duplicate `.home-hero` block below 
+*/
+  min-height: 220px;
+  padding: 28px 2px 35px;
+  border-bottom: 0;
+  align-items: flex-end;
 }
 .home-copy {
   max-width: 760px;
+  /*
+   folded in from a duplicate `.home-copy` block below 
+*/
+  max-width: 730px;
 }
 .home-kicker,
 .section-kicker {
@@ -687,6 +782,11 @@ h1.title {
   align-items: center;
   gap: 8px;
   margin-bottom: 18px;
+  /*
+   folded in from a duplicate `.home-kicker` block below 
+*/
+  margin-bottom: 14px;
+  color: var(--accent);
 }
 .home-hero h1 {
   margin: 0;
@@ -695,10 +795,24 @@ h1.title {
   font-weight: 300;
   line-height: 1.1;
   letter-spacing: 0.015em;
+  /*
+   folded in from a duplicate `.home-hero h1` block below 
+*/
+  font-family: var(--font-sans);
+  font-size: clamp(42px, 5.2vw, 64px);
+  font-weight: 300;
+  line-height: 1.1;
+  letter-spacing: 0.015em;
 }
 .home-hero h1 em {
   color: var(--ink-2);
   font-weight: 400;
+  /*
+   folded in from a duplicate `.home-hero h1 em` block below 
+*/
+  color: var(--ink-2);
+  font-style: normal;
+  font-weight: inherit;
 }
 .home-hero p {
   max-width: 610px;
@@ -706,12 +820,24 @@ h1.title {
   color: var(--ink-2);
   font-size: 15px;
   line-height: 1.65;
+  /*
+   folded in from a duplicate `.home-hero p` block below 
+*/
+  max-width: 570px;
+  margin-top: 18px;
+  font-size: 13.5px;
+  line-height: 1.6;
 }
 .hero-action {
   height: 44px;
   padding-inline: 18px;
   margin-bottom: 5px;
   box-shadow: 0 8px 24px rgba(38, 35, 31, 0.15);
+  /*
+   folded in from a duplicate `.hero-action` block below 
+*/
+  min-width: 132px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 .ops-strip {
   display: grid;
@@ -719,6 +845,12 @@ h1.title {
   margin: 0 0 58px;
   border-bottom: 1px solid var(--border);
   animation: enter 0.55s 0.06s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  /*
+   folded in from a duplicate `.ops-strip` block below 
+*/
+  gap: 9px;
+  margin-bottom: 48px;
+  border-bottom: 0;
 }
 .ops-metric {
   min-width: 0;
@@ -737,6 +869,14 @@ h1.title {
   font-weight: 300;
   line-height: 1;
   letter-spacing: 0.015em;
+  /*
+   folded in from a duplicate `.ops-metric strong` block below 
+*/
+  margin-top: 13px;
+  font-family: var(--font-sans);
+  font-size: 29px;
+  font-weight: 300;
+  letter-spacing: 0.015em;
 }
 .ops-metric small {
   display: block;
@@ -753,6 +893,14 @@ h1.title {
 .metric-label {
   color: var(--ink-2);
   font-size: 12px;
+  /*
+   folded in from a duplicate `.metric-label` block below 
+*/
+  color: var(--ink-3);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-transform: lowercase;
 }
 .section-heading {
   display: flex;
@@ -995,6 +1143,10 @@ h1.title {
   margin-bottom: 72px;
   scroll-margin-top: 88px;
   animation: enter 0.55s 0.09s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  /*
+   folded in from a duplicate `.configuration-section` block below 
+*/
+  margin-bottom: 58px;
 }
 .configuration-head {
   display: flex;
@@ -1002,6 +1154,10 @@ h1.title {
   justify-content: space-between;
   gap: 32px;
   margin-bottom: 20px;
+  /*
+   folded in from a duplicate `.configuration-head` block below 
+*/
+  margin-bottom: 17px;
 }
 .configuration-head h2 {
   margin: 5px 0 0;
@@ -1009,6 +1165,11 @@ h1.title {
   font-size: 32px;
   font-weight: 300;
   line-height: 1.08;
+  letter-spacing: 0.015em;
+  /*
+   folded in from a duplicate `.configuration-head h2` block below 
+*/
+  font-size: 27px;
   letter-spacing: 0.015em;
 }
 .configuration-head p {
@@ -1026,6 +1187,10 @@ h1.title {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: rgba(255, 254, 250, 0.66);
+  /*
+   folded in from a duplicate `.readiness` block below 
+*/
+  background: var(--surface-soft);
 }
 .readiness.needs-setup .signal {
   background: var(--amber);
@@ -1060,6 +1225,15 @@ h1.title {
   overflow: hidden;
   background: rgba(255, 254, 250, 0.68);
   box-shadow: 0 16px 44px rgba(48, 43, 36, 0.035);
+  /*
+   folded in from a duplicate `.resource-grid` block below 
+*/
+  gap: 10px;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 .resource-card {
   min-width: 0;
@@ -1067,8 +1241,23 @@ h1.title {
   padding: 22px 24px 20px;
   display: flex;
   flex-direction: column;
+  /*
+   folded in from a duplicate `.resource-card` block below 
+*/
+  min-height: 252px;
+  padding: 18px 18px 17px;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-soft);
+  transition: border-color 0.16s ease, background 0.16s ease, transform 0.16s ease;
 }
 .resource-card + .resource-card {
+  border-left: 1px solid var(--border);
+  /*
+   folded in from a duplicate `.resource-card + .resource-card` block below 
+*/
   border-left: 1px solid var(--border);
 }
 .resource-card-top {
@@ -1076,6 +1265,11 @@ h1.title {
   grid-template-columns: auto 1fr auto;
   align-items: baseline;
   gap: 9px;
+  /*
+   folded in from a duplicate `.resource-card-top` block below 
+*/
+  align-items: center;
+  grid-template-columns: auto 1fr auto;
 }
 .resource-index,
 .resource-count {
@@ -1092,6 +1286,10 @@ h1.title {
   text-overflow: ellipsis;
   text-transform: lowercase;
   white-space: nowrap;
+  /*
+   folded in from a duplicate `.resource-eyebrow` block below 
+*/
+  color: var(--ink-3);
 }
 .resource-count {
   min-width: 24px;
@@ -1099,6 +1297,12 @@ h1.title {
   border: 1px solid var(--border);
   border-radius: 999px;
   text-align: center;
+  /*
+   folded in from a duplicate `.resource-count` block below 
+*/
+  color: currentColor;
+  border-color: color-mix(in srgb, currentColor 30%, transparent);
+  background: color-mix(in srgb, currentColor 8%, transparent);
 }
 .resource-card h3 {
   margin: 31px 0 0;
@@ -1106,6 +1310,14 @@ h1.title {
   font-size: 27px;
   font-weight: 300;
   letter-spacing: 0.015em;
+  /*
+   folded in from a duplicate `.resource-card h3` block below 
+*/
+  margin-top: 22px;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 20px;
+  font-weight: 300;
 }
 .resource-card > p {
   min-height: 61px;
@@ -1113,6 +1325,11 @@ h1.title {
   color: var(--ink-2);
   font-size: 12.5px;
   line-height: 1.6;
+  /*
+   folded in from a duplicate `.resource-card > p` block below 
+*/
+  min-height: 56px;
+  color: var(--ink-2);
 }
 .resource-items {
   min-height: 54px;
@@ -1121,6 +1338,11 @@ h1.title {
   flex-wrap: wrap;
   align-content: flex-start;
   gap: 5px;
+  /*
+   folded in from a duplicate `.resource-items` block below 
+*/
+  min-height: 39px;
+  margin-top: 12px;
 }
 .resource-items span {
   max-width: 100%;
@@ -1134,6 +1356,10 @@ h1.title {
   font-size: 10px;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /*
+   folded in from a duplicate `.resource-items span` block below 
+*/
+  background: var(--interactive-subtle);
 }
 .resource-actions {
   min-height: 34px;
@@ -1144,6 +1370,10 @@ h1.title {
   justify-content: space-between;
   gap: 12px;
   border-top: 1px solid var(--border);
+  /*
+   folded in from a duplicate `.resource-actions` block below 
+*/
+  color: var(--ink);
 }
 .text-action {
   padding: 0;
@@ -1161,6 +1391,10 @@ h1.title {
   text-underline-offset: 3px;
 }
 .primary-text-action {
+  color: var(--accent);
+  /*
+   folded in from a duplicate `.primary-text-action` block below 
+*/
   color: var(--accent);
 }
 .resource-secondary {
@@ -1988,14 +2222,28 @@ a.row:hover,
   background: var(--ink);
   color: var(--flood-ink);
   border-color: transparent;
+  /*
+   folded in from a duplicate `.btn.primary` block below 
+*/
+  border-color: var(--primary-bg);
+  background: var(--primary-bg);
+  color: var(--primary-ink);
 }
 .btn.primary:hover {
-  background: #11100e;
+  background: var(--primary-hover);
+  /*
+   folded in from a duplicate `.btn.primary:hover` block below 
+*/
+  background: var(--primary-hover);
 }
 .btn.human {
   background: var(--amber);
   color: var(--flood-ink);
   border-color: transparent;
+  /*
+   folded in from a duplicate `.btn.human` block below 
+*/
+  color: var(--flood-ink);
 }
 .btn.human:hover {
   filter: brightness(1.07);
@@ -2063,6 +2311,10 @@ a.row:hover,
   height: 2px;
   background: var(--ink);
   border-radius: 999px;
+  /*
+   folded in from a duplicate `.tab.active::after` block below 
+*/
+  background: var(--accent);
 }
 .tab .n {
   color: var(--ink-3);
@@ -2278,6 +2530,10 @@ select.inp {
   font-size: 13px;
   outline: none;
   transition: border-color 0.12s;
+  /*
+   folded in from a duplicate `input.inp, textarea.inp, select.inp` block below 
+*/
+  background: var(--control-bg);
 }
 input.inp:focus,
 textarea.inp:focus,
@@ -2424,6 +2680,11 @@ fieldset.seg:disabled label {
   z-index: 50;
   animation: fadein 0.15s;
   padding: 24px;
+  /*
+   folded in from a duplicate `.overlay` block below 
+*/
+  background: var(--overlay-bg);
+  backdrop-filter: blur(9px);
 }
 .modal {
   width: min(560px, 92vw);
@@ -2433,6 +2694,10 @@ fieldset.seg:disabled label {
   background: var(--surface);
   border: 1px solid var(--border-strong);
   box-shadow: 0 26px 80px rgba(35, 31, 26, 0.18);
+  /*
+   folded in from a duplicate `.modal` block below 
+*/
+  box-shadow: var(--modal-shadow);
 }
 .modal .mh {
   display: flex;
@@ -2473,6 +2738,10 @@ fieldset.seg:disabled label {
 .modal .xbtn:hover {
   color: var(--ink);
   background: rgba(38, 35, 31, 0.05);
+  /*
+   folded in from a duplicate `.modal .xbtn:hover` block below 
+*/
+  background: var(--interactive-hover);
 }
 
 /* ─── Integrations store ─────────────────────────────────────────────── */
@@ -2939,6 +3208,11 @@ fieldset.seg:disabled label {
   background: linear-gradient(90deg, var(--skeleton-a) 20%, var(--skeleton-b) 48%, var(--skeleton-a) 76%);
   background-size: 200% 100%;
   animation: shimmer 1.45s linear infinite;
+  /*
+   folded in from a duplicate `.skeleton` block below 
+*/
+  background: linear-gradient(90deg, var(--skeleton-a) 20%, var(--skeleton-b) 48%, var(--skeleton-a) 76%);
+  background-size: 200% 100%;
 }
 .skeleton.short {
   width: 62px;
@@ -2973,24 +3247,6 @@ pre.token {
 /* ─── Nocturne interface ──────────────────────────────────────────────
    One continuous dark workspace keeps the dashboard visually quiet. Color
    appears only where it identifies a resource or communicates live state. */
-
-.topbar {
-  background: var(--chrome-bg);
-  border-bottom-color: var(--border);
-  backdrop-filter: blur(22px) saturate(130%);
-}
-.topbar-inner {
-  max-width: 1240px;
-  min-height: 64px;
-  padding: 0 40px;
-  /* Kept in step with the base rule and with kernel.css: the nav column is
-   * max-content, the actions column yields. A stale value here would win over
-   * globals' base rule and silently reinstate the clip. */
-  grid-template-columns: auto max-content minmax(0, 1fr);
-}
-.masthead-brand {
-  gap: 10px;
-}
 .brand-symbol {
   width: 23px;
   height: 23px;
@@ -3028,27 +3284,6 @@ pre.token {
   top: 11px;
   background: var(--accent);
 }
-.wordmark {
-  font-size: 14px;
-  font-weight: 400;
-  letter-spacing: 0.02em;
-  text-transform: lowercase;
-}
-.product-label {
-  color: var(--ink-3);
-}
-.masthead-nav {
-  border-color: var(--border);
-  background: var(--interactive-subtle);
-}
-.masthead-nav a {
-  color: var(--ink-2);
-}
-.masthead-nav a:hover,
-.masthead-nav a.active {
-  background: var(--interactive-hover);
-  color: var(--ink);
-}
 .masthead-actions {
   justify-self: end;
   display: flex;
@@ -3073,10 +3308,6 @@ pre.token {
   background: var(--primary-hover);
   transform: translateY(-1px);
 }
-
-.pagehead {
-  margin-bottom: 28px;
-}
 h1.title,
 .modal .mh .t,
 .section-heading h2,
@@ -3088,57 +3319,11 @@ h1.title,
   font-family: var(--font-sans);
   font-weight: 500;
 }
-h1.title {
-  font-size: clamp(30px, 3vw, 38px);
-  letter-spacing: 0.015em;
-}
-
-.home-hero {
-  min-height: 220px;
-  padding: 28px 2px 35px;
-  border-bottom: 0;
-  align-items: flex-end;
-}
-.home-copy {
-  max-width: 730px;
-}
-.home-kicker {
-  margin-bottom: 14px;
-  color: var(--accent);
-}
 .home-kicker::before {
   content: "";
   width: 18px;
   height: 1px;
   background: currentColor;
-}
-.home-hero h1 {
-  font-family: var(--font-sans);
-  font-size: clamp(42px, 5.2vw, 64px);
-  font-weight: 300;
-  line-height: 1.1;
-  letter-spacing: 0.015em;
-}
-.home-hero h1 em {
-  color: var(--ink-2);
-  font-style: normal;
-  font-weight: inherit;
-}
-.home-hero p {
-  max-width: 570px;
-  margin-top: 18px;
-  font-size: 13.5px;
-  line-height: 1.6;
-}
-.hero-action {
-  min-width: 132px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-}
-
-.ops-strip {
-  gap: 9px;
-  margin-bottom: 48px;
-  border-bottom: 0;
 }
 .ops-metric,
 .ops-metric + .ops-metric {
@@ -3166,20 +3351,6 @@ h1.title {
 .ops-metric:nth-child(4)::before {
   background: var(--accent);
 }
-.ops-metric strong {
-  margin-top: 13px;
-  font-family: var(--font-sans);
-  font-size: 29px;
-  font-weight: 300;
-  letter-spacing: 0.015em;
-}
-.metric-label {
-  color: var(--ink-3);
-  font-size: 10.5px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  text-transform: lowercase;
-}
 
 .panel,
 .run-list,
@@ -3197,38 +3368,6 @@ a.row:hover,
 .run-glyph,
 .empty-mark {
   background: var(--raised);
-}
-
-.configuration-section {
-  margin-bottom: 58px;
-}
-.configuration-head {
-  margin-bottom: 17px;
-}
-.configuration-head h2 {
-  font-size: 27px;
-  letter-spacing: 0.015em;
-}
-.readiness {
-  background: var(--surface-soft);
-}
-.resource-grid {
-  gap: 10px;
-  overflow: visible;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-}
-.resource-card {
-  min-height: 252px;
-  padding: 18px 18px 17px;
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--surface-soft);
-  transition: border-color 0.16s ease, background 0.16s ease, transform 0.16s ease;
 }
 .resource-card::after {
   content: "";
@@ -3248,9 +3387,6 @@ a.row:hover,
   background: var(--surface-hover);
   transform: translateY(-2px);
 }
-.resource-card + .resource-card {
-  border-left: 1px solid var(--border);
-}
 .resource-card.resource-integration {
   color: var(--amber);
 }
@@ -3259,10 +3395,6 @@ a.row:hover,
 }
 .resource-card.resource-agent {
   color: var(--accent);
-}
-.resource-card-top {
-  align-items: center;
-  grid-template-columns: auto 1fr auto;
 }
 .resource-glyph {
   width: 34px;
@@ -3280,38 +3412,6 @@ a.row:hover,
   stroke-width: 1.6;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-.resource-eyebrow {
-  color: var(--ink-3);
-}
-.resource-count {
-  color: currentColor;
-  border-color: color-mix(in srgb, currentColor 30%, transparent);
-  background: color-mix(in srgb, currentColor 8%, transparent);
-}
-.resource-card h3 {
-  margin-top: 22px;
-  color: var(--ink);
-  font-family: var(--font-sans);
-  font-size: 20px;
-  font-weight: 300;
-}
-.resource-card > p {
-  min-height: 56px;
-  color: var(--ink-2);
-}
-.resource-items {
-  min-height: 39px;
-  margin-top: 12px;
-}
-.resource-items span {
-  background: var(--interactive-subtle);
-}
-.resource-actions {
-  color: var(--ink);
-}
-.primary-text-action {
-  color: var(--accent);
 }
 
 .mode-card,
@@ -3338,26 +3438,6 @@ a.row:hover,
   border-color: var(--border-strong);
   background: var(--interactive-hover);
 }
-.btn.primary {
-  border-color: var(--primary-bg);
-  background: var(--primary-bg);
-  color: var(--primary-ink);
-}
-.btn.primary:hover {
-  background: var(--primary-hover);
-}
-.btn.human {
-  color: var(--flood-ink);
-}
-.tab.active::after {
-  background: var(--accent);
-}
-
-input.inp,
-textarea.inp,
-select.inp {
-  background: var(--control-bg);
-}
 .opt,
 .cap-row,
 .seg {
@@ -3367,16 +3447,6 @@ select.inp {
 .cap-row:hover,
 .fchip:hover {
   border-color: var(--border-strong);
-}
-.overlay {
-  background: var(--overlay-bg);
-  backdrop-filter: blur(9px);
-}
-.modal {
-  box-shadow: var(--modal-shadow);
-}
-.modal .xbtn:hover {
-  background: var(--interactive-hover);
 }
 .discard-confirm {
   padding: 11px 16px;
@@ -3434,10 +3504,6 @@ select.inp {
   margin: 0 0 14px;
   border: 1px solid color-mix(in srgb, var(--amber) 34%, var(--border));
   border-radius: var(--radius-lg);
-}
-.skeleton {
-  background: linear-gradient(90deg, var(--skeleton-a) 20%, var(--skeleton-b) 48%, var(--skeleton-a) 76%);
-  background-size: 200% 100%;
 }
 
 /* The connector catalog mirrors the reference's compact grouped rows. */
@@ -5877,34 +5943,6 @@ html[data-theme="light"] .docs-body .shiki span {
    these names. (Per foundation-spec these should eventually alias the
    dashboard semantics rather than restate them — but marketing pins itself
    always-light, so that is a scoped design change, not a sweep.) */
-:root {
-  --st-bg: #f2f0e7;
-  --st-panel: #faf9f2;
-  --st-panel-2: #eae7db;
-  --st-ink: #1c2024;
-  --st-body: #3d4147;
-  --st-dim: #60646c;
-  --st-faint: #82868e;
-  --st-line: rgba(33, 34, 37, 0.4);
-  --st-line-2: rgba(33, 34, 37, 0.72);
-  --st-hairline: rgba(33, 34, 37, 0.26);
-  --st-accent: #567a00;
-  --st-accent-dim: #486700;
-  --st-accent-tint: rgba(129, 179, 0, 0.14);
-  --st-flood: #81b300;
-  --st-flood-ink: #1c2024;
-  --st-gold: #cab168;
-  --st-charcoal: #212225;
-  --st-charcoal-ink: #edeef0;
-  --st-charcoal-body: #b3b7bc;
-  --st-article: #efe5d7;
-  --st-indigo: #8a6d1c;
-  --st-code-bg: var(--term-film-cover);
-  --st-mono: var(--font-mono);
-  --st-sans: var(--font-sans);
-  --st-jp: var(--font-jp);
-  --st-sc: var(--font-sc);
-}
 /* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
 .skip-link {

--- a/apps/web/app/kernel.css
+++ b/apps/web/app/kernel.css
@@ -104,6 +104,50 @@
   --radius: 4px;
   --radius-lg: 8px;
   --hairline: 0.5px;
+
+  /* Third-party brand marks. These are other companies' identities, not our
+     scale — they must NOT be tokenised into the palette or flipped by theme,
+     and they are the one legitimate literal ghetto besides the tokens
+     themselves. Named here so a component rule never carries a raw hex. */
+  --brand-mark-ink: #ffffff;
+  --brand-github: #20242b;
+  --brand-github-light: #292b2f;
+  --brand-notion: #f3f3f2;
+  --brand-notion-ink: #111214;
+  --brand-atlassian-from: #2684ff;
+  --brand-atlassian-to: #0754bb;
+  --brand-linear-from: #8a7cff;
+  --brand-linear-to: #4c3bcf;
+  --brand-sentry-from: #8a68d5;
+  --brand-sentry-to: #4f2d91;
+  --brand-stripe-from: #7767ff;
+  --brand-stripe-to: #5142d8;
+  --brand-workspace-from: #36cba8;
+  --brand-workspace-to: #187e96;
+  --brand-custom-from: #ef7c63;
+  --brand-custom-to: #a74169;
+
+  /* Simulated-terminal / ledger swatches for the marketing mockups. A fake
+     terminal has ONE look — these are picture, not interface, so they are
+     theme-exempt by design and never flip. The other sanctioned literal
+     ghetto (foundation-spec 2.1). */
+  --term-bg: #26282c;
+  --term-film-body: #191a1c;
+  --term-film-cover: #212225;
+  --term-red: #ff5f57;
+  --term-amber: #febc2e;
+  --term-green: #2ac840;
+  --term-teal: #6ef0c0;
+  --term-gold: #ffce6a;
+  --term-salmon: #ff8d84;
+  --term-accent: #9ccf1f;
+  --term-ink: #ecedf3;
+  --term-ink-strong: #edeef0;
+  --term-muted: #b0b1c0;
+  --term-detail: #9d9eae;
+  --term-meta: #85869a;
+  --term-kicker: #83888f;
+  --term-faint: #5c5d6e;
 }
 /* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
@@ -874,7 +918,7 @@ h1.title {
 .btn.human {
   border-color: var(--gold);
   background: var(--gold);
-  color: #1c2024;
+  color: var(--flood-ink);
 }
 
 .btn.human:hover {
@@ -1415,7 +1459,7 @@ pre.token,
   color: var(--ds-gray-800);
 }
 
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .main {
     padding: 32px 18px 72px;
   }

--- a/apps/web/app/kernel.css
+++ b/apps/web/app/kernel.css
@@ -408,8 +408,15 @@ body {
 .masthead-session-id {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  /* STRETCH, not flex-end. A flex-end child shrink-wraps its text and may
+     exceed this box, and text-overflow can only ellipsise a child that is
+     actually constrained — with flex-end the 137px email overflowed its 100px
+     column and ran 22px under the theme toggle. Stretch makes each line fill
+     the box so the ellipsis fires; text-align keeps the right edge flush,
+     which is what flex-end was really there for. */
+  align-items: stretch;
   min-width: 0;
+  overflow: hidden;
   line-height: 1.15;
   text-align: right;
 }
@@ -537,9 +544,13 @@ h1.title {
   line-height: 1.5;
 }
 
-.dashboard-header > .btn {
-  display: none;
-}
+/* The page's own primary is VISIBLE on desktop.
+   It used to be display:none here, because the masthead carried a duplicate
+   "New Run" and two dark primaries per view is one too many. The masthead copy
+   is gone (Sidebar.tsx), so hiding this one left the dashboard with NO way to
+   start a run at all on desktop — the audit reported that the page "already
+   renders its own primary" from the JSX without checking that CSS hid it.
+   The <=900 block below still re-states display for the mobile layout. */
 
 .crumbs {
   margin-bottom: 8px;

--- a/apps/web/app/kernel.css
+++ b/apps/web/app/kernel.css
@@ -11,6 +11,10 @@
   the chrome voice does.
 */
 
+/* stylelint-disable color-no-hex, scale-unlimited/declaration-strict-value --
+   The token layer is the ONE place a raw colour literal may appear. Every
+   other rule in this file must reach a colour through a custom property;
+   the gate enforces that, and this comment is the visible boundary. */
 :root {
   /* Warm paper scale (kernel.sh beige family). */
   --ds-background-100: #f2f0e7;
@@ -34,10 +38,21 @@
   /* The accent family IS kernel-green: raw chartreuse for fills, the
      darkened pair for text on beige. */
   --ds-green-100: rgba(129, 179, 0, 0.14);
-  --ds-green-700: #567a00;
+  /* -700 is the text step, so it carries a WCAG floor, not just a hue — and
+     the floor is set by the DARKEST surface it can land on, which is --raised
+     (#eae7db), not the canvas. Tuning it for --bg alone is how #567a00 (4.40
+     on --bg) became #557800 (4.52 on --bg) and still failed at 4.16 on every
+     card. #517200 clears all three: raised 4.51, surface 5.30, bg 4.90 — at
+     H 77.37deg / S 100%, i.e. the same colour two value-steps down.
+     lib/theme-contrast.test.ts asserts all three surfaces. */
+  --ds-green-700: #517200;
   --ds-green-900: #486700;
   --ds-gold-100: rgba(202, 177, 104, 0.2);
-  --ds-gold-700: #8a6d1c;
+  /* Same story as green. Was #8a6d1c (4.29 on --bg); note #866a1b computes
+     4.4959 — it rounds to 4.50 but does NOT clear the floor. #85691b cleared
+     --bg but still failed at 4.20 on --raised. #7f641a clears all three:
+     raised 4.53, surface 5.32, bg 4.92 — H 43.96deg / S 79.5%. */
+  --ds-gold-700: #7f641a;
   --ds-gold-900: #74590f;
   --ds-red-100: rgba(179, 64, 46, 0.1);
   --ds-red-700: #b3402e;
@@ -65,6 +80,14 @@
   --green-tint: var(--ds-green-100);
   --red: var(--ds-red-700);
   --red-tint: var(--ds-red-100);
+  /* The -dim step of each family, completing the pattern --accent-dim already
+     set: the -900 primitive, which darkens in light and lightens in dark.
+     Reserved for ink that sits on a TINTED surface, where the base
+     --accent/--amber/--green/--red do not clear AA. Declared once — they
+     resolve lazily, so the dark block's -900 values flip them for free. */
+  --amber-dim: var(--ds-gold-900);
+  --green-dim: var(--ds-green-900);
+  --red-dim: var(--ds-red-900);
   --chrome-bg: rgba(242, 240, 231, 0.92);
   --interactive-subtle: var(--ds-gray-alpha-100);
   --interactive-hover: var(--ds-gray-alpha-200);
@@ -82,7 +105,12 @@
   --radius-lg: 8px;
   --hairline: 0.5px;
 }
+/* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
+/* stylelint-disable color-no-hex, scale-unlimited/declaration-strict-value --
+   The token layer is the ONE place a raw colour literal may appear. Every
+   other rule in this file must reach a colour through a custom property;
+   the gate enforces that, and this comment is the visible boundary. */
 html[data-theme="dark"] {
   /* kernel.sh's dark sections: charcoal, never black. */
   --ds-background-100: #191a1c;
@@ -93,7 +121,9 @@ html[data-theme="dark"] {
   --ds-gray-400: #3d4046;
   --ds-gray-500: #4c5157;
   --ds-gray-600: #696e77;
-  --ds-gray-700: #83888f;
+  /* --ink-3 in dark. #83888f measured 4.46:1 on --surface and 4.14:1 on
+     --raised — muted text on a card was below AA. */
+  --ds-gray-700: #8d9298;
   --ds-gray-800: #9ba0a6;
   --ds-gray-900: #b3b7bc;
   --ds-gray-1000: #edeef0;
@@ -149,6 +179,7 @@ html[data-theme="dark"] {
   --panel-shadow: none;
   --modal-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
 }
+/* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
 
 html {
   color-scheme: light;
@@ -214,10 +245,23 @@ body {
   margin: 0 auto;
   padding: 0 24px;
   display: grid;
-  /* The NAV is the column that flexes; brand and actions size to their
-   * content — `auto minmax(0, 1fr) auto` keeps the actions cluster from
-   * bleeding over the nav (see the globals.css comment for the history). */
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  /* The ACTIONS cluster is the column that yields; the nav takes its intrinsic
+   * width and therefore CANNOT clip.
+   *
+   * History: `auto minmax(0, 1fr) auto` made the nav the flexing track. Under
+   * width pressure it shrank below its content, and because .masthead-nav was
+   * centre-justified with a hidden scrollbar the overflow was hidden at BOTH
+   * ends — measured on this build at 1280/1440/1790 the nav overflowed by a
+   * constant 13px and "Overview"/"Settings" each lost 13px ("erview",
+   * "settin"). Widening the viewport never helped because .topbar-inner is
+   * capped at max-width above.
+   *
+   * Fit arithmetic at the 1200px cap (measured, not estimated): brand 171 +
+   * nav max-content 538 + gaps 48 + padding 48 = 805, leaving 347 for actions.
+   * The actions cluster intrinsically wants 450 WITH the duplicate desktop
+   * "New Run" and 360 without it — so deleting that duplicate (Sidebar.tsx) is
+   * what makes the header fit, with ~35px of slack. */
+  grid-template-columns: auto max-content minmax(0, 1fr);
   align-items: center;
   gap: 24px;
 }
@@ -253,9 +297,17 @@ body {
   border: 0;
   border-radius: 0;
   background: transparent;
+  /* Stated positively here because this file is the last word: no duplicate
+     .masthead-nav block in either sheet can reinstate the clip. */
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  overflow: visible;
 }
 
 .masthead-nav a {
+  /* Links must never absorb width pressure — a shrunk link wraps or truncates
+     its own label, which is the same defect one level down. */
+  flex: 0 0 auto;
   min-height: 32px;
   padding: 0 10px;
   border-radius: var(--radius);
@@ -284,6 +336,82 @@ body {
   display: flex;
   align-items: center;
   gap: 14px;
+  /* The yielding column: without min-width:0 a grid item's automatic minimum
+     is its content, so the track would refuse to shrink and push the nav. */
+  min-width: 0;
+}
+
+/* Signed-in identity in the actions cluster. Was inline style in Sidebar.tsx;
+   moved to classes so a media query can actually hide it (an inline `display`
+   wins over any stylesheet rule short of !important). */
+.masthead-session {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.masthead-session-id {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 0;
+  line-height: 1.15;
+  text-align: right;
+}
+
+.masthead-session-id strong {
+  color: var(--ds-gray-1000);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.masthead-session-id small {
+  color: var(--ds-gray-800);
+  font-size: 11px;
+}
+
+.masthead-session-email {
+  display: block;
+  max-width: 150px;
+  overflow: hidden;
+  color: var(--ds-gray-800);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Compact desktop, 901-1280.
+   min-width:0 frees the TRACK, but a justify-self:end grid item still sizes to
+   its own content, so the cluster does not actually shrink — measured, it wants
+   396px while the track offers 209px at 1024, and the overflow lands on the
+   "Log out" button (12px of horizontal page scroll). A cluster that must yield
+   has to shed content, not be squeezed.
+   So below 1280 the two things that are labels rather than controls go: the
+   status word (the chartreuse dot still carries live state and the title
+   attribute still carries the words) and the org/email (one tap away in
+   Settings). That takes the cluster to ~148px, which is what keeps the
+   seven-item nav INLINE down to 901px instead of hiding primary navigation
+   behind a hamburger on an ordinary laptop. */
+@media (max-width: 1280px) {
+  .topbar-inner {
+    padding: 0 16px;
+    gap: 16px;
+  }
+
+  .masthead-nav a {
+    padding: 0 7px;
+  }
+
+  .masthead-state span:not(.signal) {
+    display: none;
+  }
+
+  .masthead-session-id,
+  .masthead-session-email {
+    display: none;
+  }
 }
 
 .masthead-state,
@@ -1654,7 +1782,7 @@ pre.token,
 /* The compact defaults are excellent on a pointer-precise desktop, but the
    responsive shell needs an explicit touch contract. This final block is
    intentionally last so older mobile rules cannot shrink the menu again. */
-@media (max-width: 760px) {
+@media (max-width: 900px) {
   .masthead-brand {
     min-height: 44px;
     display: inline-flex;

--- a/apps/web/app/kernel.css
+++ b/apps/web/app/kernel.css
@@ -230,9 +230,19 @@ html {
   background: var(--bg);
 }
 
+/* Kept as its own block rather than folded into the dark token block above,
+   which is why one no-duplicate-selectors warning survives here.
+   SEPARATE, PRE-EXISTING BUG worth its own fix: measured on the running app,
+   `getComputedStyle(html).colorScheme` reports `light` even when
+   data-theme="dark" — verified BOTH with and without the fold, so the fold is
+   not the cause. Lightning CSS rewrites color-scheme into a paired
+   --lightningcss-light/--lightningcss-dark mechanism, and something in that
+   path is not resolving. Consequence: native scrollbars, form controls and
+   the browser's own UI stay in light mode on a dark page. */
 html[data-theme="dark"] {
   color-scheme: dark;
 }
+
 
 body {
   background: var(--bg);

--- a/apps/web/app/kernel.css
+++ b/apps/web/app/kernel.css
@@ -383,6 +383,13 @@ body {
   color: var(--ds-gray-1000);
 }
 
+/* The out-of-app marker on the docs link: that click leaves the dashboard for
+   the public surface, and the arrow says so before the click (Sidebar.tsx). */
+.masthead-nav a .masthead-ext {
+  color: var(--ds-gray-700);
+  font-size: 11px;
+}
+
 .masthead-nav .mobile-primary-action {
   display: none;
 }

--- a/apps/web/app/kernel.css
+++ b/apps/web/app/kernel.css
@@ -232,13 +232,15 @@ html {
 
 /* Kept as its own block rather than folded into the dark token block above,
    which is why one no-duplicate-selectors warning survives here.
-   SEPARATE, PRE-EXISTING BUG worth its own fix: measured on the running app,
-   `getComputedStyle(html).colorScheme` reports `light` even when
-   data-theme="dark" — verified BOTH with and without the fold, so the fold is
-   not the cause. Lightning CSS rewrites color-scheme into a paired
-   --lightningcss-light/--lightningcss-dark mechanism, and something in that
-   path is not resolving. Consequence: native scrollbars, form controls and
-   the browser's own UI stay in light mode on a dark page. */
+
+   This rule is a FALLBACK, not the primary mechanism. The theme is applied by
+   ThemeToggle.tsx:23-24 and THEME_INIT_SCRIPT, which set BOTH `data-theme` and
+   an inline `style.colorScheme` on <html> — and an inline style beats any
+   stylesheet. This declaration only matters if that script has not run.
+   (An earlier comment here claimed color-scheme was broken in dark mode. It is
+   not: that measurement set data-theme by hand while the init script's inline
+   `color-scheme: light` was still on the element, so the inline style won.
+   Verified via the real toggle path — both mechanisms compute `dark`.) */
 html[data-theme="dark"] {
   color-scheme: dark;
 }
@@ -441,6 +443,34 @@ body {
   font-size: 11.5px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* The public/private boundary in the chrome.
+   Both variants are rendered so the marketing pages stay STATICALLY generated;
+   `data-session` (stamped before first paint by lib/session-hint) decides which
+   one is shown, so there is no post-hydration swap.
+
+   !important because this is a visibility SWITCH, not a style preference: if
+   it loses, a signed-out visitor is shown a dashboard link they cannot use, or
+   a signed-in one is told to log in. Measured, `html .site-when-in` (0,1,1)
+   still lost to the header's own descendant button rules (0,2,0). Rather than
+   escalate specificity and lose again to the next rule someone adds, this
+   follows the precedent already set for the masthead's own chrome toggles
+   (globals.css: `.masthead-state, .topbar-action { display: none !important }`).
+
+   The default is SIGNED OUT: if the script has not run, cookies are off, or
+   the attribute is anything unexpected, a visitor is offered "Log In" rather
+   than a dashboard link they cannot use. Fail toward the public chrome. */
+html .site-when-in {
+  display: none !important;
+}
+
+html[data-session="in"] .site-when-in {
+  display: inline-flex !important;
+}
+
+html[data-session="in"] .site-when-out {
+  display: none !important;
 }
 
 /* Compact desktop, 901-1280.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { IBM_Plex_Mono, Inter, Noto_Sans_JP, Noto_Sans_SC } from "next/font/goog
 import "./globals.css";
 import "./kernel.css";
 import { webMode } from "./lib/proxy-auth";
+import { SESSION_HINT_INIT_SCRIPT } from "./lib/session-hint";
 import { THEME_INIT_SCRIPT } from "./lib/theme";
 
 // The kernel.sh type stack: Inter for everything, IBM Plex Mono for code and
@@ -82,6 +83,10 @@ export default function RootLayout({
     >
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+        {/* Stamps data-session before first paint, the same way the theme is
+            stamped. This is what lets the STATICALLY generated marketing pages
+            show a signed-in header with no flash — see lib/session-hint. */}
+        <script dangerouslySetInnerHTML={{ __html: SESSION_HINT_INIT_SCRIPT }} />
       </head>
       <body>{children}</body>
     </html>

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -4,6 +4,67 @@
 
 const BASE = "/api/fluidbox";
 
+export type ApiErrorKind = "notFound" | "denied" | "unreachable" | "error";
+
+function defaultDetail(status: number): string {
+  if (status === 0) return "the control plane could not be reached";
+  if (status === 404) return "not found";
+  if (status === 401 || status === 403) return "not permitted";
+  return "the request failed";
+}
+
+/**
+ * A control-plane failure that still knows its HTTP status.
+ *
+ * Every failure used to collapse into a bare `Error` carrying only a string,
+ * so no surface could tell a deleted run (404) from an outage (5xx) from a
+ * dead control plane (transport failure) — which is why a bad run id rendered
+ * an outage card with a Retry that could never succeed.
+ *
+ * `status` is 0 for a transport failure: fetch rejects rather than answering,
+ * and that is exactly the case a caller most needs to distinguish. `message`
+ * deliberately keeps the pre-existing `<status>: <detail>` shape so string
+ * consumers are unaffected; `detail` is the server's own words, which is what
+ * a human-facing surface should render.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly detail: string;
+
+  constructor(status: number, detail: string, options?: ErrorOptions) {
+    const text = detail.trim() || defaultDetail(status);
+    super(`${status}: ${text}`, options);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = text;
+  }
+
+  get kind(): ApiErrorKind {
+    if (this.status === 404) return "notFound";
+    if (this.status === 401 || this.status === 403) return "denied";
+    if (this.status === 0 || this.status >= 500) return "unreachable";
+    return "error";
+  }
+}
+
+/** The text to show a person: the server's own words rather than the
+ *  status-prefixed `message`, and never "[object Object]". */
+export function errorDetail(error: unknown): string {
+  if (error instanceof ApiError) return error.detail;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+/** Wraps fetch so a transport failure becomes an ApiError with status 0
+ *  instead of a bare TypeError that no surface can classify. */
+async function send(path: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(`${BASE}${path}`, init);
+  } catch (cause) {
+    throw new ApiError(0, defaultDetail(0), { cause });
+  }
+}
+
 // The deployment mode is server-authoritative: the root layout stamps it onto
 // <html data-web-mode>. Only two things vary by mode client-side, and both are
 // presentation, not authorization: writes carry the CSRF header (required in
@@ -40,10 +101,10 @@ const inflightGets = new Map<string, Promise<unknown>>();
 let cacheGeneration = 0;
 
 async function fetchGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, { cache: "no-store" });
+  const res = await send(path, { cache: "no-store" });
   if (!res.ok) {
     redirectOnUnauthorized(res);
-    throw new Error(`${res.status}: ${await res.text()}`);
+    throw new ApiError(res.status, await res.text());
   }
   return res.json();
 }
@@ -103,62 +164,45 @@ export async function apiGetCached<T = unknown>(
   return value;
 }
 
-export async function apiPost<T = unknown>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    method: "POST",
-    headers: { "content-type": "application/json", ...CSRF_HEADERS },
-    body: JSON.stringify(body),
+/**
+ * The one write path. POST/PUT/PATCH/DELETE were four byte-identical copies
+ * apart from the verb, which is how four of the five throw sites drifted into
+ * a different message shape from the GET helper. One implementation means one
+ * place where a failure becomes an ApiError.
+ */
+async function mutate<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> =
+    body === undefined ? { ...CSRF_HEADERS } : { "content-type": "application/json", ...CSRF_HEADERS };
+  const res = await send(path, {
+    method,
+    headers,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
   const text = await res.text();
   if (!res.ok) {
     redirectOnUnauthorized(res);
-    throw new Error(text || `${res.status}`);
+    throw new ApiError(res.status, text);
   }
   invalidateApiCache();
-  return text ? JSON.parse(text) : ({} as T);
+  return text ? (JSON.parse(text) as T) : ({} as T);
 }
 
-export async function apiPut<T = unknown>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    method: "PUT",
-    headers: { "content-type": "application/json", ...CSRF_HEADERS },
-    body: JSON.stringify(body),
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    redirectOnUnauthorized(res);
-    throw new Error(text || `${res.status}`);
-  }
-  invalidateApiCache();
-  return text ? JSON.parse(text) : ({} as T);
+export function apiPost<T = unknown>(path: string, body: unknown): Promise<T> {
+  return mutate<T>("POST", path, body);
+}
+
+export function apiPut<T = unknown>(path: string, body: unknown): Promise<T> {
+  return mutate<T>("PUT", path, body);
 }
 
 // No call sites yet — this exists so a future partial-update goes through the
 // sanctioned surface (CSRF header + 401→/login) instead of a raw fetch.
-export async function apiPatch<T = unknown>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    method: "PATCH",
-    headers: { "content-type": "application/json", ...CSRF_HEADERS },
-    body: JSON.stringify(body),
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    redirectOnUnauthorized(res);
-    throw new Error(text || `${res.status}`);
-  }
-  invalidateApiCache();
-  return text ? JSON.parse(text) : ({} as T);
+export function apiPatch<T = unknown>(path: string, body: unknown): Promise<T> {
+  return mutate<T>("PATCH", path, body);
 }
 
-export async function apiDelete<T = unknown>(path: string): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, { method: "DELETE", headers: { ...CSRF_HEADERS } });
-  const text = await res.text();
-  if (!res.ok) {
-    redirectOnUnauthorized(res);
-    throw new Error(text || `${res.status}`);
-  }
-  invalidateApiCache();
-  return text ? JSON.parse(text) : ({} as T);
+export function apiDelete<T = unknown>(path: string): Promise<T> {
+  return mutate<T>("DELETE", path);
 }
 
 export function streamUrl(sessionId: string): string {
@@ -501,7 +545,7 @@ export async function fetchConnectionTools(id: string): Promise<ConnectionToolSn
     const r = await apiGet<{ snapshot: ConnectionToolSnapshot }>(`/connections/${id}/tools`);
     return r.snapshot;
   } catch (e) {
-    if (e instanceof Error && e.message.startsWith("404")) return null;
+    if (e instanceof ApiError && e.status === 404) return null;
     throw e;
   }
 }

--- a/apps/web/app/lib/contrast.test.ts
+++ b/apps/web/app/lib/contrast.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { compositeOver, contrastRatio, parseColor, relativeLuminance } from "./contrast";
+
+describe("parseColor", () => {
+  it("reads the three hex forms", () => {
+    expect(parseColor("#fff")).toEqual({ rgb: [255, 255, 255], alpha: 1 });
+    expect(parseColor("#1c2024")).toEqual({ rgb: [28, 32, 36], alpha: 1 });
+    expect(parseColor("#21222526").alpha).toBeCloseTo(0x26 / 255, 5);
+  });
+
+  it("reads rgb() and rgba(), space- or comma-separated", () => {
+    expect(parseColor("rgb(76, 183, 130)")).toEqual({ rgb: [76, 183, 130], alpha: 1 });
+    expect(parseColor("rgba(129, 179, 0, 0.14)")).toEqual({ rgb: [129, 179, 0], alpha: 0.14 });
+    expect(parseColor("rgb(28 32 36 / 40%)").alpha).toBeCloseTo(0.4, 5);
+  });
+
+  it("rejects anything it cannot read rather than guessing a colour", () => {
+    expect(() => parseColor("var(--bg)")).toThrow(/unsupported colour/i);
+    expect(() => parseColor("chartreuse")).toThrow(/unsupported colour/i);
+  });
+});
+
+describe("relativeLuminance", () => {
+  // WCAG 2.x anchors: pure white is exactly 1, pure black exactly 0.
+  it("anchors black at 0 and white at 1", () => {
+    expect(relativeLuminance([0, 0, 0])).toBeCloseTo(0, 10);
+    expect(relativeLuminance([255, 255, 255])).toBeCloseTo(1, 10);
+  });
+
+  // Below 0.04045 the linearisation is the c/12.92 branch, not the power one.
+  it("uses the linear branch for very dark channels", () => {
+    expect(relativeLuminance([10, 10, 10])).toBeCloseTo(10 / 255 / 12.92, 10);
+  });
+});
+
+describe("contrastRatio", () => {
+  it("is 21:1 for black on white and 1:1 for a colour on itself", () => {
+    expect(contrastRatio([0, 0, 0], [255, 255, 255])).toBeCloseTo(21, 10);
+    expect(contrastRatio([129, 179, 0], [129, 179, 0])).toBeCloseTo(1, 10);
+  });
+
+  it("is symmetric in its arguments", () => {
+    const a: [number, number, number] = [86, 122, 0];
+    const b: [number, number, number] = [242, 240, 231];
+    expect(contrastRatio(a, b)).toBeCloseTo(contrastRatio(b, a), 12);
+  });
+
+  // #767676 on white is the canonical smallest grey that clears AA body text.
+  it("matches the published WCAG reference greys", () => {
+    expect(contrastRatio([0x76, 0x76, 0x76], [255, 255, 255])).toBeCloseTo(4.54, 2);
+    expect(contrastRatio([0x77, 0x77, 0x77], [255, 255, 255])).toBeCloseTo(4.48, 2);
+  });
+});
+
+describe("compositeOver", () => {
+  it("returns the base untouched at zero alpha and the top at full alpha", () => {
+    expect(compositeOver({ rgb: [255, 0, 0], alpha: 0 }, [10, 20, 30])).toEqual([10, 20, 30]);
+    expect(compositeOver({ rgb: [255, 0, 0], alpha: 1 }, [10, 20, 30])).toEqual([255, 0, 0]);
+  });
+
+  it("mixes linearly in between", () => {
+    expect(compositeOver({ rgb: [0, 0, 0], alpha: 0.5 }, [255, 255, 255])).toEqual([
+      127.5, 127.5, 127.5,
+    ]);
+  });
+});

--- a/apps/web/app/lib/contrast.ts
+++ b/apps/web/app/lib/contrast.ts
@@ -1,0 +1,103 @@
+// WCAG 2.x colour arithmetic.
+//
+// This exists so contrast claims about the design tokens are MEASURED rather
+// than asserted: theme-contrast.test.ts reads the real stylesheets, resolves
+// the token graph, and fails the build if a pair drops below its floor. The
+// 2026-08-14 audit found `.diff .add` at 1.97:1 in dark mode — on the screen
+// where a person reviews what an agent changed — precisely because nothing
+// mechanical was checking.
+//
+// Pure functions, no I/O, no DOM.
+
+/** An opaque sRGB triple. Channels are 0-255 but need not be integers: the
+ *  result of compositing a translucent layer is a fractional colour, and
+ *  rounding it to 8-bit before measuring would introduce error the browser
+ *  does not make. */
+export type Rgb = readonly [number, number, number];
+
+export interface Rgba {
+  readonly rgb: Rgb;
+  readonly alpha: number;
+}
+
+/** WCAG AA floors. Large text is >=18.66px bold or >=24px. */
+export const AA_BODY = 4.5;
+export const AA_LARGE = 3;
+/** The floor below which even a non-text UI boundary is not distinguishable. */
+export const NON_TEXT = 3;
+
+function channel(token: string): number {
+  const value = token.endsWith("%")
+    ? (Number.parseFloat(token) * 255) / 100
+    : Number.parseFloat(token);
+  if (!Number.isFinite(value)) throw new Error(`unsupported colour channel: ${token}`);
+  return value;
+}
+
+function alphaChannel(token: string): number {
+  const value = token.endsWith("%") ? Number.parseFloat(token) / 100 : Number.parseFloat(token);
+  if (!Number.isFinite(value)) throw new Error(`unsupported colour alpha: ${token}`);
+  return value;
+}
+
+function parseHex(hex: string): Rgba {
+  const body = hex.length <= 4 ? hex.replace(/./g, (c) => c + c) : hex;
+  if (!/^[0-9a-f]{6}([0-9a-f]{2})?$/i.test(body)) {
+    throw new Error(`unsupported colour: #${hex}`);
+  }
+  const byte = (i: number) => Number.parseInt(body.slice(i, i + 2), 16);
+  return {
+    rgb: [byte(0), byte(2), byte(4)],
+    alpha: body.length === 8 ? byte(6) / 255 : 1,
+  };
+}
+
+function parseFunctional(inner: string): Rgba {
+  // Both `rgb(r, g, b, a)` and the modern `rgb(r g b / a)` reach here.
+  const [head, slashAlpha] = inner.split("/");
+  const parts = head.trim().split(/[\s,]+/).filter(Boolean);
+  if (parts.length < 3) throw new Error(`unsupported colour: rgb(${inner})`);
+  const rawAlpha = slashAlpha !== undefined ? slashAlpha.trim() : parts[3];
+  return {
+    rgb: [channel(parts[0]), channel(parts[1]), channel(parts[2])],
+    alpha: rawAlpha === undefined ? 1 : alphaChannel(rawAlpha),
+  };
+}
+
+/**
+ * Read a CSS colour literal. Deliberately supports ONLY the notations the
+ * stylesheets actually use (hex 3/4/6/8, rgb(), rgba()) and throws on anything
+ * else — a named colour or an unresolved `var()` silently defaulting to black
+ * would turn a contrast test into a source of false confidence.
+ */
+export function parseColor(value: string): Rgba {
+  const text = value.trim();
+  if (text.startsWith("#")) return parseHex(text.slice(1));
+  const functional = /^rgba?\(([^)]*)\)$/i.exec(text);
+  if (functional) return parseFunctional(functional[1]);
+  throw new Error(`unsupported colour: ${value}`);
+}
+
+/** Flatten a translucent layer onto an opaque one (source-over). */
+export function compositeOver(top: Rgba, base: Rgb): Rgb {
+  const mix = (t: number, b: number) => t * top.alpha + b * (1 - top.alpha);
+  return [mix(top.rgb[0], base[0]), mix(top.rgb[1], base[1]), mix(top.rgb[2], base[2])];
+}
+
+/** sRGB 0-255 -> linear-light 0-1. */
+function linearize(value: number): number {
+  const c = value / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+/** L = 0.2126R + 0.7152G + 0.0722B over linear-light channels. */
+export function relativeLuminance(rgb: Rgb): number {
+  const [r, g, b] = [linearize(rgb[0]), linearize(rgb[1]), linearize(rgb[2])];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** (Llighter + 0.05) / (Ldarker + 0.05). Symmetric; 1..21. */
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const [la, lb] = [relativeLuminance(a), relativeLuminance(b)];
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}

--- a/apps/web/app/lib/nav.test.ts
+++ b/apps/web/app/lib/nav.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { NAV, crumbsFor, sectionFor } from "./nav";
+
+describe("sectionFor — every dashboard route resolves to exactly one section", () => {
+  const cases: [string, string][] = [
+    ["/app", "overview"],
+    ["/app/activity", "activity"],
+    ["/app/sessions/019ff5d7-fa7e-7310-95b9-93a7a865e211", "activity"],
+    ["/app/automations", "activity"],
+    ["/app/automations/abc123", "activity"],
+    ["/app/resources", "resources"],
+    ["/app/agents", "resources"],
+    ["/app/agents/new", "resources"],
+    ["/app/capabilities", "resources"],
+    ["/app/integrations", "resources"],
+    ["/app/governance", "governance"],
+    ["/app/governance/default", "governance"],
+    ["/app/recipes", "recipes"],
+    ["/app/recipes/pr-review", "recipes"],
+    ["/app/recipes/instances/xyz", "recipes"],
+    ["/app/settings", "settings"],
+  ];
+  for (const [path, section] of cases) {
+    it(`${path} -> ${section}`, () => expect(sectionFor(path)).toBe(section));
+  }
+
+  it("returns null off the dashboard, so public routes light nothing", () => {
+    for (const p of ["/", "/docs", "/pricing", "/login", "/applesauce"]) {
+      expect(sectionFor(p), p).toBeNull();
+    }
+  });
+
+  it("never resolves a route to a section that is not in the nav", () => {
+    const ids = new Set(NAV.map((n) => n.id));
+    for (const [path] of cases) expect(ids.has(sectionFor(path)!), path).toBe(true);
+  });
+});
+
+describe("crumbsFor — every deep page can walk back to a real route", () => {
+  it("gives section-index pages no trail (they ARE the top level)", () => {
+    for (const p of [
+      "/app",
+      "/app/activity",
+      "/app/resources",
+      "/app/governance",
+      "/app/recipes",
+      "/app/settings",
+    ]) {
+      expect(crumbsFor(p), p).toEqual([]);
+    }
+  });
+
+  it("puts the owning section first and the current page last", () => {
+    expect(crumbsFor("/app/agents")).toEqual([
+      { label: "resources", href: "/app/resources" },
+      { label: "agents" },
+    ]);
+    expect(crumbsFor("/app/capabilities")).toEqual([
+      { label: "resources", href: "/app/resources" },
+      { label: "mcp" },
+    ]);
+  });
+
+  it("walks three levels when the route is three deep", () => {
+    expect(crumbsFor("/app/agents/new")).toEqual([
+      { label: "resources", href: "/app/resources" },
+      { label: "agents", href: "/app/agents" },
+      { label: "new agent" },
+    ]);
+  });
+
+  it("labels a dynamic leaf with the value it was given, not the raw id", () => {
+    const trail = crumbsFor("/app/sessions/019ff5d7-fa7e-7310", { leaf: "019ff5d7" });
+    expect(trail[0]).toEqual({ label: "activity", href: "/app/activity" });
+    expect(trail.at(-1)).toEqual({ label: "019ff5d7" });
+  });
+
+  it("falls back to the path segment when no leaf label is supplied", () => {
+    expect(crumbsFor("/app/governance/default").at(-1)).toEqual({ label: "default" });
+  });
+
+  // The whole point of the trail: the LAST crumb is where you are, so it must
+  // not be a link, and every crumb BEFORE it must be somewhere you can go.
+  it("makes only the last crumb unlinked, and every other crumb a real route", () => {
+    for (const p of [
+      "/app/agents/new",
+      "/app/sessions/x",
+      "/app/automations/y",
+      "/app/recipes/z",
+      "/app/governance/g",
+    ]) {
+      const trail = crumbsFor(p);
+      expect(trail.at(-1)!.href, p).toBeUndefined();
+      for (const crumb of trail.slice(0, -1)) {
+        expect(crumb.href, `${p} :: ${crumb.label}`).toMatch(/^\/app(\/|$)/);
+      }
+    }
+  });
+
+  it("returns nothing off the dashboard", () => {
+    expect(crumbsFor("/docs/getting-started")).toEqual([]);
+  });
+});

--- a/apps/web/app/lib/nav.ts
+++ b/apps/web/app/lib/nav.ts
@@ -1,0 +1,130 @@
+// The dashboard's route model — ONE source of truth for "where am I".
+//
+// The masthead's you-are-here state and the breadcrumb trail both derive from
+// this table, so they cannot disagree. Before this existed, Sidebar.tsx carried
+// hand-maintained `pathname.startsWith(...)` checks and nothing else knew the
+// hierarchy at all — which is why deep pages had no way back: there was no
+// parent to return to, only browser history, and history is simply wrong for
+// anyone who arrived from a deep link or a shared URL.
+//
+// Pure functions over a path string. No React, no I/O, so it is testable in
+// this repo's node-only vitest setup (see nav.test.ts).
+
+export type SectionId =
+  | "overview"
+  | "activity"
+  | "resources"
+  | "governance"
+  | "recipes"
+  | "settings";
+
+export interface NavItem {
+  readonly id: SectionId;
+  readonly label: string;
+  readonly href: string;
+}
+
+/** The masthead, in order. Six items, every one a real destination. */
+export const NAV: readonly NavItem[] = [
+  { id: "overview", label: "overview", href: "/app" },
+  { id: "activity", label: "activity", href: "/app/activity" },
+  { id: "resources", label: "resources", href: "/app/resources" },
+  { id: "governance", label: "governance", href: "/app/governance" },
+  { id: "recipes", label: "recipes", href: "/app/recipes" },
+  { id: "settings", label: "settings", href: "/app/settings" },
+];
+
+export interface Crumb {
+  readonly label: string;
+  /** Absent on the LAST crumb: you are already there, so it is not a link. */
+  readonly href?: string;
+}
+
+/**
+ * A route and its ancestry. `prefix` matches the route itself and anything
+ * beneath it, so the list is ordered most-specific-first and the first match
+ * wins.
+ */
+interface RouteNode {
+  readonly prefix: string;
+  readonly section: SectionId;
+  /** Ancestors, outermost first. Empty means a section index page. */
+  readonly trail: readonly Crumb[];
+  /** The page's own label, when the route is not dynamic. */
+  readonly label?: string;
+}
+
+const ACTIVITY: Crumb = { label: "activity", href: "/app/activity" };
+const RESOURCES: Crumb = { label: "resources", href: "/app/resources" };
+
+const ROUTES: readonly RouteNode[] = [
+  // ── activity ───────────────────────────────────────────────────────────
+  { prefix: "/app/automations", section: "activity", trail: [ACTIVITY], label: "automations" },
+  { prefix: "/app/sessions", section: "activity", trail: [ACTIVITY] },
+  { prefix: "/app/activity", section: "activity", trail: [] },
+  // ── resources ──────────────────────────────────────────────────────────
+  {
+    prefix: "/app/agents/new",
+    section: "resources",
+    trail: [RESOURCES, { label: "agents", href: "/app/agents" }],
+    label: "new agent",
+  },
+  { prefix: "/app/agents", section: "resources", trail: [RESOURCES], label: "agents" },
+  { prefix: "/app/capabilities", section: "resources", trail: [RESOURCES], label: "mcp" },
+  { prefix: "/app/integrations", section: "resources", trail: [RESOURCES], label: "integrations" },
+  { prefix: "/app/resources", section: "resources", trail: [] },
+  // ── single-level sections ──────────────────────────────────────────────
+  {
+    prefix: "/app/governance",
+    section: "governance",
+    trail: [{ label: "governance", href: "/app/governance" }],
+  },
+  {
+    prefix: "/app/recipes",
+    section: "recipes",
+    trail: [{ label: "recipes", href: "/app/recipes" }],
+  },
+  { prefix: "/app/settings", section: "settings", trail: [] },
+];
+
+function matches(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function nodeFor(pathname: string): RouteNode | null {
+  return ROUTES.find((route) => matches(pathname, route.prefix)) ?? null;
+}
+
+/** Which nav section owns this route. `null` off the dashboard, so a public
+ *  page lights nothing. */
+export function sectionFor(pathname: string): SectionId | null {
+  if (pathname === "/app") return "overview";
+  if (!pathname.startsWith("/app/")) return null;
+  return nodeFor(pathname)?.section ?? null;
+}
+
+/**
+ * The breadcrumb trail. Empty for top-level pages (they ARE the top level);
+ * otherwise the owning section first and the current page last, unlinked.
+ *
+ * `leaf` names a dynamic segment — a run id is not a label a person can read,
+ * so the page passes the short form it already shows in its heading.
+ */
+export function crumbsFor(pathname: string, { leaf }: { leaf?: string } = {}): Crumb[] {
+  if (pathname === "/app") return [];
+  const node = nodeFor(pathname);
+  if (!node) return [];
+
+  // A section index page is the top of its own trail.
+  if (pathname === node.prefix && node.trail.length === 0) return [];
+
+  const own =
+    pathname === node.prefix
+      ? node.label
+      : (leaf ?? pathname.slice(node.prefix.length + 1).split("/").pop());
+
+  // Never link a crumb to the page you are already on.
+  const trail = node.trail.filter((crumb) => crumb.href !== pathname);
+  if (!own) return [...trail];
+  return [...trail, { label: own }];
+}

--- a/apps/web/app/lib/session-hint.test.ts
+++ b/apps/web/app/lib/session-hint.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  SESSION_HINT_COOKIE,
+  SESSION_HINT_INIT_SCRIPT,
+  hintFromCookieValue,
+  hintSetCookie,
+} from "./session-hint";
+
+describe("hintFromCookieValue", () => {
+  it("reads a present hint as signed in", () => {
+    expect(hintFromCookieValue("1")).toBe("in");
+  });
+
+  it("treats absent, empty and any other value as signed OUT", () => {
+    for (const raw of [undefined, "", "0", "false", "yes", "junk"]) {
+      expect(hintFromCookieValue(raw), String(raw)).toBe("out");
+    }
+  });
+});
+
+describe("hintSetCookie", () => {
+  it("sets a durable hint when a session exists", () => {
+    const cookie = hintSetCookie(true);
+    expect(cookie).toContain(`${SESSION_HINT_COOKIE}=1`);
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).not.toMatch(/Max-Age=0/);
+  });
+
+  it("expires the hint when the session is gone", () => {
+    const cookie = hintSetCookie(false);
+    expect(cookie).toContain(`${SESSION_HINT_COOKIE}=`);
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  // This cookie is a UI hint, never a credential. It must stay readable by the
+  // pre-paint script (so NOT HttpOnly), and it must never be confused with the
+  // real session cookie, which is __Host-fbx_web and stays HttpOnly.
+  it("is deliberately NOT HttpOnly and is not the session cookie", () => {
+    for (const cookie of [hintSetCookie(true), hintSetCookie(false)]) {
+      expect(cookie).not.toMatch(/HttpOnly/i);
+      expect(cookie).not.toContain("__Host-fbx_web");
+    }
+  });
+});
+
+describe("SESSION_HINT_INIT_SCRIPT", () => {
+  it("references the cookie it reads", () => {
+    expect(SESSION_HINT_INIT_SCRIPT).toContain(SESSION_HINT_COOKIE);
+  });
+
+  it("is self-contained and swallows its own errors, like the theme script", () => {
+    // It runs before paint in <head>; a throw there would blank the page.
+    expect(SESSION_HINT_INIT_SCRIPT).toContain("try");
+    expect(SESSION_HINT_INIT_SCRIPT).toContain("catch");
+  });
+
+  it("actually sets data-session when the cookie is present", () => {
+    const root: { dataset: Record<string, string> } = { dataset: {} };
+    const doc = { documentElement: root, cookie: `theme=dark; ${SESSION_HINT_COOKIE}=1` };
+    new Function("document", SESSION_HINT_INIT_SCRIPT)(doc);
+    expect(root.dataset.session).toBe("in");
+  });
+
+  it("sets it to out when the cookie is absent", () => {
+    const root: { dataset: Record<string, string> } = { dataset: {} };
+    const doc = { documentElement: root, cookie: "theme=dark" };
+    new Function("document", SESSION_HINT_INIT_SCRIPT)(doc);
+    expect(root.dataset.session).toBe("out");
+  });
+
+  // A cookie whose NAME merely ends with the hint name must not be mistaken
+  // for it — e.g. `other_fbx_ui=1` while the real hint is absent.
+  it("does not match a cookie whose name only ends with the hint name", () => {
+    const root: { dataset: Record<string, string> } = { dataset: {} };
+    const doc = { documentElement: root, cookie: `other_${SESSION_HINT_COOKIE}=1` };
+    new Function("document", SESSION_HINT_INIT_SCRIPT)(doc);
+    expect(root.dataset.session).toBe("out");
+  });
+});

--- a/apps/web/app/lib/session-hint.ts
+++ b/apps/web/app/lib/session-hint.ts
@@ -1,0 +1,56 @@
+// A pre-paint hint that the browser holds a session — so the PUBLIC pages can
+// show "Dashboard" instead of "Sign in" without giving up static rendering.
+//
+// The problem: /docs, /pricing and the rest are statically generated, and the
+// real session cookie (__Host-fbx_web) is HttpOnly, so neither the server
+// render nor client JS can see it. Reading it server-side would make every
+// marketing page dynamic — losing static generation on the one surface where
+// SEO and TTFB matter most. Fetching /auth/me on the client would flash
+// "Sign in" and then swap, which is the opposite of seamless.
+//
+// So proxy.ts — which already runs on every navigation and already reads the
+// session cookie — mirrors its PRESENCE into a plain boolean cookie, and the
+// script below stamps `data-session` on <html> before first paint. The header
+// renders both variants and CSS shows the matching one. Same mechanism as
+// THEME_INIT_SCRIPT in ./theme.
+//
+// SECURITY: this cookie is a UI hint and NEVER a credential. It carries no
+// identity, grants nothing, and no authorization path reads it. Every
+// authorization decision stays in the control plane behind the HttpOnly
+// session cookie. Forging it changes only which button a stranger sees: /app
+// still redirects to /login and the API still answers 401.
+
+export const SESSION_HINT_COOKIE = "fbx_ui";
+
+export type SessionHint = "in" | "out";
+
+/** Only an exact "1" counts. Anything else — absent, empty, stale, hostile —
+ *  reads as signed out, so the failure mode is "offered a Sign in link". */
+export function hintFromCookieValue(raw: string | undefined): SessionHint {
+  return raw === "1" ? "in" : "out";
+}
+
+/**
+ * The Set-Cookie value proxy.ts emits. Not HttpOnly on purpose: the pre-paint
+ * script has to read it. Lax so it survives ordinary top-level navigation from
+ * an external link without riding cross-site subrequests.
+ */
+export function hintSetCookie(hasSession: boolean): string {
+  const base = `${SESSION_HINT_COOKIE}=`;
+  const attrs = "Path=/; SameSite=Lax";
+  return hasSession
+    ? `${base}1; ${attrs}; Max-Age=${60 * 60 * 24 * 400}`
+    : `${base}; ${attrs}; Max-Age=0`;
+}
+
+/**
+ * Runs in <head> before first paint. Mirrors ./theme's THEME_INIT_SCRIPT:
+ * self-contained, no imports, and wrapped in try/catch because a throw here
+ * would blank the page.
+ *
+ * The regex anchors the cookie name to a boundary so `other_fbx_ui=1` cannot
+ * masquerade as `fbx_ui=1`.
+ */
+export const SESSION_HINT_INIT_SCRIPT = `(()=>{try{const n=${JSON.stringify(
+  SESSION_HINT_COOKIE
+)};const m=new RegExp("(?:^|; *)"+n+"=([^;]*)").exec(document.cookie||"");document.documentElement.dataset.session=m&&m[1]==="1"?"in":"out"}catch{}})()`;

--- a/apps/web/app/lib/theme-contrast.test.ts
+++ b/apps/web/app/lib/theme-contrast.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { AA_BODY, compositeOver, contrastRatio, parseColor, type Rgb } from "./contrast";
+
+// The mechanical guard behind the 2026-08-14 contrast fixes.
+//
+// It reads the REAL stylesheets and resolves the real token graph, so a future
+// edit to `--ds-green-700` (or to the `.diff` tints, or to any alias in
+// between) fails here instead of shipping. Hard-coding the resolved hex would
+// defeat the entire point.
+//
+// Cascade note: globals.css loads first (layout.tsx:3), kernel.css second
+// (layout.tsx:4), so kernel wins ties at equal specificity. Both roots are read
+// in that order.
+
+const globals = readFileSync(new URL("../globals.css", import.meta.url), "utf8");
+const kernel = readFileSync(new URL("../kernel.css", import.meta.url), "utf8");
+
+/** Every `--name: value` declared inside the given selector's blocks, in
+ *  source order across the supplied sheets (later wins). */
+function customProperties(sheets: readonly string[], selector: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const sheet of sheets) {
+    // Multiline-anchored: both roots start their own line, and `}`-anchoring
+    // would miss kernel.css, whose `:root` follows the file's banner comment.
+    const blocks = new RegExp(`^\\s*${selector}\\s*\\{([^}]*)\\}`, "gm");
+    for (const block of sheet.matchAll(blocks)) {
+      for (const decl of block[1].matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+        out.set(decl[1], decl[2].trim());
+      }
+    }
+  }
+  return out;
+}
+
+/** Follow `var(--a)` chains to a literal. Throws on an unknown or cyclic token
+ *  rather than returning something plausible. */
+function resolve(value: string, tokens: Map<string, string>, seen = new Set<string>()): string {
+  const ref = /^var\(\s*(--[\w-]+)\s*\)$/.exec(value.trim());
+  if (!ref) return value.trim();
+  const name = ref[1];
+  if (seen.has(name)) throw new Error(`cyclic token reference: ${name}`);
+  const next = tokens.get(name);
+  if (next === undefined) throw new Error(`undefined token: ${name}`);
+  return resolve(next, tokens, new Set(seen).add(name));
+}
+
+const LIGHT = customProperties([globals, kernel], ":root");
+const DARK = new Map([
+  ...customProperties([globals, kernel], ":root"),
+  ...customProperties([globals, kernel], 'html\\[data-theme="dark"\\]'),
+]);
+const THEMES = { light: LIGHT, dark: DARK } as const;
+
+function opaque(token: string, tokens: Map<string, string>): Rgb {
+  return parseColor(resolve(tokens.get(token) ?? token, tokens)).rgb;
+}
+
+/** The declarations of a component rule, verbatim from source. */
+function ruleDeclarations(sheet: string, selector: string): Record<string, string> {
+  const head = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const block = new RegExp(`^\\s*${head}\\s*\\{([^}]*)\\}`, "m").exec(sheet);
+  if (!block) throw new Error(`rule not found: ${selector}`);
+  return Object.fromEntries(
+    [...block[1].matchAll(/([\w-]+)\s*:\s*([^;]+);/g)].map((d) => [d[1], d[2].trim()])
+  );
+}
+
+describe("token graph", () => {
+  it("resolves every semantic alias this suite depends on", () => {
+    for (const [theme, tokens] of Object.entries(THEMES)) {
+      for (const name of ["--bg", "--surface", "--raised", "--ink", "--ink-2", "--ink-3"]) {
+        expect(() => opaque(name, tokens), `${theme} ${name}`).not.toThrow();
+      }
+    }
+  });
+});
+
+describe("body and muted text clear WCAG AA in both themes", () => {
+  for (const [theme, tokens] of Object.entries(THEMES)) {
+    for (const ink of ["--ink", "--ink-2", "--ink-3"] as const) {
+      for (const surface of ["--bg", "--surface", "--raised"] as const) {
+        it(`${theme}: ${ink} on ${surface}`, () => {
+          const ratio = contrastRatio(opaque(ink, tokens), opaque(surface, tokens));
+          expect(ratio, `${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_BODY);
+        });
+      }
+    }
+  }
+});
+
+describe("accent and amber clear WCAG AA as text on the light canvas", () => {
+  // Light-only: both tokens are far lighter in dark mode and pass comfortably.
+  //
+  // --raised is included deliberately. It is the DARKEST light surface, and
+  // accent text does land on it (globals.css `.tl-body code` and `.recipe-mark`
+  // pair them in a single rule, and more reach it through ancestry inside
+  // cards). Asserting only --bg and --surface is how a token gets tuned for
+  // the canvas and then quietly fails on every card — which is exactly what
+  // this suite missed on its first pass.
+  for (const token of ["--accent", "--amber"] as const) {
+    for (const surface of ["--bg", "--surface", "--raised"] as const) {
+      it(`light: ${token} on ${surface}`, () => {
+        const ratio = contrastRatio(opaque(token, LIGHT), opaque(surface, LIGHT));
+        expect(ratio, `${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_BODY);
+      });
+    }
+  }
+});
+
+describe("the diff viewer is legible in both themes", () => {
+  // kernel.css re-declares `.diff` AFTER globals.css and therefore sets the
+  // real panel background. Assert the winner is still what we think it is — if
+  // this declaration moves, every ratio below is measured against the wrong
+  // base and must be recomputed.
+  it("still takes its panel background from --raised via kernel.css", () => {
+    expect(kernel).toMatch(/\.diff,\s*\n?\s*\.codebox\s*\{[^}]*background:\s*var\(--ds-gray-100\)/);
+  });
+
+  for (const [theme, tokens] of Object.entries(THEMES)) {
+    for (const kind of ["add", "del"] as const) {
+      it(`${theme}: .diff .${kind} ink on its tinted row`, () => {
+        const rule = ruleDeclarations(globals, `.diff .${kind}`);
+        const row = compositeOver(parseColor(rule.background), opaque("--raised", tokens));
+        const ink = parseColor(resolve(rule.color, tokens)).rgb;
+        const ratio = contrastRatio(ink, row);
+        expect(
+          ratio,
+          `${ratio.toFixed(2)}:1 on rgb(${row.map(Math.round).join(",")})`
+        ).toBeGreaterThanOrEqual(AA_BODY);
+      });
+    }
+
+    for (const part of ["hdr", "at"] as const) {
+      it(`${theme}: .diff .${part} ink on the panel`, () => {
+        const rule = ruleDeclarations(globals, `.diff .${part}`);
+        const ink = parseColor(resolve(rule.color, tokens)).rgb;
+        const ratio = contrastRatio(ink, opaque("--raised", tokens));
+        expect(ratio, `${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_BODY);
+      });
+    }
+  }
+});

--- a/apps/web/app/lib/theme-contrast.test.ts
+++ b/apps/web/app/lib/theme-contrast.test.ts
@@ -108,6 +108,27 @@ describe("accent and amber clear WCAG AA as text on the light canvas", () => {
   }
 });
 
+describe("the always-light marketing scope tracks the dashboard scale", () => {
+  // `.st` re-pins the semantic layer to light literals so marketing never
+  // flips with the theme. Restating rather than aliasing means it can DRIFT:
+  // --accent sat at the pre-fix #567a00 here long after the dashboard token
+  // moved, so the public site kept a 4.40:1 accent the product had fixed.
+  // These assertions are what make that drift a build failure.
+  const ST = new Map([
+    ...customProperties([globals, kernel], ":root"),
+    ...customProperties([globals], "\\.st"),
+  ]);
+
+  for (const ink of ["--ink", "--ink-2", "--ink-3", "--accent"] as const) {
+    for (const surface of ["--bg", "--surface", "--raised"] as const) {
+      it(`marketing: ${ink} on ${surface}`, () => {
+        const ratio = contrastRatio(opaque(ink, ST), opaque(surface, ST));
+        expect(ratio, `${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_BODY);
+      });
+    }
+  }
+});
+
 describe("the diff viewer is legible in both themes", () => {
   // kernel.css re-declares `.diff` AFTER globals.css and therefore sets the
   // real panel background. Assert the winner is still what we think it is — if

--- a/apps/web/app/login/login-form.tsx
+++ b/apps/web/app/login/login-form.tsx
@@ -19,7 +19,14 @@ import { useState } from "react";
  * round-trip (page.tsx clamps it; the control plane re-validates). It rides the
  * login flow as `redirect_to`, so a deep link survives the whole dance.
  */
-export default function LoginForm({ redirectTo = "/app" }: { redirectTo?: string }) {
+export default function LoginForm({
+  redirectTo = "/app",
+  error = null,
+}: {
+  redirectTo?: string;
+  /** Narrowed by page.tsx to a known token — never raw query text. */
+  error?: "unavailable" | null;
+}) {
   const [org, setOrg] = useState("");
   const [busy, setBusy] = useState(false);
 
@@ -50,6 +57,17 @@ export default function LoginForm({ redirectTo = "/app" }: { redirectTo?: string
         <div className="sub" style={{ marginTop: 4, marginBottom: 20 }}>
           Enter your organization to continue to your identity provider.
         </div>
+
+        {/* One message for every cause — an unknown slug, an organization with
+            no identity provider, a suspended one, and a discovery failure all
+            land here identically. That is deliberate: the control plane never
+            reveals whether an organization exists. */}
+        {error === "unavailable" && (
+          <div className="err" role="alert" style={{ marginBottom: 14 }}>
+            Sign-in is not available for that organization. Check the name, or ask whoever
+            administers your fluidbox.
+          </div>
+        )}
 
         <label className="field" style={{ display: "block" }}>
           <span className="lab">Organization</span>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -49,15 +49,22 @@ async function sessionIsLive(cookieValue: string): Promise<boolean> {
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ next?: string }>;
+  searchParams: Promise<{ next?: string; error?: string }>;
 }) {
   if (webMode(process.env.FLUIDBOX_WEB_MODE) === "admin") {
     redirect("/app");
   }
-  const next = sanitizeNext((await searchParams).next);
+  const params = await searchParams;
+  const next = sanitizeNext(params.next);
   const session = (await cookies()).get(SESSION_COOKIE)?.value;
   if (session && (await sessionIsLive(session))) {
     redirect(next);
   }
-  return <LoginForm redirectTo={next} />;
+  // The control plane redirects its neutral refusal here (login.rs
+  // `neutral_unavailable`). The parameter is untrusted, so it is NARROWED to a
+  // known token rather than passed through — the form renders fixed copy for
+  // that token and nothing at all for anything else. Never render the raw
+  // value: it is attacker-controlled text on a pre-auth page.
+  const error = params.error === "unavailable" ? "unavailable" : null;
+  return <LoginForm redirectTo={next} error={error} />;
 }

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,25 @@
+import { StateNotFound } from "./components/state";
+
+// The root not-found boundary.
+//
+// Next routes two different things here: an explicit `notFound()` thrown in a
+// segment with no closer boundary, AND any URL that matches no route at all
+// ("the root app/not-found.js ... handle any unmatched URLs for your whole
+// application" — node_modules/next/dist/docs/.../file-conventions/not-found.md).
+// Until this file existed both fell through to Next's built-in page: white
+// background, black system type, no chrome, and the root layout's default
+// <title>. It links to the public home because an unmatched URL is more often
+// a mistyped public address than a dashboard one; /app/* misses get their own
+// boundary in app/app/not-found.tsx.
+export default function NotFound() {
+  return (
+    <main className="main">
+      <StateNotFound
+        title="page not found"
+        body="That address does not match anything here. It may have moved, or the link may be wrong."
+        href="/"
+        label="Back to fluidbox"
+      />
+    </main>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "lint:css": "stylelint 'app/**/*.css' --max-warnings 59",
+    "lint:css": "stylelint 'app/**/*.css' --max-warnings 10",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "lint:css": "stylelint 'app/**/*.css' --max-warnings 298",
+    "lint:css": "stylelint 'app/**/*.css' --max-warnings 59",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "lint:css": "stylelint 'app/**/*.css' --max-warnings 298",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
@@ -27,6 +28,9 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
+    "stylelint": "^17.14.1",
+    "stylelint-config-standard": "^40.0.0",
+    "stylelint-declaration-strict-value": "^1.11.1",
     "tailwindcss": "^4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -51,6 +51,15 @@ importers:
       eslint-config-next:
         specifier: 16.2.10
         version: 16.2.10(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      stylelint:
+        specifier: ^17.14.1
+        version: 17.14.1(typescript@6.0.3)
+      stylelint-config-standard:
+        specifier: ^40.0.0
+        version: 40.0.0(stylelint@17.14.1(typescript@6.0.3))
+      stylelint-declaration-strict-value:
+        specifier: ^1.11.1
+        version: 1.11.1(stylelint@17.14.1(typescript@6.0.3))
       tailwindcss:
         specifier: ^4
         version: 4.3.2
@@ -140,8 +149,58 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
+
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/media-query-list-parser@5.0.0':
+    resolution: {integrity: sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.1':
+    resolution: {integrity: sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -397,6 +456,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
@@ -618,6 +686,10 @@ packages:
   '@sindresorhus/fnv1a@3.1.0':
     resolution: {integrity: sha512-KV321z5m/0nuAg83W1dPLy85HpHDk7Sdi4fJbwvacWsEhAh+rZUW4ZfGcXmUIvjZg4ss2bcwNlRhJ7GBEUG08w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1094,6 +1166,17 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1144,6 +1227,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -1187,6 +1274,9 @@ packages:
     resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1234,6 +1324,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -1261,9 +1354,31 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1498,12 +1613,22 @@ packages:
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -1689,11 +1814,22 @@ packages:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1706,6 +1842,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-entry-cache@11.1.5:
+    resolution: {integrity: sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1722,6 +1861,9 @@ packages:
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
+
+  flat-cache@6.1.23:
+    resolution: {integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -1753,6 +1895,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1776,6 +1922,14 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1787,6 +1941,13 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  globby@16.2.3:
+    resolution: {integrity: sha512-VZX7TV7jmd/pn71vdnLKtgwy1IWqc3KjI9x1/UtPkwoKk5fKrNLY30ltDe3cAM5xruIN7YuuaulFt133jRrKZg==}
+    engines: {node: '>=20'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1806,6 +1967,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -1820,6 +1985,10 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -1836,6 +2005,16 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  html-tags@5.1.0:
+    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
+    engines: {node: '>=20.10'}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -1863,6 +2042,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -1883,6 +2065,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -1927,6 +2112,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -1950,6 +2139,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2019,8 +2212,14 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2045,8 +2244,15 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -2139,6 +2345,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2148,6 +2357,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2173,8 +2385,18 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mathml-tag-names@4.0.0:
+    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2257,6 +2479,10 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2322,6 +2548,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -2363,6 +2593,19 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2384,6 +2627,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2416,6 +2663,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2527,6 +2778,18 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2546,6 +2809,14 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2573,6 +2844,14 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -2594,16 +2873,54 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  stylelint-config-recommended@18.0.0:
+    resolution: {integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint-config-standard@40.0.0:
+    resolution: {integrity: sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint-declaration-strict-value@1.11.1:
+    resolution: {integrity: sha512-DYihiMuKGk9AeCYp+c3PMy6Z+Qu6yb6wRLeXQJZVMdXV+QOqs7P+Xj6jt8RVTgFJfII+cEQaFI5uWu08WwlkOA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: '>=16 <=17'
+
+  stylelint@17.14.1:
+    resolution: {integrity: sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@4.5.0:
+    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
+    engines: {node: '>=20'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tailwindcss@4.3.2:
     resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
@@ -2692,6 +3009,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -2718,6 +3039,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
@@ -2837,6 +3161,10 @@ packages:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2850,6 +3178,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2981,7 +3313,47 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@cacheable/memory@2.2.0':
+    dependencies:
+      '@cacheable/utils': 2.5.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.5.0':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@chevrotain/types@11.1.2': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/media-query-list-parser@5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.1(postcss-selector-parser@7.1.5)':
+    dependencies:
+      postcss-selector-parser: 7.1.5
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.5)':
+    dependencies:
+      postcss-selector-parser: 7.1.5
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -3206,6 +3578,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
   '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -3364,6 +3744,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/fnv1a@3.1.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3841,6 +4223,17 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -3920,6 +4313,8 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  astral-regex@2.0.0: {}
+
   async-function@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -3956,6 +4351,14 @@ snapshots:
       electron-to-chromium: 1.5.389
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.5)
+
+  cacheable@2.5.0:
+    dependencies:
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3999,6 +4402,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colord@2.9.3: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@7.2.0: {}
@@ -4019,11 +4424,29 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
+  cosmiconfig@9.0.2(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-functions-list@3.3.3: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -4283,12 +4706,20 @@ snapshots:
 
   electron-to-chromium@1.5.389: {}
 
+  emoji-regex@8.0.0: {}
+
   emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract-get@1.0.0:
     dependencies:
@@ -4630,9 +5061,21 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.5: {}
+
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.20.1:
     dependencies:
@@ -4641,6 +5084,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  file-entry-cache@11.1.5:
+    dependencies:
+      flat-cache: 6.1.23
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4659,6 +5106,12 @@ snapshots:
     dependencies:
       flatted: 3.4.2
       keyv: 4.5.4
+
+  flat-cache@6.1.23:
+    dependencies:
+      cacheable: 2.5.0
+      flatted: 3.4.2
+      hookified: 1.15.1
 
   flatted@3.4.2: {}
 
@@ -4688,6 +5141,8 @@ snapshots:
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4725,6 +5180,16 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
   globals@14.0.0: {}
 
   globals@16.4.0: {}
@@ -4733,6 +5198,17 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  globby@16.2.3:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  globjoin@0.1.4: {}
 
   gopd@1.2.0: {}
 
@@ -4743,6 +5219,8 @@ snapshots:
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
+
+  has-flag@5.0.1: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -4757,6 +5235,10 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
 
   hasown@2.0.4:
     dependencies:
@@ -4786,6 +5268,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
+
+  html-tags@5.1.0: {}
+
   html-void-elements@3.0.0: {}
 
   iconv-lite@0.6.3:
@@ -4804,6 +5292,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  ini@1.3.8: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -4828,6 +5318,8 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -4877,6 +5369,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -4899,6 +5393,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -4966,7 +5462,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4991,7 +5491,13 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   khroma@2.1.0: {}
+
+  kind-of@6.0.3: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -5057,6 +5563,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lines-and-columns@1.2.4: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5064,6 +5572,8 @@ snapshots:
   lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.truncate@4.4.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -5085,6 +5595,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mathml-tag-names@4.0.0: {}
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.5
@@ -5096,6 +5608,10 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
+  mdn-data@2.27.1: {}
+
+  meow@14.1.0: {}
 
   merge2@1.4.1: {}
 
@@ -5196,6 +5712,8 @@ snapshots:
 
   node-releases@2.0.51: {}
 
+  normalize-path@3.0.0: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -5277,6 +5795,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
@@ -5304,6 +5829,17 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-safe-parser@7.0.1(postcss@8.5.16):
+    dependencies:
+      postcss: 8.5.16
+
+  postcss-selector-parser@7.1.5:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.15
@@ -5327,6 +5863,10 @@ snapshots:
   property-information@7.2.0: {}
 
   punycode@2.3.1: {}
+
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
 
   queue-microtask@1.2.3: {}
 
@@ -5368,6 +5908,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -5550,6 +6092,16 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
@@ -5564,6 +6116,17 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -5621,6 +6184,14 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -5632,13 +6203,84 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  stylelint-config-recommended@18.0.0(stylelint@17.14.1(typescript@6.0.3)):
+    dependencies:
+      stylelint: 17.14.1(typescript@6.0.3)
+
+  stylelint-config-standard@40.0.0(stylelint@17.14.1(typescript@6.0.3)):
+    dependencies:
+      stylelint: 17.14.1(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.14.1(typescript@6.0.3))
+
+  stylelint-declaration-strict-value@1.11.1(stylelint@17.14.1(typescript@6.0.3)):
+    dependencies:
+      stylelint: 17.14.1(typescript@6.0.3)
+
+  stylelint@17.14.1(typescript@6.0.3):
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/selector-resolve-nested': 4.0.1(postcss-selector-parser@7.1.5)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.5)
+      colord: 2.9.3
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      css-functions-list: 3.3.3
+      css-tree: 3.2.1
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.5
+      global-modules: 2.0.0
+      globby: 16.2.3
+      globjoin: 0.1.4
+      html-tags: 5.1.0
+      ignore: 7.0.5
+      import-meta-resolve: 4.2.0
+      mathml-tag-names: 4.0.0
+      meow: 14.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.16
+      postcss-safe-parser: 7.0.1(postcss@8.5.16)
+      postcss-selector-parser: 7.1.5
+      postcss-value-parser: 4.2.0
+      string-width: 8.2.2
+      supports-hyperlinks: 4.5.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   stylis@4.4.0: {}
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@4.5.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-tags@1.0.0: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.20.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tailwindcss@4.3.2: {}
 
@@ -5737,6 +6379,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unicorn-magic@0.4.0: {}
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -5796,6 +6440,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   uuid@14.0.1: {}
 
@@ -5893,6 +6539,10 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5903,6 +6553,10 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   yallist@3.1.1: {}
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { gateDecision, APP_HOME, SESSION_COOKIE } from "./app/lib/auth-gate";
 import { webMode } from "./app/lib/proxy-auth";
+import { hintSetCookie } from "./app/lib/session-hint";
 import {
   assertAuthModeCompatible,
   requireWorkosEnv,
@@ -23,22 +24,34 @@ const WORKOS = AUTH === "workos" ? requireWorkosEnv(process.env) : null;
 
 export async function proxy(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
-  const decision = gateDecision({
-    mode: MODE,
-    pathname,
-    search,
-    hasSession: request.cookies.has(SESSION_COOKIE),
-  });
+  const hasSession = request.cookies.has(SESSION_COOKIE);
+
+  // The public pages are statically generated, so they cannot ask the server
+  // who you are. This stamps a NON-CREDENTIAL boolean (see lib/session-hint)
+  // that a pre-paint script reads, which is what lets the marketing header
+  // show "Dashboard" instead of "Sign in" with no flash and without making
+  // every marketing page dynamic. Applied to whichever response we return.
+  const stamp = <T extends NextResponse>(response: T, signedIn: boolean): T => {
+    // append, not set: the WorkOS path already attaches its own Set-Cookie
+    // headers to this response and they must all survive.
+    response.headers.append("set-cookie", hintSetCookie(signedIn));
+    return response;
+  };
+
+  const decision = gateDecision({ mode: MODE, pathname, search, hasSession });
   if (decision.kind === "to-app") {
-    return NextResponse.redirect(new URL(APP_HOME, request.url));
+    return stamp(NextResponse.redirect(new URL(APP_HOME, request.url)), hasSession);
   }
   if (decision.kind === "to-login") {
     const url = new URL("/login", request.url);
     if (decision.next !== APP_HOME) url.searchParams.set("next", decision.next);
-    return NextResponse.redirect(url);
+    // Reaching /login means the session did not satisfy the gate, so clear the
+    // hint too — otherwise a lapsed session leaves the public header still
+    // claiming you are signed in.
+    return stamp(NextResponse.redirect(url), false);
   }
 
-  if (!WORKOS) return NextResponse.next();
+  if (!WORKOS) return stamp(NextResponse.next(), hasSession);
 
   // WorkOS web tier (FLUIDBOX_WEB_AUTH=workos). Imported lazily so `none`
   // deployments never load the SDK (which reads its env at module load).
@@ -56,11 +69,13 @@ export async function proxy(request: NextRequest) {
       // through to the app shell.
       return new NextResponse("authentication unavailable", { status: 503 });
     }
-    return handleAuthkitProxy(request, headers, { redirect: authorizationUrl });
+    return stamp(handleAuthkitProxy(request, headers, { redirect: authorizationUrl }), false);
   }
   // Session-refresh cookies (and the headers withAuth() consumes in server
   // components / route handlers) ride every response, public pages included.
-  return handleAuthkitProxy(request, headers);
+  // In workos mode the live AuthKit user is the truth for the hint, not the
+  // fluidbox session cookie.
+  return stamp(handleAuthkitProxy(request, headers), !!session.user);
 }
 
 export const config = {

--- a/apps/web/stylelint.config.mjs
+++ b/apps/web/stylelint.config.mjs
@@ -19,13 +19,30 @@
 // warnings. The scales are the contract; formatting is not.
 
 /** The only radius values in the system: two tokens plus three literals that
- *  are shapes rather than scale steps (pill, circle, square panel). */
-const RADIUS = ["/^var\\(--radius(-lg)?\\)$/", "999px", "50%", "0"];
+ *  are shapes rather than scale steps (pill, circle, square panel).
+ *
+ *  Expressed as one regex over 1-4 space-separated parts, because a per-corner
+ *  shorthand is legal CSS made of legal parts — `0 var(--radius) var(--radius)
+ *  0` (a tab joined to its neighbour) is correct, and an anchored single-value
+ *  pattern reported it as a violation. A rule that cries wolf on correct code
+ *  is how a gate gets switched off. */
+const RADIUS_PART = String.raw`(?:var\(--radius(?:-lg)?\)|999px|50%|0)`;
+const RADIUS = [`/^${RADIUS_PART}(?: +${RADIUS_PART}){0,3}$/`];
 
 /** Three breakpoints, no others. Keyed on the real feature names — keying on
  *  `width` would be a silent no-op, because no query in this codebase uses the
  *  range syntax. */
-const BREAKPOINTS = ["640px", "900px", "1280px"];
+const BREAKPOINTS = [
+  "640px",
+  "900px",
+  "1280px",
+  // The min-width COMPLEMENTS of the same three tiers. `min-width: 901px` is
+  // not a fourth breakpoint — it is "above the 900 tier", and spelling it any
+  // other way (`not all and (max-width: 900px)`) is less readable for no gain.
+  "641px",
+  "901px",
+  "1281px",
+];
 
 const config = {
   ignoreFiles: ["**/node_modules/**", ".next/**"],

--- a/apps/web/stylelint.config.mjs
+++ b/apps/web/stylelint.config.mjs
@@ -1,0 +1,77 @@
+// The CSS gate.
+//
+// Deliberately DECOUPLED from eslint: its own config, its own script, its own
+// CI step. eslint has a pre-existing red baseline (15 errors, 11 of them
+// react-hooks/set-state-in-effect) that is a runtime-behaviour problem in the
+// run composer and policy editor, and nothing about enforcing the design
+// scales should wait on greening it.
+//
+// Every rule here reports at `warning`, and `pnpm lint:css` runs with a
+// --max-warnings ceiling set to the current count. That is the ratchet: the
+// existing violations do not block anyone, but ONE new raw hex, off-scale
+// radius, fourth breakpoint or duplicate selector pushes the count over the
+// ceiling and fails CI. As each migration lands, lower the ceiling in
+// package.json — the number going down is the visible progress bar.
+//
+// stylelint-config-standard is deliberately NOT extended. It is a general CSS
+// style guide; enabling it against a 9,700-line legacy stylesheet buries the
+// four things the owner actually locked under hundreds of formatting
+// warnings. The scales are the contract; formatting is not.
+
+/** The only radius values in the system: two tokens plus three literals that
+ *  are shapes rather than scale steps (pill, circle, square panel). */
+const RADIUS = ["/^var\\(--radius(-lg)?\\)$/", "999px", "50%", "0"];
+
+/** Three breakpoints, no others. Keyed on the real feature names — keying on
+ *  `width` would be a silent no-op, because no query in this codebase uses the
+ *  range syntax. */
+const BREAKPOINTS = ["640px", "900px", "1280px"];
+
+const config = {
+  ignoreFiles: ["**/node_modules/**", ".next/**"],
+  plugins: ["stylelint-declaration-strict-value"],
+  rules: {
+    // COLOUR — every colour comes from a custom property. The token blocks
+    // themselves are the one sanctioned home for a literal and carry an
+    // explicit `stylelint-disable` comment, so the boundary is visible in the
+    // source rather than implied.
+    "color-no-hex": [true, { severity: "warning" }],
+    "scale-unlimited/declaration-strict-value": [
+      ["/color$/", "background-color", "background", "border-color", "fill", "stroke"],
+      {
+        ignoreValues: [
+          "currentColor",
+          "transparent",
+          "inherit",
+          "initial",
+          "unset",
+          "none",
+          "0",
+        ],
+        disableFix: true,
+        severity: "warning",
+      },
+    ],
+
+    // RADIUS — an allow-list rather than a disallow-lookahead, so the
+    // `0 0 11px 11px` shorthand is caught too.
+    "declaration-property-value-allowed-list": [
+      { "/^border(-[a-z]+)?-radius$/": RADIUS },
+      { severity: "warning" },
+    ],
+
+    // BREAKPOINTS — a fourth width becomes un-typeable.
+    "media-feature-name-value-allowed-list": [
+      { "/^(min|max)-width$/": BREAKPOINTS },
+      { severity: "warning" },
+    ],
+
+    // DUPLICATE SELECTORS — the reason `.topbar-inner` is declared seven times
+    // in one file and the last one silently wins. This is the cheap guard that
+    // makes splitting the monolith unnecessary; note it only sees duplicates
+    // WITHIN a file, so the globals-vs-kernel overlap is still on us.
+    "no-duplicate-selectors": [true, { severity: "warning" }],
+  },
+};
+
+export default config;

--- a/crates/fluidbox-server/src/login.rs
+++ b/crates/fluidbox-server/src/login.rs
@@ -385,14 +385,39 @@ fn page(
 
 /// The single neutral refusal shown for an unknown slug, an IdP-less org, a
 /// suspended org, and a discovery failure alike — it never enumerates orgs.
+///
+/// It REDIRECTS back to the sign-in form rather than terminating on a page.
+/// The terminal page had no way back, so a mistyped organization stranded the
+/// browser on bare system-ui HTML with only the back button for an exit.
+///
+/// The no-enumeration property is untouched: all four causes still produce one
+/// byte-identical response, and `?error=unavailable` carries no more
+/// information than the single sentence the old page already showed everyone.
+///
+/// The body is DELIBERATELY retained even though a browser following the 303
+/// never renders it. A non-browser caller does not follow redirects — notably
+/// scripts/identity-e2e.sh, which asserts that an IdP-less org and a
+/// never-created slug answer identically AND that the answer greps as
+/// 'not configured'. Dropping the body would break that proof of the
+/// anti-enumeration property while looking like a cosmetic change.
 fn neutral_unavailable() -> Response {
-    page(
-        StatusCode::OK,
+    let mut response = page(
+        StatusCode::SEE_OTHER,
         "Sign in",
         "<p>SSO is not configured for this organization.</p>",
         "default-src 'none'; style-src 'unsafe-inline'",
         &[],
-    )
+    );
+    // Relative on purpose. The browser only ever reaches this endpoint through
+    // the dashboard origin (the same-origin API proxy, or the /v1/* rewrite),
+    // so a relative Location resolves to the dashboard's own /login. An
+    // absolute URL would need public_url, which addresses the control plane in
+    // some deployments and would send the user somewhere with no login form.
+    response.headers_mut().insert(
+        axum::http::header::LOCATION,
+        axum::http::HeaderValue::from_static("/login?error=unavailable"),
+    );
+    response
 }
 
 fn too_many() -> Response {

--- a/docs/superpowers/specs/2026-08-14-navigation-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-14-navigation-boundary-design.md
@@ -1,0 +1,113 @@
+# Navigation boundary — public site and signed-in app
+
+**Date:** 2026-08-14 · **Status:** approved, implementing
+
+## Problem
+
+The two surfaces bleed into each other and neither knows the other exists.
+
+- The dashboard masthead's `docs` link **leaves the authenticated app** for the
+  public site.
+- The public header then offers a signed-in user **"Sign in"** and
+  **"Get started"**, because it never checks for a session.
+- The only route back to the dashboard is a footer link under *Product →
+  Dashboard*.
+- `resources` and `activity` in the masthead are not places. They are `#hash`
+  jumps onto Overview, yet they rendered the you-are-here state on sub-pages.
+
+One click on `docs` strands a signed-in user in a surface that treats them as a
+stranger, with no visible way home. And because the dashboard has no hierarchy,
+there is nothing for a deep page to breadcrumb back to.
+
+## Decisions
+
+| # | Decision | Rejected alternative |
+|---|---|---|
+| 1 | **One product; the chrome adapts to the session.** Same URLs, same pages, signed in or out. | A hard wall with docs duplicated at `/app/docs`; opening docs in a new tab. |
+| 2 | **The two groups become real places** — `/app/resources`, `/app/activity`. | Flattening all 9 destinations into the nav (measured ~700px against a ~538px budget); collapsing to an Overview-only hub (2 clicks to anything). |
+| 3 | **Scope is foundations.** Boundary, hierarchy, breadcrumbs, focus. | A ⌘K command palette; view transitions and prefetch. Both deferred — a palette over a broken hierarchy just reaches the mess faster. |
+| 4 | **Session awareness via a pre-paint hint cookie.** | Making `(site)/layout.tsx` dynamic (loses static generation on the SEO surface); a client fetch of `/auth/me` (visible flash on every load). |
+
+## The invariant
+
+> From any page, the other surface is at most one click away, and that link is
+> always visible and labelled.
+
+```
+SIGNED OUT · /docs   product docs pricing oss security   [GitHub] [Get started] [Sign in]
+SIGNED IN  · /docs   product docs pricing oss security   [GitHub] [← Dashboard] [you@…]
+SIGNED IN  · /app    overview activity resources governance recipes docs↗  [status] [you@…]
+```
+
+## Architecture
+
+### Session hint (`app/lib/session-hint.ts`)
+
+`proxy.ts` already runs on every navigation and already reads the session
+cookie. It additionally writes a **non-httpOnly boolean** cookie, and an inline
+script in the root layout stamps `data-session="in"|"out"` on `<html>` **before
+first paint** — the same mechanism `THEME_INIT_SCRIPT` uses for the theme.
+
+The header renders both variants; CSS shows the one that matches. Marketing
+pages stay statically generated and there is no post-hydration swap.
+
+**Security:** the hint cookie is a UI hint and never a credential. It carries no
+identity, grants nothing, and is read by no authorization path. Every
+authorization decision stays in the control plane behind the httpOnly
+`__Host-fbx_web` session cookie. A forged hint changes only which button a
+stranger sees; `/app` still redirects to `/login` and the API still answers 401.
+
+### Route model (`app/lib/nav.ts`)
+
+One pure module owns the route→section→ancestry mapping. Both the masthead's
+active state and the breadcrumb derive from it, so they cannot disagree.
+
+```
+/app                        overview
+/app/activity               activity      → runs · automations
+/app/sessions/[id]          activity      ancestry: activity › runs
+/app/automations[/id]       activity      ancestry: activity › automations
+/app/resources              resources     → agents · mcp · integrations
+/app/agents[/new]           resources     ancestry: resources › agents
+/app/capabilities           resources     ancestry: resources › mcp
+/app/integrations           resources     ancestry: resources › integrations
+/app/governance[/name]      governance
+/app/recipes[/...]          recipes
+/app/settings               settings
+```
+
+Nav is six truthful items: `overview · activity · resources · governance ·
+recipes · settings`. A section lights when the current route is anywhere
+beneath it.
+
+### Breadcrumbs
+
+Derived from the route, never hand-written per page. One `<Breadcrumb />`
+reading `nav.ts`. The last crumb is the current page and is not a link. This
+gives an explicit parent link, so "back" does not depend on browser history —
+which is wrong for anyone arriving via a deep link or a shared URL.
+
+### Focus
+
+A skip link targets the existing `<main id="content">`; focus moves to the page
+`<h1>` after client navigation so keyboard and screen-reader users land on the
+new page rather than the top of the nav.
+
+## Out of scope
+
+⌘K palette · view transitions · prefetch-on-intent · any change to existing
+URLs · moving Recipes under Resources (a distinct concept, not a resource).
+
+## Proofs
+
+Each claim is measured, not asserted.
+
+| Claim | Measurement |
+|---|---|
+| Boundary holds | Signed in, every public route shows exactly ONE visible link back to `/app`; signed out, zero |
+| No flash | The signed-in header variant is present in first paint — no post-hydration swap |
+| Static preserved | `next build` still marks marketing routes `○`/`●`, never `ƒ` |
+| IA is truthful | Every `/app/*` route resolves to exactly ONE active nav item |
+| Back always works | Every deep route renders a crumb trail whose first link is a real route |
+| Focus lands right | After client navigation `document.activeElement` is the new `<h1>` |
+| Nothing regressed | tsc · vitest · `lint:css` at its ceiling · `next build` · eslint unchanged |


### PR DESCRIPTION
Closes the Tier 0 and Tier 1 items from the 2026-08-14 UI audit
(`docs/reviews/2026-08-14-ui-audit/`). Two commits, reviewable separately.

## Why

CI ran `build` + `test` and never lint, so drift had no cost. The four defects
below are symptoms; nothing mechanical was checking, which is why they
accumulated. This adds the check *and* fixes what it found.

## The gate

A stylelint step in the `web` job, deliberately **not** `pnpm lint` — eslint has
a pre-existing red baseline (15 errors, 11 `react-hooks/set-state-in-effect` in
RunComposer and PolicyVersionHistory) that is a runtime-behaviour problem and
must not block enforcing the design scales.

Every rule reports at `warning`; `lint:css` carries `--max-warnings 298`, the
exact current count with **zero headroom**. Existing debt blocks nobody; one new
raw hex, off-scale radius, fourth breakpoint or duplicate selector fails CI.
Lower the ceiling as each migration lands — the number going down is the
progress bar.

Proof: baseline `exit=0`; with a probe adding a hex + `border-radius: 7px` +
`@media (max-width: 999px)` + a duplicate selector → `306 found. 298 allowed`,
`exit=2`.

## The four defects, measured

| | before | after |
|---|---|---|
| `.diff .add` dark | **1.97:1** | **8.41:1** |
| `.diff .del` dark | **2.10:1** | **5.63:1** |
| `.diff .hdr` / `.at` light | 4.06 / 3.96 | 5.27 / 5.33 |
| masthead overflow @1280/1440/1790 | **13px, "Overview" and "Settings" clipped** | **0px, no truncation** |
| `/app/sessions/<bad-id>` | outage card + a Retry that can never work | `404` state, no Retry |
| `/no-such-page` | Next's unstyled default | product 404 on `#f2f0e7` |
| docs copy button | `opacity: 0` until hover — invisible on touch | always visible, 44px on coarse pointers |

Two corrections to the audit worth knowing: it computed diff contrast against
`--surface`, but `kernel.css` re-declares `.diff` and wins by load order, so the
real panel is `--raised` — the wrong base made dark look *better* than it was
and light *safer*. And following its prescription (`var(--green)`/`var(--red)`)
would have pushed light `.add` to **3.91**, fixing dark by breaking light; a
`-dim` step per family clears all four cells instead.

`app/lib/theme-contrast.test.ts` reads the real stylesheets, resolves the
`var()` token graph and fails the build if any pair drops below AA — including
on `--raised`, the darkest surface, which the first pass missed.

## Tier 1

- **Revocation now confirms.** All three "Revoke" buttons destroyed a credential
  on one click. Adds a shared `ConfirmAction` reusing the existing `ModalShell`,
  rather than a fourth ad-hoc copy or `window.confirm`.
- **The sign-in refusal has a way back.** The audit called this "no error
  surface"; reading `login.rs`, `neutral_unavailable` is a deliberate posture —
  one identical response for unknown / IdP-less / suspended / discovery-failed,
  so it never enumerates orgs. The real defect was that it was a *dead end*. Now
  `303 → /login?error=unavailable` with one neutral message.
  - The response **body is retained on purpose**: `scripts/identity-e2e.sh:676`
    asserts the answer greps as `not configured` and that two causes answer
    byte-identically. Dropping it would have broken that proof while looking
    cosmetic. Verified both still hold.
  - The query param is narrowed to a known token and never rendered; verified
    `?error=<img onerror=…>` produces no alert element and no injected node.
- **Naming.** "Guardrails" → "Policy" (already 164 uses; matches the API, DB and
  PLAN.md). The "MCP named six ways" finding is **not** applied — connector,
  connection and capability bundle are genuinely different objects, so the page
  gains a sentence saying which is which instead of a flattening rename.

## Deliberately not in scope

The 15 eslint errors (own PR, own tests — runtime-behavioural), the 298 gated
warnings, and foundation-spec Phase 6.

## Test plan

- [x] `tsc --noEmit` exit 0
- [x] `vitest run` — 194 passed / 14 files (was 175 / 12)
- [x] `lint:css` exit 0 at the ceiling; proven to fail on a deliberate regression
- [x] `next build` exit 0
- [x] `cargo fmt --check` + `cargo clippy` clean
- [x] eslint unchanged at its 16-problem baseline
- [x] Masthead measured live at 640/900/901/1024/1280/1440/1790 with the SSO actions cluster
- [x] Login redirect verified end to end through the proxy; anti-enumeration and the e2e body assertion both re-checked
- [ ] `scripts/identity-e2e.sh` — **needs a manual run**; it hits real infrastructure so I did not run it. The assertions it makes were re-checked by hand against the new response.
- [ ] Click-through of the revoke confirmation — needs a logged-in session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TMHk8bzcSB78eFBqg9Zba
