### PR TITLE
feat(web): the delight pass — activity workbench, warm kernel, real tables

### DIFF
--- a/apps/web/app/app/activity/page.tsx
+++ b/apps/web/app/app/activity/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { apiGet, Session } from "../../lib/api";
+import { useCallback, useMemo, useState } from "react";
+import { Agent, apiGet, apiGetCached, Session } from "../../lib/api";
+import { ActivityFilter, filterSessions, groupCounts } from "../../lib/activity";
+import { ActivityPulse } from "../../components/ActivityPulse";
 import { AutomationPanel } from "../../components/AutomationPanel";
-import { RunHistory } from "../../components/RunHistory";
+import { RunTable } from "../../components/RunTable";
 import {
   MintedAutomation,
   RunComposer,
@@ -13,13 +15,25 @@ import {
 import { LoadingRows, PageHead } from "../../components/bits";
 import { useSmartPolling } from "../../lib/useSmartPolling";
 
+const FILTERS: { key: ActivityFilter; label: string }[] = [
+  { key: "all", label: "all" },
+  { key: "live", label: "live" },
+  { key: "attention", label: "waiting" },
+  { key: "failed", label: "failed" },
+  { key: "completed", label: "completed" },
+];
+
 // The activity workbench (2026-08-14 navigation-boundary design): run history
 // and automations as a real place — what the masthead's `activity` points at
 // and what sessions/* and automations/* breadcrumb back to. Overview keeps the
 // operations summary; the list itself is the shared RunHistory component, so
-// the two surfaces cannot drift.
+// the two surfaces cannot drift. This page adds the triage layer on top: the
+// 24h pulse, filter chips, and day grouping — all pure derivations of the
+// same polled list (lib/activity.ts), never a second source of truth.
 export default function ActivityPage() {
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [agentNames, setAgentNames] = useState<ReadonlyMap<string, string>>(new Map());
+  const [filter, setFilter] = useState<ActivityFilter>("all");
   const [composerMode, setComposerMode] = useState<RunMode | null>(null);
   const [minted, setMinted] = useState<MintedAutomation | null>(null);
   const [automationRefresh, setAutomationRefresh] = useState(0);
@@ -40,9 +54,23 @@ export default function ActivityPage() {
     } finally {
       setLoading(false);
     }
+    try {
+      // Names are chrome, not truth: a failed read just leaves ids meta-less.
+      const agentResponse = await apiGetCached<{ agents: Agent[] }>("/agents", {
+        maxAgeMs: 15_000,
+      });
+      setAgentNames(new Map(agentResponse.agents.map((agent) => [agent.id, agent.name])));
+    } catch {
+      // Rows fall back to trigger/workspace/id — never block the timeline.
+    }
   }, []);
 
   useSmartPolling(load, 2500);
+
+  const counts = useMemo(() => groupCounts(sessions), [sessions]);
+  const visible = useMemo(() => filterSessions(sessions, filter), [sessions, filter]);
+  const chipCount = (key: ActivityFilter): number =>
+    key === "all" ? sessions.length : counts[key];
 
   return (
     <>
@@ -56,13 +84,34 @@ export default function ActivityPage() {
         }
       />
 
+      {sessions.length > 0 && <ActivityPulse sessions={sessions} />}
+
       <section className="operate-view" aria-labelledby="activity-runs-heading">
         <div className="section-heading recent-heading">
           <div>
             <span className="section-kicker">Every invocation</span>
             <h2 id="activity-runs-heading">Run history</h2>
           </div>
-          <span className="section-note">Runs open their live timeline and diff.</span>
+          {sessions.length > 0 && (
+            <div className="run-filters" role="group" aria-label="Filter runs by status">
+              {FILTERS.map(({ key, label }) => {
+                const count = chipCount(key);
+                if (key !== "all" && count === 0) return null;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    className={`run-filter ${key}${filter === key ? " on" : ""}`}
+                    aria-pressed={filter === key}
+                    onClick={() => setFilter(key)}
+                  >
+                    {label}
+                    <b>{count}</b>
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
         <div className="run-list">
           {loading ? (
@@ -91,8 +140,20 @@ export default function ActivityPage() {
                 </button>
               </div>
             </div>
+          ) : visible.length === 0 ? (
+            <div className="launch-empty slim">
+              <div>
+                <h3>Nothing {FILTERS.find((f) => f.key === filter)?.label} right now.</h3>
+                <p>Runs matching this filter will appear here as the timeline moves.</p>
+              </div>
+              <div className="empty-actions">
+                <button className="btn" type="button" onClick={() => setFilter("all")}>
+                  Show all runs
+                </button>
+              </div>
+            </div>
           ) : (
-            <RunHistory sessions={sessions} />
+            <RunTable sessions={visible} agents={agentNames} />
           )}
         </div>
       </section>

--- a/apps/web/app/app/agents/page.tsx
+++ b/apps/web/app/app/agents/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ChevronDown, ChevronRight, Search as SearchIcon } from "lucide-react";
+import { ChevronDown, Search as SearchIcon } from "lucide-react";
 import {
   apiGetCached,
   apiPost,
@@ -204,93 +204,110 @@ function Agents() {
           ) : shown.length === 0 ? (
             <div className="empty">No agents match “{q}”.</div>
           ) : (
-            <div className="rows">
-              {shown.map((a) => (
-                <div key={a.id}>
-                  <button
-                    type="button"
-                    className="row click"
-                    style={{ gridTemplateColumns: "16px 180px 1fr", cursor: "pointer" }}
-                    onClick={() => toggle(a.id)}
-                    aria-expanded={open === a.id}
-                    aria-controls={`agent-revisions-${a.id}`}
-                  >
-                    <span className="faint" style={{ display: "grid" }}>
-                      {open === a.id ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                    </span>
-                    <span className="mono" style={{ fontSize: 12.5, color: "var(--accent)" }}>
-                      {a.name}
-                    </span>
-                    <span className="task mut">
-                      {a.description || "—"}
-                      {/* The current revision's declaration, stated where an
-                          operator actually looks. Rendered only once the
-                          revisions are known — an unknown declaration shows
-                          nothing rather than claiming "Offline". */}
-                      {revs[a.id]?.[0] && (
-                        <span className="chip" style={{ marginLeft: 8 }}>
-                          network <b>{summarizeRequest(requestOf(revs[a.id][0].network))}</b>
-                        </span>
-                      )}
-                    </span>
-                  </button>
-                  {open === a.id && (
-                    <div
-                      id={`agent-revisions-${a.id}`}
-                      style={{
-                        padding: "4px 16px 14px 42px",
-                        borderBottom: "1px solid var(--border)",
-                      }}
+            <div className="agent-table" role="table" aria-label="Agents">
+              <div className="agent-thead" role="row">
+                <span role="columnheader">agent</span>
+                <span role="columnheader">harness</span>
+                <span role="columnheader">model</span>
+                <span role="columnheader">network</span>
+                <span role="columnheader" className="agent-th-revs">
+                  revisions
+                </span>
+                <span aria-hidden />
+              </div>
+              {shown.map((a) => {
+                const current = revs[a.id]?.[0];
+                const count = revs[a.id]?.length ?? 0;
+                const isOpen = open === a.id;
+                return (
+                  <div key={a.id} role="rowgroup">
+                    {/* The WHOLE row is the expand control; the revision
+                        declaration renders only once revisions are known —
+                        an unknown declaration shows nothing, never a guess. */}
+                    <button
+                      type="button"
+                      className="agent-tr"
+                      role="row"
+                      onClick={() => toggle(a.id)}
+                      aria-expanded={isOpen}
+                      aria-controls={`agent-revisions-${a.id}`}
                     >
-                      {(revs[a.id] || []).map((r, i) => (
-                        <div
-                          key={r.id}
-                          className="chips"
-                          style={{
-                            padding: "8px 0",
-                            borderBottom: "1px solid var(--border)",
-                            alignItems: "center",
-                          }}
-                        >
-                          <span className="chip">
-                            rev <b>{r.rev}</b>
+                      <span className="agent-td-name" role="cell">
+                        <strong>{a.name}</strong>
+                        <small>{a.description || "—"}</small>
+                      </span>
+                      <span className="agent-td-mono" role="cell">
+                        {current?.harness ?? ""}
+                      </span>
+                      <span className="agent-td-mono" role="cell">
+                        {current?.model ?? ""}
+                      </span>
+                      <span role="cell">
+                        {current && (
+                          <span className="run-kind">
+                            {summarizeRequest(requestOf(current.network))}
                           </span>
-                          {i === 0 && <span className="badge ok">current</span>}
-                          <span className="chip">
-                            harness <b>{r.harness}</b>
-                          </span>
-                          <span className="chip">
-                            model <b>{r.model}</b>
-                          </span>
-                          {r.system_prompt && <span className="chip">prompt set</span>}
-                          {r.default_workspace && (
-                            <span className="chip">
-                              workspace <b>{workspaceLabel(r.default_workspace)}</b>
-                            </span>
-                          )}
-                          {r.capability_bundles?.length > 0 && (
-                            <span className="chip">
-                              bundles <b>{bundleRefsLabel(r.capability_bundles)}</b>
-                            </span>
-                          )}
-                          <span className="chip">
-                            network <b>{summarizeRequest(requestOf(r.network))}</b>
-                          </span>
-                          <span className="chip">image {short(r.runner_image, 24)}</span>
+                        )}
+                      </span>
+                      <span className="agent-td-revs" role="cell">
+                        {count > 0 ? `v${current!.rev} · ${count}` : ""}
+                      </span>
+                      <ChevronDown className={`agent-chevron${isOpen ? " open" : ""}`} aria-hidden />
+                    </button>
+                    {isOpen && (
+                      <div id={`agent-revisions-${a.id}`} className="agent-revisions">
+                        <div className="rev-table">
+                          <div className="rev-thead" aria-hidden>
+                            <span>rev</span>
+                            <span>harness</span>
+                            <span>model</span>
+                            <span>network</span>
+                            <span>details</span>
+                            <span>image</span>
+                          </div>
+                          {(revs[a.id] || []).map((r, i) => (
+                            <div key={r.id} className="rev-tr">
+                              <span className="mono">
+                                v{r.rev}
+                                {i === 0 && <span className="badge ok">current</span>}
+                              </span>
+                              <span className="mono">{r.harness}</span>
+                              <span className="mono">{r.model}</span>
+                              <span>
+                                <span className="run-kind">
+                                  {summarizeRequest(requestOf(r.network))}
+                                </span>
+                              </span>
+                              <span className="rev-details">
+                                {[
+                                  r.default_workspace
+                                    ? workspaceLabel(r.default_workspace)
+                                    : "scratch workspace",
+                                  r.capability_bundles?.length
+                                    ? bundleRefsLabel(r.capability_bundles)
+                                    : null,
+                                  r.system_prompt ? "prompt set" : null,
+                                ]
+                                  .filter(Boolean)
+                                  .join(" · ")}
+                              </span>
+                              <span className="mono rev-image">{short(r.runner_image, 24)}</span>
+                            </div>
+                          ))}
                         </div>
-                      ))}
-                      <button
-                        className="btn sm"
-                        style={{ marginTop: 12 }}
-                        disabled={!revs[a.id]}
-                        onClick={() => setAddRev(a.id)}
-                      >
-                        Add revision
-                      </button>
-                    </div>
-                  )}
-                </div>
-              ))}
+                        <button
+                          className="btn sm"
+                          style={{ marginTop: 12 }}
+                          disabled={!revs[a.id]}
+                          onClick={() => setAddRev(a.id)}
+                        >
+                          Add revision
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )}
         </div>

--- a/apps/web/app/app/resources/page.tsx
+++ b/apps/web/app/app/resources/page.tsx
@@ -22,11 +22,16 @@ export default function ResourcesPage() {
         title="Resources"
         sub="The agents, MCP servers, and integrations every run draws from."
       />
-      <ResourceOverview
-        refreshKey={resourceRefresh}
-        onCreateAgent={() => setAgentComposer(true)}
-        onAddCapability={() => setShowCapabilityWizard(true)}
-      />
+      {/* Standalone framing: the page header above already says "resources",
+          so the shared section's own h2/p are hidden here (globals.css
+          .resources-standalone) and only the readiness chip survives. */}
+      <div className="resources-standalone">
+        <ResourceOverview
+          refreshKey={resourceRefresh}
+          onCreateAgent={() => setAgentComposer(true)}
+          onAddCapability={() => setShowCapabilityWizard(true)}
+        />
+      </div>
       {agentComposer && (
         <RunComposer
           agentOnly

--- a/apps/web/app/components/ActivityPulse.tsx
+++ b/apps/web/app/components/ActivityPulse.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMemo } from "react";
+import { Session } from "../lib/api";
+import { groupCounts, pulseHours } from "../lib/activity";
+
+const BAR_MIN_PCT = 12;
+
+function hourLabel(start: Date): string {
+  return `${String(start.getHours()).padStart(2, "0")}:00`;
+}
+
+/**
+ * The pulse: 24 hour-aligned bars, height = run volume, colour = the worst
+ * outcome in that hour (failed > waiting > live > clean). One glance answers
+ * "when was the fleet busy, and did any hour go wrong?" — the readout line
+ * below repeats the same numbers in words for screen readers and skimmers.
+ */
+export function ActivityPulse({ sessions }: { sessions: Session[] }) {
+  const hours = useMemo(() => pulseHours(sessions), [sessions]);
+  const windowSessions = useMemo(() => {
+    const first = hours[0].start.getTime();
+    return sessions.filter((session) => new Date(session.created_at).getTime() >= first);
+  }, [sessions, hours]);
+  const counts = useMemo(() => groupCounts(windowSessions), [windowSessions]);
+
+  const total = windowSessions.length;
+  const max = Math.max(...hours.map((hour) => hour.total), 1);
+
+  return (
+    <section className="activity-pulse" aria-label="Activity in the last 24 hours">
+      <div className="pulse-bars" aria-hidden>
+        {hours.map((hour) => {
+          const pct =
+            hour.total === 0
+              ? 0
+              : BAR_MIN_PCT + Math.round(Math.sqrt(hour.total / max) * (100 - BAR_MIN_PCT));
+          const detail = hour.total === 0 ? "no runs" : `${hour.total} run${hour.total === 1 ? "" : "s"}`;
+          const failed = hour.counts.failed > 0 ? ` · ${hour.counts.failed} failed` : "";
+          return (
+            <span
+              key={hour.start.getTime()}
+              className={`pulse-bar ${hour.worst ?? "idle"}`}
+              style={{ "--pulse-h": `${pct}%` } as React.CSSProperties}
+              title={`${hourLabel(hour.start)} · ${detail}${failed}`}
+            />
+          );
+        })}
+      </div>
+      <div className="pulse-readout">
+        <span className="pulse-count">
+          <b>{total}</b> run{total === 1 ? "" : "s"} · 24h
+        </span>
+        {counts.live > 0 && <span className="pulse-live">{counts.live} live</span>}
+        {counts.attention > 0 && <span className="pulse-attention">{counts.attention} waiting</span>}
+        {counts.failed > 0 && <span className="pulse-failed">{counts.failed} failed</span>}
+        {counts.completed > 0 && <span className="pulse-completed">{counts.completed} clean</span>}
+        {total === 0 && <span className="pulse-quiet">a quiet day so far</span>}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/components/AutomationPanel.tsx
+++ b/apps/web/app/components/AutomationPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { StateError } from "./state";
 import {
   Agent,
@@ -197,6 +198,7 @@ function AutomationRow({
   onToggle: (subscription: TriggerSubscription, enabled: boolean) => void;
   onRotate: (subscription: TriggerSubscription) => void;
 }) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const details = [
     subscription.pinned_revision_id ? "pinned revision" : null,
@@ -209,7 +211,15 @@ function AutomationRow({
 
   return (
     <article className="automation-row">
-      <div className="automation-row-main">
+      {/* The WHOLE row opens the automation; inner buttons/links keep their
+          own jobs (the guard lets any nested interactive element win). */}
+      <div
+        className="automation-row-main"
+        onClick={(event) => {
+          if ((event.target as HTMLElement).closest("button, a")) return;
+          router.push(`/automations/${subscription.id}`);
+        }}
+      >
         <KindIcon kind={subscription.trigger_kind} />
         <div className="automation-copy">
           <div className="automation-title-line">

--- a/apps/web/app/components/ResourceOverview.tsx
+++ b/apps/web/app/components/ResourceOverview.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   Agent,
   apiGetCached,
@@ -155,6 +156,7 @@ export function ResourceOverview({
         <div className="resource-grid">
           <ResourceCard
             tone="agent"
+            href="/app/agents"
             eyebrow="Required"
             title="Agents"
             count={snapshot.agents.length}
@@ -170,6 +172,7 @@ export function ResourceOverview({
 
           <ResourceCard
             tone="integration"
+            href="/app/integrations"
             eyebrow="Optional"
             title="Integrations"
             count={activeConnections.length}
@@ -193,6 +196,7 @@ export function ResourceOverview({
 
           <ResourceCard
             tone="capability"
+            href="/app/capabilities"
             eyebrow="Optional"
             title="MCP"
             count={latestBundles.length}
@@ -213,6 +217,7 @@ export function ResourceOverview({
 
 function ResourceCard({
   tone,
+  href,
   eyebrow,
   title,
   count,
@@ -222,6 +227,8 @@ function ResourceCard({
   secondary,
 }: {
   tone: "integration" | "capability" | "agent";
+  /** The manage surface the WHOLE card opens; inner buttons/links win. */
+  href: string;
   eyebrow: string;
   title: string;
   count: number;
@@ -230,8 +237,15 @@ function ResourceCard({
   action: React.ReactNode;
   secondary?: React.ReactNode;
 }) {
+  const router = useRouter();
   return (
-    <article className={`resource-card resource-${tone}`}>
+    <article
+      className={`resource-card resource-${tone}`}
+      onClick={(event) => {
+        if ((event.target as HTMLElement).closest("button, a")) return;
+        router.push(href);
+      }}
+    >
       <ResourceGlyph tone={tone} />
       <div className="resource-card-content">
         <div className="resource-card-top">

--- a/apps/web/app/components/RunHistory.tsx
+++ b/apps/web/app/components/RunHistory.tsx
@@ -2,36 +2,99 @@
 
 import Link from "next/link";
 import { Session, workspaceLabel } from "../lib/api";
+import { groupByDay, runGroup } from "../lib/activity";
 import { AutoPill, Pill, short, timeAgo } from "./bits";
 
 /**
  * The run-history rows, shared by Overview and /app/activity so the two
  * surfaces cannot drift. Data stays with the page — each has its own polling
  * cadence and its own loading/empty states — this is only the populated list.
+ *
+ * `agents` (optional) turns agent ids into names on the meta line; `grouped`
+ * (optional, used by /app/activity) adds lowercase day dividers.
  */
-export function RunHistory({ sessions }: { sessions: Session[] }) {
+export function RunHistory({
+  sessions,
+  agents,
+  grouped = false,
+}: {
+  sessions: Session[];
+  agents?: ReadonlyMap<string, string>;
+  grouped?: boolean;
+}) {
+  if (!grouped) {
+    return (
+      <div className="run-rows">
+        {sessions.map((session) => (
+          <RunRow key={session.id} session={session} agents={agents} />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="run-rows">
-      {sessions.map((session) => (
-        <Link key={session.id} href={`/app/sessions/${session.id}`} className="run-row">
-          <span className="run-copy">
-            <strong>{session.task}</strong>
-            <small>
-              <span className="mono">{short(session.id)}</span>
-              <span>·</span>
-              <span>{session.trigger?.kind || "manual"}</span>
-              {session.repo_source && (
-                <><span>·</span><span>{workspaceLabel(session.repo_source)}</span></>
-              )}
-            </small>
-          </span>
-          <span className="run-status">
-            <Pill status={session.status} />
-            {session.autonomy === "autonomous" && <AutoPill autonomy={session.autonomy} />}
-          </span>
-          <span className="run-time">{timeAgo(session.created_at)}</span>
-        </Link>
+      {groupByDay(sessions).map((group) => (
+        <div key={group.label} className="run-day">
+          <div className="run-day-label" aria-hidden>
+            {group.label}
+          </div>
+          {group.sessions.map((session) => (
+            <RunRow key={session.id} session={session} agents={agents} />
+          ))}
+        </div>
       ))}
     </div>
+  );
+}
+
+function RunRow({
+  session,
+  agents,
+}: {
+  session: Session;
+  agents?: ReadonlyMap<string, string>;
+}) {
+  const agentName = agents?.get(session.agent_id);
+  return (
+    <Link
+      href={`/app/sessions/${session.id}`}
+      className={`run-row rail-${runGroup(session.status)}`}
+    >
+      <span className="run-copy">
+        <strong>{session.task}</strong>
+        <small>
+          {agentName && (
+            <>
+              <span className="run-agent">{agentName}</span>
+              <span>·</span>
+            </>
+          )}
+          <span>{session.trigger?.kind || "manual"}</span>
+          {session.repo_source && (
+            <><span>·</span><span>{workspaceLabel(session.repo_source)}</span></>
+          )}
+          <span>·</span>
+          <span className="mono">{short(session.id)}</span>
+        </small>
+      </span>
+      <span className="run-status">
+        <Pill status={session.status} />
+        {session.autonomy === "autonomous" && <AutoPill autonomy={session.autonomy} />}
+      </span>
+      <span className="run-time">{timeAgo(session.created_at)}</span>
+      <svg
+        className="run-arrow"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M9 18l6-6-6-6" />
+      </svg>
+    </Link>
   );
 }

--- a/apps/web/app/components/RunTable.tsx
+++ b/apps/web/app/components/RunTable.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { Session, workspaceLabel } from "../lib/api";
+import { groupByDay, runGroup, splitTask } from "../lib/activity";
+import { Pill, short, timeAgo } from "./bits";
+
+/**
+ * The activity workbench's run table: one row per run with real columns
+ * (run · agent · trigger · status · age) under a sticky mono header, grouped
+ * by day. GitHub-event boilerplate is folded out of the headline by
+ * splitTask so the column reads as WHAT each run did, not the same suffix
+ * twenty-eight times. Overview keeps the compact RunHistory rows — this
+ * table is the workbench view of the same Session list.
+ */
+export function RunTable({
+  sessions,
+  agents,
+}: {
+  sessions: Session[];
+  agents?: ReadonlyMap<string, string>;
+}) {
+  return (
+    <div className="run-table" role="table" aria-label="Run history">
+      <div className="run-thead" role="row">
+        <span role="columnheader">run</span>
+        <span role="columnheader">agent</span>
+        <span role="columnheader">trigger</span>
+        <span role="columnheader">status</span>
+        <span role="columnheader" className="run-th-age">
+          age
+        </span>
+        <span aria-hidden />
+      </div>
+      {groupByDay(sessions).map((group) => (
+        <div key={group.label} role="rowgroup">
+          <div className="run-day-label" role="presentation" aria-hidden>
+            {group.label}
+          </div>
+          {group.sessions.map((session) => (
+            <RunTableRow key={session.id} session={session} agents={agents} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RunTableRow({
+  session,
+  agents,
+}: {
+  session: Session;
+  agents?: ReadonlyMap<string, string>;
+}) {
+  const { headline, context } = splitTask(session.task);
+  const workspace = session.repo_source ? workspaceLabel(session.repo_source) : context;
+  const agentName = agents?.get(session.agent_id);
+
+  return (
+    <Link
+      href={`/app/sessions/${session.id}`}
+      className={`run-tr rail-${runGroup(session.status)}`}
+      role="row"
+    >
+      <span className="run-td-task" role="cell">
+        <strong>{headline}</strong>
+        <small>
+          {workspace && (
+            <>
+              <span className="mono">{workspace}</span>
+              <span>·</span>
+            </>
+          )}
+          <span className="mono">{short(session.id)}</span>
+        </small>
+      </span>
+      <span className="run-td-agent" role="cell">
+        {agentName ?? <span className="faint">—</span>}
+      </span>
+      <span className="run-td-trigger" role="cell">
+        <span className="run-kind">{session.trigger?.kind || "manual"}</span>
+      </span>
+      <span className="run-td-status" role="cell">
+        <Pill status={session.status} />
+        {session.autonomy === "autonomous" && (
+          <span className="badge warn" title="autonomous">
+            auto
+          </span>
+        )}
+      </span>
+      <span className="run-td-age" role="cell">
+        {timeAgo(session.created_at)}
+      </span>
+      <svg
+        className="run-arrow"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M9 18l6-6-6-6" />
+      </svg>
+    </Link>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -962,10 +962,11 @@ h1.title {
   flex-direction: column;
 }
 .run-row {
+  position: relative;
   min-height: 78px;
   padding: 14px 18px;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto 76px;
+  grid-template-columns: minmax(0, 1fr) auto 76px 14px;
   align-items: center;
   gap: 14px;
   border-bottom: 1px solid var(--border);
@@ -1657,6 +1658,8 @@ h1.title {
   display: grid;
   grid-template-columns: 66px minmax(0, 1fr) auto;
   align-items: center;
+  /* The whole row navigates (AutomationPanel guards inner buttons/links). */
+  cursor: pointer;
   gap: 14px;
 }
 .automation-glyph {
@@ -3924,7 +3927,8 @@ a.row:hover,
   .run-row {
     grid-template-columns: minmax(0, 1fr) auto;
   }
-  .run-time {
+  .run-time,
+  .run-row .run-arrow {
     display: none;
   }
   .launch-empty {
@@ -8091,4 +8095,526 @@ a.st-use:hover p {
   .recipe-detail-grid { grid-template-columns: 1fr; }
   .recipe-row { grid-template-columns: minmax(0, 1fr) 100px; }
   .recipe-row span:nth-child(2), .recipe-row span:nth-child(4), .recipe-row span:nth-child(5) { display: none; }
+}
+
+/* ── Activity workbench: the pulse + triage layer ─────────────────────────
+   The pulse is the page's signature: 24 hour-aligned bars, height = volume,
+   colour = the WORST outcome of that hour (failed > waiting > live > clean) —
+   the same fail-closed precedence the gate uses. Everything below derives
+   from the polled sessions list; colours come only from the token layer. */
+.activity-pulse {
+  margin: 0 0 44px;
+  padding: 16px 18px 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-soft);
+  box-shadow: var(--panel-shadow);
+  animation: enter 0.5s 0.05s ease both;
+}
+.pulse-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 46px;
+}
+.pulse-bar {
+  flex: 1 1 0;
+  min-width: 0;
+  height: var(--pulse-h, 0%);
+  min-height: 2px;
+  background: var(--border-strong);
+  transform-origin: bottom;
+  animation: pulse-grow 0.45s ease both;
+}
+.pulse-bar.idle {
+  opacity: 0.5;
+}
+.pulse-bar.cancelled {
+  background: var(--border-strong);
+}
+.pulse-bar.completed {
+  background: var(--green);
+  opacity: 0.75;
+}
+.pulse-bar.live {
+  background: var(--accent);
+  animation:
+    pulse-grow 0.45s ease both,
+    pulse-breathe 1.8s ease-in-out 0.5s infinite;
+}
+.pulse-bar.attention {
+  background: var(--amber);
+}
+.pulse-bar.failed {
+  background: var(--red);
+}
+@keyframes pulse-grow {
+  from {
+    transform: scaleY(0);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+@keyframes pulse-breathe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+.pulse-readout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 10px;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: lowercase;
+}
+.pulse-count b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.pulse-live {
+  color: var(--accent);
+}
+.pulse-attention {
+  color: var(--amber);
+}
+.pulse-failed {
+  color: var(--red);
+}
+.pulse-completed {
+  color: var(--green);
+}
+.pulse-quiet {
+  color: var(--ink-3);
+}
+
+/* Status filter chips: mono lowercase, square per the kernel language. */
+.run-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.run-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: none;
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s,
+    background 0.15s;
+}
+.run-filter:hover {
+  border-color: var(--border-strong);
+  color: var(--ink);
+}
+.run-filter b {
+  color: var(--ink-3);
+  font-weight: 500;
+}
+.run-filter.on {
+  border-color: var(--border-strong);
+  background: var(--interactive-subtle);
+  color: var(--ink);
+}
+.run-filter.on b {
+  color: inherit;
+}
+.run-filter.live.on {
+  border-color: var(--accent);
+  background: var(--accent-tint);
+  color: var(--accent-dim);
+}
+.run-filter.attention.on {
+  border-color: var(--amber);
+  background: var(--amber-tint);
+  color: var(--amber-dim);
+}
+.run-filter.failed.on {
+  border-color: var(--red);
+  background: var(--red-tint);
+  color: var(--red-dim);
+}
+.run-filter.completed.on {
+  border-color: var(--green);
+  background: var(--green-tint);
+  color: var(--green-dim);
+}
+
+/* Day dividers inside the shared run list (activity only, via `grouped`). */
+.run-day-label {
+  padding: 7px 18px 6px;
+  border-bottom: 1px solid var(--border);
+  background: var(--interactive-subtle);
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+.run-day + .run-day .run-day-label {
+  border-top: 1px solid var(--border);
+}
+
+/* The status rail: scanning the left edge reads the red/green pattern
+   without reading a single row. Live runs breathe. */
+.run-row::before,
+.run-tr::before {
+  content: "";
+  position: absolute;
+  top: 14px;
+  bottom: 14px;
+  left: 0;
+  width: 2px;
+  background: none;
+}
+.run-row.rail-live::before,
+.run-tr.rail-live::before {
+  background: var(--accent);
+  animation: pulse-breathe 1.8s ease-in-out infinite;
+}
+.run-row.rail-attention::before,
+.run-tr.rail-attention::before {
+  background: var(--amber);
+}
+.run-row.rail-failed::before,
+.run-tr.rail-failed::before {
+  background: var(--red);
+}
+.run-row.rail-completed::before,
+.run-tr.rail-completed::before {
+  background: var(--green);
+  opacity: 0.55;
+}
+.run-row.rail-cancelled::before,
+.run-tr.rail-cancelled::before {
+  background: var(--border-strong);
+}
+.run-agent {
+  color: var(--ink-2);
+  font-weight: 500;
+}
+.launch-empty.slim {
+  min-height: 150px;
+  padding: 30px 48px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pulse-bar,
+  .pulse-bar.live,
+  .run-row.rail-live::before,
+  .run-tr.rail-live::before {
+    animation: none;
+  }
+}
+@media (max-width: 640px) {
+  .pulse-bars {
+    gap: 3px;
+    height: 38px;
+  }
+  .run-filters {
+    gap: 5px;
+  }
+}
+
+/* ── Standalone resources page framing ────────────────────────────────
+   /app/resources renders PageHead("resources") ABOVE the shared
+   ResourceOverview section, whose own h2/p would read as a duplicate
+   heading. Hide the words, keep the readiness chip. */
+.resources-standalone .configuration-head > div:first-child {
+  display: none;
+}
+.resources-standalone .configuration-head {
+  justify-content: flex-end;
+  margin-bottom: 14px;
+}
+
+/* ── The run table (activity workbench) ───────────────────────────────
+   Real columns under a mono header: run · agent · trigger · status · age.
+   Shares the day-divider and rail language with the compact run rows. */
+.run-thead {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 150px 90px 170px 64px 14px;
+  gap: 14px;
+  padding: 9px 18px 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--interactive-subtle);
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+.run-th-age {
+  text-align: right;
+}
+.run-tr {
+  position: relative;
+  min-height: 64px;
+  padding: 11px 18px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 150px 90px 170px 64px 14px;
+  gap: 14px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  color: inherit;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+.run-tr:hover {
+  background: var(--surface-hover);
+}
+.run-table > div:last-child .run-tr:last-child {
+  border-bottom: 0;
+}
+.run-td-task {
+  min-width: 0;
+}
+.run-td-task strong {
+  display: block;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 13.5px;
+  font-weight: 500;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.run-td-task small {
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--ink-3);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.run-td-agent {
+  overflow: hidden;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.run-kind {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  text-transform: lowercase;
+}
+.run-td-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.run-td-age {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: right;
+}
+.run-tr .run-arrow {
+  width: 14px;
+  height: 14px;
+  color: var(--ink-3);
+  transition: transform 0.15s, color 0.15s;
+}
+.run-tr:hover .run-arrow {
+  color: var(--ink);
+  transform: translateX(2px);
+}
+@media (max-width: 900px) {
+  .run-thead {
+    display: none;
+  }
+  .run-tr {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+  }
+  .run-td-agent,
+  .run-td-trigger,
+  .run-td-age,
+  .run-tr .run-arrow {
+    display: none;
+  }
+}
+
+/* ── The agents table ─────────────────────────────────────────────────
+   Same table language as run history: mono header, whole-row control
+   (the row button expands the revision history), chevron affordance. */
+.agent-thead {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) 140px 180px 130px 90px 14px;
+  gap: 14px;
+  padding: 9px 18px 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--interactive-subtle);
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+.agent-th-revs {
+  text-align: right;
+}
+.agent-tr {
+  width: 100%;
+  min-height: 64px;
+  padding: 11px 18px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) 140px 180px 130px 90px 14px;
+  gap: 14px;
+  align-items: center;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.agent-tr:hover {
+  background: var(--surface-hover);
+}
+.agent-table > div:last-child > .agent-tr[aria-expanded="false"]:last-child {
+  border-bottom: 0;
+}
+.agent-td-name {
+  min-width: 0;
+}
+.agent-td-name strong {
+  display: block;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 13.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agent-td-name small {
+  display: block;
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--ink-3);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agent-td-mono {
+  overflow: hidden;
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agent-td-revs {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: right;
+  white-space: nowrap;
+}
+.agent-chevron {
+  width: 14px;
+  height: 14px;
+  color: var(--ink-3);
+  transform: rotate(-90deg);
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+.agent-chevron.open {
+  transform: rotate(0deg);
+}
+.agent-tr:hover .agent-chevron {
+  color: var(--ink);
+}
+
+/* The expanded revision history: a quiet inset sub-table. */
+.agent-revisions {
+  padding: 4px 18px 16px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+  background: var(--interactive-subtle);
+}
+.rev-table {
+  min-width: 760px;
+}
+.rev-thead,
+.rev-tr {
+  display: grid;
+  grid-template-columns: 96px 130px 180px 120px minmax(0, 1fr) 130px;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.rev-thead {
+  padding: 10px 0 6px;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+.rev-tr {
+  font-size: 12px;
+}
+.rev-tr:last-child {
+  border-bottom: 0;
+}
+.rev-tr .mono {
+  overflow: hidden;
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rev-tr .badge {
+  margin-left: 8px;
+}
+.rev-details {
+  overflow: hidden;
+  color: var(--ink-3);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rev-image {
+  color: var(--ink-3);
+}
+
+@media (max-width: 900px) {
+  .agent-thead {
+    display: none;
+  }
+  .agent-tr {
+    grid-template-columns: minmax(0, 1fr) 14px;
+  }
+  .agent-td-mono,
+  .agent-td-revs,
+  .agent-tr > span:nth-child(4) {
+    display: none;
+  }
 }

--- a/apps/web/app/kernel.css
+++ b/apps/web/app/kernel.css
@@ -99,10 +99,15 @@
   --selection-bg: rgba(129, 179, 0, 0.25);
   --scrollbar: var(--ds-gray-300);
   --scrollbar-hover: var(--ds-gray-500);
-  --panel-shadow: none;
+  /* 2026-08-14 warmth pass (cerebras learnings): panels carry a soft real
+     shadow, the shell glows from one corner, and the flood accent gets a
+     bloom for filled controls. Literals stay in this token layer. */
+  --panel-shadow: 0 1px 2px rgba(28, 32, 36, 0.04), 0 10px 30px rgba(28, 32, 36, 0.06);
+  --canvas-glow: rgba(129, 179, 0, 0.09);
+  --flood-glow: 0 6px 22px rgba(129, 179, 0, 0.3);
   --modal-shadow: 0 24px 70px rgba(28, 32, 36, 0.18);
-  --radius: 4px;
-  --radius-lg: 8px;
+  --radius: 6px;
+  --radius-lg: 12px;
   --hairline: 0.5px;
 
   /* Third-party brand marks. These are other companies' identities, not our
@@ -156,10 +161,13 @@
    other rule in this file must reach a colour through a custom property;
    the gate enforces that, and this comment is the visible boundary. */
 html[data-theme="dark"] {
-  /* kernel.sh's dark sections: charcoal, never black. */
-  --ds-background-100: #191a1c;
-  --ds-background-200: #212225;
-  --ds-gray-100: #26282c;
+  /* kernel.sh's dark sections: deep charcoal, never black — deepened one
+     step (2026-08-14) so cards visibly sit ABOVE the canvas instead of
+     dissolving into it. Ink tokens are near-white, so deeper surfaces only
+     raise every contrast ratio the theme-contrast suite asserts. */
+  --ds-background-100: #131417;
+  --ds-background-200: #1c1d21;
+  --ds-gray-100: #232428;
   --ds-gray-200: #2c2e33;
   --ds-gray-300: #33363b;
   --ds-gray-400: #3d4046;
@@ -209,18 +217,20 @@ html[data-theme="dark"] {
   --green-tint: var(--ds-green-100);
   --red: var(--ds-red-700);
   --red-tint: var(--ds-red-100);
-  --chrome-bg: rgba(25, 26, 28, 0.92);
+  --chrome-bg: rgba(19, 20, 23, 0.9);
   --interactive-subtle: var(--ds-gray-alpha-100);
   --interactive-hover: var(--ds-gray-alpha-200);
-  --control-bg: #212225;
+  --control-bg: #1c1d21;
   --primary-bg: #edeef0;
   --primary-hover: #ffffff;
   --primary-ink: #1c2024;
-  --overlay-bg: rgba(10, 11, 12, 0.6);
+  --overlay-bg: rgba(8, 9, 10, 0.62);
   --selection-bg: rgba(129, 179, 0, 0.3);
   --scrollbar: var(--ds-gray-300);
   --scrollbar-hover: var(--ds-gray-500);
-  --panel-shadow: none;
+  --panel-shadow: 0 1px 0 rgba(237, 238, 240, 0.03) inset, 0 14px 40px rgba(0, 0, 0, 0.32);
+  --canvas-glow: rgba(129, 179, 0, 0.07);
+  --flood-glow: 0 6px 24px rgba(129, 179, 0, 0.22);
   --modal-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
 }
 /* stylelint-enable color-no-hex, scale-unlimited/declaration-strict-value */
@@ -379,8 +389,9 @@ body {
 }
 
 .masthead-nav a.active {
-  background: var(--ds-gray-alpha-200);
-  color: var(--ds-gray-1000);
+  background: var(--accent-tint);
+  color: var(--accent-dim);
+  font-weight: 500;
 }
 
 /* The out-of-app marker on the docs link: that click leaves the dashboard for
@@ -564,10 +575,10 @@ h1.title {
   margin: 0;
   color: var(--ds-gray-1000);
   font-family: var(--font-sans);
-  font-size: 33px;
-  font-weight: 300;
-  line-height: 1.2;
-  letter-spacing: 0.02em;
+  font-size: 40px;
+  font-weight: 350;
+  line-height: 1.12;
+  letter-spacing: -0.01em;
   text-transform: lowercase;
 }
 
@@ -635,18 +646,18 @@ h1.title {
   text-transform: lowercase;
 }
 
-/* Materials — hairline-bordered boxes, no shadows (kernel keeps panels
-   square; only small controls take the 4px radius). */
+/* Materials — cards now sit visibly above the canvas: soft border, real
+   radius, and the token shadow (2026-08-14 warmth pass). */
 
 .panel,
 .run-list,
 .configuration-loading,
 .feature-card,
 .overview-panel {
-  border: var(--hairline) solid var(--border-strong);
-  border-radius: 0;
+  border: var(--hairline) solid var(--border);
+  border-radius: var(--radius-lg);
   background: var(--surface);
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 
 .panel.pad {
@@ -786,60 +797,62 @@ h1.title {
   background: var(--gold);
 }
 
+/* Resources — real tone-coloured cards (2026-08-14 warmth pass): the
+   3-up grid returns, each card keyed by its tone colour (glyph tile, count
+   chip, and the soft ::after bloom all ride currentColor from globals). */
+
 .resource-grid {
-  display: block;
-  overflow: hidden;
-  border: var(--hairline) solid var(--border-strong);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  overflow: visible;
+  border: 0;
   border-radius: 0;
-  background: var(--surface);
+  background: transparent;
   box-shadow: none;
 }
 
 .resource-card,
 .resource-card + .resource-card {
-  min-height: 96px;
-  padding: 16px;
-  display: grid;
-  grid-template-columns: 36px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 14px;
-  overflow: visible;
-  border: 0;
-  border-bottom: var(--hairline) solid var(--border);
-  border-radius: 0;
+  min-height: 250px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  overflow: hidden;
+  /* The whole card navigates (ResourceCard guards inner buttons/links). */
+  cursor: pointer;
+  border: var(--hairline) solid var(--border);
+  border-radius: var(--radius-lg);
   background: var(--surface);
-  color: var(--ds-gray-1000);
-  transition: background 0.15s ease;
-}
-
-.resource-card:last-child {
-  border-bottom: 0;
+  box-shadow: var(--panel-shadow);
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
 }
 
 .resource-card:hover {
-  border-color: var(--border);
-  background: var(--accent-tint);
-  transform: none;
-}
-
-.resource-card::after {
-  display: none;
+  border-color: var(--border-strong);
+  background: var(--surface-hover);
+  transform: translateY(-2px);
 }
 
 .resource-glyph {
-  width: 36px;
-  height: 36px;
-  border: var(--hairline) solid var(--border-strong);
-  border-radius: var(--radius);
-  background: var(--surface);
-  color: var(--ds-gray-1000);
+  width: 40px;
+  height: 40px;
+  margin-bottom: 14px;
+  border: var(--hairline) solid currentColor;
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, currentColor 12%, transparent);
 }
 
 .resource-glyph svg {
-  width: 17px;
-  height: 17px;
+  width: 19px;
+  height: 19px;
   stroke: currentColor;
-  stroke-width: 1.2;
+  stroke-width: 1.4;
 }
 
 .resource-card-content {
@@ -856,7 +869,7 @@ h1.title {
   margin: 0;
   color: var(--ds-gray-1000);
   font-family: var(--font-sans);
-  font-size: 14.5px;
+  font-size: 17px;
   font-weight: 500;
   letter-spacing: 0;
   text-transform: lowercase;
@@ -864,6 +877,7 @@ h1.title {
 
 .resource-eyebrow {
   order: 3;
+  margin-left: auto;
   padding: 2px 8px;
   border: var(--hairline) solid var(--border-strong);
   border-radius: var(--radius);
@@ -889,15 +903,15 @@ h1.title {
 
 .resource-card > .resource-card-content > p {
   min-height: 0;
-  margin: 3px 0 0;
+  margin: 7px 0 0;
   color: var(--ds-gray-900);
   font-size: 13px;
-  line-height: 1.4;
+  line-height: 1.55;
 }
 
 .resource-items {
   min-height: 0;
-  margin-top: 7px;
+  margin-top: 12px;
   gap: 5px;
 }
 
@@ -912,13 +926,14 @@ h1.title {
 
 .resource-actions {
   min-height: 0;
-  margin: 0;
-  padding: 0;
+  margin: auto 0 0;
+  padding: 16px 0 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 10px;
   border: 0;
+  border-top: var(--hairline) solid var(--border);
 }
 
 .text-action {
@@ -961,16 +976,18 @@ h1.title {
 }
 
 .btn.primary {
-  border-color: var(--ds-gray-1000);
-  background: var(--ds-gray-1000);
-  color: var(--ds-background-100);
-  box-shadow: none;
-}
-
-.btn.primary:hover {
   border-color: var(--flood);
   background: var(--flood);
   color: var(--flood-ink);
+  font-weight: 500;
+  box-shadow: var(--flood-glow);
+}
+
+.btn.primary:hover {
+  border-color: var(--accent-dim);
+  background: var(--accent-dim);
+  color: var(--flood-ink);
+  transform: translateY(-1px);
 }
 
 .btn.human {
@@ -1622,14 +1639,7 @@ pre.token,
   .resource-card,
   .resource-card + .resource-card {
     min-height: 0;
-    padding: 14px;
-    grid-template-columns: 36px minmax(0, 1fr);
-    align-items: start;
-  }
-
-  .resource-actions {
-    grid-column: 2;
-    justify-content: flex-start;
+    padding: 16px;
   }
 
   .connector-card {

--- a/apps/web/app/lib/activity.test.ts
+++ b/apps/web/app/lib/activity.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "vitest";
+import {
+  dayLabel,
+  filterSessions,
+  groupByDay,
+  groupCounts,
+  PULSE_HOURS,
+  pulseHours,
+  runGroup,
+  splitTask,
+} from "./activity";
+import { Session } from "./api";
+
+function session(overrides: Partial<Session>): Session {
+  return {
+    id: "01a00000",
+    status: "completed",
+    autonomy: "supervised",
+    task: "test task",
+    agent_id: "agent-1",
+    result_summary: null,
+    created_at: "2026-08-14T12:00:00Z",
+    base_commit: null,
+    repo_source: null,
+    trigger: null,
+    ...overrides,
+  };
+}
+
+describe("runGroup", () => {
+  test("maps every terminal status to its triage group", () => {
+    expect(runGroup("completed")).toBe("completed");
+    expect(runGroup("failed")).toBe("failed");
+    expect(runGroup("budget_exceeded")).toBe("failed");
+    expect(runGroup("cancelled")).toBe("cancelled");
+  });
+
+  test("maps pauses to attention and in-flight states to live", () => {
+    expect(runGroup("awaiting_approval")).toBe("attention");
+    expect(runGroup("awaiting_authorization")).toBe("attention");
+    expect(runGroup("running")).toBe("live");
+    expect(runGroup("provisioning")).toBe("live");
+    expect(runGroup("finalizing")).toBe("live");
+  });
+
+  test("treats an unknown status as live so it stays visible", () => {
+    expect(runGroup("some_future_status")).toBe("live");
+  });
+});
+
+describe("pulseHours", () => {
+  const now = new Date("2026-08-14T21:30:00Z");
+
+  test("returns 24 hour-aligned buckets ending at the current hour", () => {
+    const hours = pulseHours([], now);
+    expect(hours).toHaveLength(PULSE_HOURS);
+    expect(hours[PULSE_HOURS - 1].start.getTime()).toBe(
+      new Date("2026-08-14T21:30:00Z").setMinutes(0, 0, 0)
+    );
+    expect(hours[0].start.getTime()).toBe(
+      new Date("2026-08-14T21:30:00Z").setMinutes(0, 0, 0) - 23 * 3_600_000
+    );
+    expect(hours.every((hour) => hour.total === 0 && hour.worst === null)).toBe(true);
+  });
+
+  // Timestamps are derived from the empty run's own bucket starts so the
+  // assertions hold in every timezone (buckets align to LOCAL clock hours).
+  const bucketStarts = pulseHours([], now).map((hour) => hour.start.getTime());
+  const at = (bucket: number, minutes: number) =>
+    new Date(bucketStarts[bucket] + minutes * 60_000).toISOString();
+
+  test("buckets sessions by hour and reports the worst outcome", () => {
+    const hours = pulseHours(
+      [
+        session({ status: "completed", created_at: at(PULSE_HOURS - 1, 5) }),
+        session({ status: "failed", created_at: at(PULSE_HOURS - 1, 10) }),
+        session({ status: "running", created_at: at(PULSE_HOURS - 2, 5) }),
+      ],
+      now
+    );
+    const last = hours[PULSE_HOURS - 1];
+    expect(last.total).toBe(2);
+    expect(last.worst).toBe("failed");
+    expect(hours[PULSE_HOURS - 2].worst).toBe("live");
+  });
+
+  test("drops sessions older than the window and tolerates bad timestamps", () => {
+    const hours = pulseHours(
+      [
+        session({ created_at: at(0, -90) }),
+        session({ created_at: "not a date" }),
+      ],
+      now
+    );
+    expect(hours.every((hour) => hour.total === 0)).toBe(true);
+  });
+});
+
+describe("groupCounts / filterSessions", () => {
+  const sessions = [
+    session({ id: "a", status: "running" }),
+    session({ id: "b", status: "awaiting_approval" }),
+    session({ id: "c", status: "failed" }),
+    session({ id: "d", status: "completed" }),
+    session({ id: "e", status: "completed" }),
+  ];
+
+  test("counts each triage group", () => {
+    expect(groupCounts(sessions)).toEqual({
+      live: 1,
+      attention: 1,
+      failed: 1,
+      completed: 2,
+      cancelled: 0,
+    });
+  });
+
+  test("filters by group and passes everything through on all", () => {
+    expect(filterSessions(sessions, "completed").map((s) => s.id)).toEqual(["d", "e"]);
+    expect(filterSessions(sessions, "all")).toHaveLength(5);
+  });
+});
+
+describe("splitTask", () => {
+  test("strips the GitHub-event boilerplate into context", () => {
+    expect(
+      splitTask(
+        "Review pull request #143 (test: PR review panel smoke test) of hrishikeshdkakkad/fluidbox at head 4a3643d898074a4745bc187deefaf32e6e273ff1"
+      )
+    ).toEqual({
+      headline: "Review pull request #143 (test: PR review panel smoke test)",
+      context: "hrishikeshdkakkad/fluidbox@4a3643d",
+    });
+  });
+
+  test("also strips the checkout/compare instructions after the sha", () => {
+    expect(
+      splitTask(
+        "Security-review pull request #143 (test: PR review panel smoke test) of hrishikeshdkakkad/fluidbox at head 4a3643d898074a4745bc187deefaf32e6e273ff1. The PR is checked out in /workspace. Compare against base bbf27d2636f7c00a384e895622e3e21ed17ce367."
+      )
+    ).toEqual({
+      headline: "Security-review pull request #143 (test: PR review panel smoke test)",
+      context: "hrishikeshdkakkad/fluidbox@4a3643d",
+    });
+  });
+
+  test("passes non-templated tasks through untouched", () => {
+    expect(splitTask("Fix the failing unit test in policy.rs")).toEqual({
+      headline: "Fix the failing unit test in policy.rs",
+      context: null,
+    });
+  });
+
+  test("does not fire on a mid-sentence 'of … at head' with trailing text", () => {
+    const task = "Summarize of a/b at head cafe1234 and then do more work";
+    expect(splitTask(task).context).toBeNull();
+  });
+});
+
+describe("day grouping", () => {
+  // Local-time construction keeps these assertions timezone-independent.
+  const local = (day: number, hour: number) =>
+    new Date(2026, 7, day, hour, 0, 0).toISOString();
+  const now = new Date(2026, 7, 14, 21, 30);
+
+  test("labels today and yesterday in the chrome voice", () => {
+    expect(dayLabel(local(14, 20), now)).toBe("today");
+    expect(dayLabel(local(13, 23), now)).toBe("yesterday");
+    expect(dayLabel("garbage", now)).toBe("earlier");
+  });
+
+  test("partitions a newest-first list into contiguous day groups", () => {
+    const groups = groupByDay(
+      [
+        session({ id: "a", created_at: local(14, 20) }),
+        session({ id: "b", created_at: local(14, 8) }),
+        session({ id: "c", created_at: local(13, 22) }),
+      ],
+      now
+    );
+    expect(groups.map((group) => group.label)).toEqual(["today", "yesterday"]);
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(groups[1].sessions.map((s) => s.id)).toEqual(["c"]);
+  });
+});

--- a/apps/web/app/lib/activity.ts
+++ b/apps/web/app/lib/activity.ts
@@ -1,0 +1,164 @@
+// Pure derivations for the activity workbench: status triage groups, the
+// 24-hour pulse buckets, and day grouping. No I/O — everything here is a
+// function of the sessions list the page already polls, so it stays
+// presentation-only (the control plane remains the source of truth).
+
+import { Session } from "./api";
+
+/** Triage groups, in the order an operator cares about them. */
+export type RunGroup = "live" | "attention" | "failed" | "completed" | "cancelled";
+
+/** Chip filters: the triage groups an operator actually reaches for. */
+export type ActivityFilter = "all" | "live" | "attention" | "failed" | "completed";
+
+const ATTENTION_STATUSES = new Set(["awaiting_approval", "awaiting_authorization"]);
+const FAILED_STATUSES = new Set(["failed", "budget_exceeded"]);
+
+/**
+ * Map a raw session status onto a triage group. Unknown statuses read as
+ * "live" on purpose: a status this UI has never heard of is an in-flight
+ * shape from a newer server, and hiding it would be the one wrong answer.
+ */
+export function runGroup(status: string): RunGroup {
+  if (ATTENTION_STATUSES.has(status)) return "attention";
+  if (FAILED_STATUSES.has(status)) return "failed";
+  if (status === "completed") return "completed";
+  if (status === "cancelled") return "cancelled";
+  return "live";
+}
+
+/** Severity precedence for the pulse: a bar shows the WORST outcome of its
+ *  hour, because "does this hour need me?" is the question the strip answers. */
+const SEVERITY: readonly RunGroup[] = ["failed", "attention", "live", "completed", "cancelled"];
+
+export const PULSE_HOURS = 24;
+const HOUR_MS = 3_600_000;
+
+export interface PulseHour {
+  /** Start of the hour bucket (local time). */
+  start: Date;
+  total: number;
+  /** Worst triage group present in this hour, or null when empty. */
+  worst: RunGroup | null;
+  counts: Readonly<Record<RunGroup, number>>;
+}
+
+/**
+ * Bucket sessions into the trailing 24 hour-aligned windows, oldest first,
+ * ending with the hour containing `now`. Sessions older than the window are
+ * ignored; sessions timestamped after `now` land in the current hour.
+ */
+export function pulseHours(sessions: readonly Session[], now: Date = new Date()): PulseHour[] {
+  const currentHour = new Date(now);
+  currentHour.setMinutes(0, 0, 0);
+  const firstHourMs = currentHour.getTime() - (PULSE_HOURS - 1) * HOUR_MS;
+
+  const tallies = Array.from({ length: PULSE_HOURS }, () => ({
+    live: 0,
+    attention: 0,
+    failed: 0,
+    completed: 0,
+    cancelled: 0,
+  }));
+
+  for (const session of sessions) {
+    const createdMs = new Date(session.created_at).getTime();
+    if (Number.isNaN(createdMs) || createdMs < firstHourMs) continue;
+    const index = Math.min(Math.floor((createdMs - firstHourMs) / HOUR_MS), PULSE_HOURS - 1);
+    tallies[index][runGroup(session.status)] += 1;
+  }
+
+  return tallies.map((counts, index) => {
+    const total = SEVERITY.reduce((sum, group) => sum + counts[group], 0);
+    const worst = SEVERITY.find((group) => counts[group] > 0) ?? null;
+    return {
+      start: new Date(firstHourMs + index * HOUR_MS),
+      total,
+      worst,
+      counts,
+    };
+  });
+}
+
+/** Group tallies for a set of sessions (chip counts, pulse readout). */
+export function groupCounts(sessions: readonly Session[]): Record<RunGroup, number> {
+  const counts: Record<RunGroup, number> = {
+    live: 0,
+    attention: 0,
+    failed: 0,
+    completed: 0,
+    cancelled: 0,
+  };
+  for (const session of sessions) counts[runGroup(session.status)] += 1;
+  return counts;
+}
+
+export function filterSessions(
+  sessions: readonly Session[],
+  filter: ActivityFilter
+): Session[] {
+  if (filter === "all") return [...sessions];
+  return sessions.filter((session) => runGroup(session.status) === filter);
+}
+
+function startOfDayMs(date: Date): number {
+  const day = new Date(date);
+  day.setHours(0, 0, 0, 0);
+  return day.getTime();
+}
+
+const DAY_MS = 86_400_000;
+
+/** "today" / "yesterday" / "aug 12" — the chrome voice is lowercase. */
+export function dayLabel(iso: string, now: Date = new Date()): string {
+  const created = new Date(iso);
+  if (Number.isNaN(created.getTime())) return "earlier";
+  const daysAgo = Math.round((startOfDayMs(now) - startOfDayMs(created)) / DAY_MS);
+  if (daysAgo <= 0) return "today";
+  if (daysAgo === 1) return "yesterday";
+  return created
+    .toLocaleDateString(undefined, { month: "short", day: "numeric" })
+    .toLowerCase();
+}
+
+export interface TaskParts {
+  /** What the run is doing — the task with boilerplate context stripped. */
+  headline: string;
+  /** "owner/repo@sha1234" recovered from the boilerplate, when present. */
+  context: string | null;
+}
+
+// GitHub-event tasks are templated: "<what> of <owner>/<repo> at head <sha>."
+// followed by checkout/compare instructions. The suffix repeats on every row
+// of a busy timeline, so the table shows the <what> as the headline and
+// demotes repo@sha to the meta line (the full task lives on the run page).
+// The lookahead requires punctuation or end-of-string right after the sha, so
+// ordinary prose that merely contains "of … at head …" passes through whole.
+const GITHUB_TASK_TEMPLATE =
+  /^(.+?)\s+of\s+(\S+\/\S+)\s+at head\s+([0-9a-f]{7,40})(?=[.,;]|\s*$)/i;
+
+export function splitTask(task: string): TaskParts {
+  const match = GITHUB_TASK_TEMPLATE.exec(task);
+  if (!match) return { headline: task, context: null };
+  return { headline: match[1], context: `${match[2]}@${match[3].slice(0, 7)}` };
+}
+
+export interface DayGroup {
+  label: string;
+  sessions: Session[];
+}
+
+/** Partition an already-newest-first list into contiguous day groups. */
+export function groupByDay(sessions: readonly Session[], now: Date = new Date()): DayGroup[] {
+  const groups: DayGroup[] = [];
+  for (const session of sessions) {
+    const label = dayLabel(session.created_at, now);
+    const last = groups[groups.length - 1];
+    if (last && last.label === label) {
+      groups[groups.length - 1] = { label, sessions: [...last.sessions, session] };
+    } else {
+      groups.push({ label, sessions: [session] });
+    }
+  }
+  return groups;
+}

--- a/apps/web/app/lib/useSmartPolling.ts
+++ b/apps/web/app/lib/useSmartPolling.ts
@@ -9,6 +9,10 @@ import { useEffect, useRef } from "react";
  * and keeps doing work in background tabs. This loop schedules only after the
  * previous refresh settles, pauses while hidden, and refreshes immediately
  * when the user returns.
+ *
+ * The FIRST refresh runs even in a hidden tab: a page opened via cmd-click
+ * would otherwise sit on skeletons until focused. One fetch is not "keeping
+ * doing work" — only the recurring poll pauses while hidden.
  */
 export function useSmartPolling(
   refresh: () => void | Promise<void>,
@@ -26,16 +30,19 @@ export function useSmartPolling(
     let stopped = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let running = false;
+    let hasRefreshedOnce = false;
 
     const schedule = (delay: number) => {
       if (timer) clearTimeout(timer);
-      if (!stopped && document.visibilityState === "visible") {
+      if (!stopped && (!hasRefreshedOnce || document.visibilityState === "visible")) {
         timer = setTimeout(run, delay);
       }
     };
 
     const run = async () => {
-      if (stopped || running || document.visibilityState !== "visible") return;
+      if (stopped || running) return;
+      if (hasRefreshedOnce && document.visibilityState !== "visible") return;
+      hasRefreshedOnce = true;
       running = true;
       try {
         await refreshRef.current();


### PR DESCRIPTION
## What

A three-part UI overhaul of the dashboard, verified live in both themes at every step.

**Activity workbench (`/app/activity`)**
- **The pulse**: a 24-hour strip above the timeline — one bar per hour, height = volume, colour = the worst outcome that hour (failed > waiting > live > clean), with per-hour tooltips and a mono readout line. Live hours breathe; `prefers-reduced-motion` respected.
- **Run table**: real columns (run · agent · trigger · status · age) under a mono header, day dividers, status rails on the left edge, and whole-row links. `splitTask` folds the templated GitHub-event boilerplate (`of owner/repo at head <sha>. The PR is checked out…`) out of the headline into the meta line — guarded so hand-written tasks pass through untouched.
- Status filter chips with counts (all / live / waiting / failed / completed), filtered empty state.

**Warm kernel (every page)**
- Token-layer retune: deeper dark canvas, real `--panel-shadow`, `--canvas-glow`, radius 4/8 → 6/12, flood-filled primary buttons with a glow bloom, accent-tinted active nav, bigger page titles.
- Resources back to a 3-up tone-coloured card grid (glyph tiles, count chips, hover lift); duplicate standalone heading removed.

**Tables + whole-component clickability**
- Agents (`/app/agents`) is a table (agent · harness · model · network · revisions); the whole row expands into a revision-history sub-table.
- Automation rows and resource cards navigate from anywhere on the surface; inner buttons/links still win (`closest("button, a")` guard).
- `useSmartPolling` now runs its first refresh even in a hidden tab (cmd-clicked pages no longer sit on skeletons until focused).

## Test plan

- [x] `vitest run` — 255/255, including 14 new tests for `lib/activity.ts` (triage grouping, timezone-proof pulse bucketing, day partitioning, `splitTask` incl. the verbatim production task string) and the stylesheet contrast suite against the retuned tokens
- [x] `tsc --noEmit` clean; touched files ESLint-clean (the two `react-hooks/set-state-in-effect` errors in `agents/page.tsx` pre-date this PR — verified against HEAD)
- [x] `stylelint --max-warnings 10` — still exactly at the pre-existing 10-warning ratchet
- [x] Clicked through overview / activity / resources / agents / integrations live in dark + light; verified filter chips, agent expand, automation-row and resource-card navigation
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCQL9CvPs3LsM5xLQbT1yX