### PR TITLE
test: PR review panel smoke test

### DIFF
--- a/docs/panel-smoke-test.md
+++ b/docs/panel-smoke-test.md
@@ -1,0 +1,10 @@
+# PR review panel — smoke test
+
+This file exists to exercise the `hrishi-init` PR review panel deployment:
+three sandboxed reviewers (correctness, security, test coverage) fire on
+`pull_request.opened`, each in a governed run with a $1 ceiling.
+
+Expected outcome for this PR: one stable summary comment from the
+correctness lead, plus three commit checks named after their automations.
+
+Safe to close without merging — nothing references this file.


### PR DESCRIPTION
A trivial docs-only change to watch the `hrishi-init` PR review panel fire end-to-end: webhook → ingress → three governed runs → checks + summary comment. Close without merging once the panel has spoken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtMwUBpT8CqTFM7YMVkaLi