### PR TITLE
feat(core): add queued session status with capacity-park edges

### DIFF
--- a/crates/fluidbox-core/src/state.rs
+++ b/crates/fluidbox-core/src/state.rs
@@ -27,6 +27,14 @@ pub enum SessionStatus {
     /// No sandbox, no runner, no tokens — nothing to reap, and nothing that
     /// can spend. The approval TTL is its only reaper.
     AwaitingAuthorization,
+    /// Frozen, parked, and waiting for a capacity slot (run admission, design
+    /// 2026-08-23). No sandbox, no runner, no tokens — nothing to reap, and
+    /// nothing that can spend. The dispatcher admits it; the queue-age sweeper
+    /// is its only reaper. Deliberately its own variant rather than a reuse of
+    /// `awaiting_authorization`: the two parks COMPOSE (a run can need a human
+    /// authorization and *then* a capacity slot), and one variant cannot
+    /// express both.
+    Queued,
     Provisioning,
     Initializing,
     Running,
@@ -44,6 +52,7 @@ impl SessionStatus {
         match self {
             Self::Created => "created",
             Self::AwaitingAuthorization => "awaiting_authorization",
+            Self::Queued => "queued",
             Self::Provisioning => "provisioning",
             Self::Initializing => "initializing",
             Self::Running => "running",
@@ -61,6 +70,7 @@ impl SessionStatus {
         Some(match s {
             "created" => Self::Created,
             "awaiting_authorization" => Self::AwaitingAuthorization,
+            "queued" => Self::Queued,
             "provisioning" => Self::Provisioning,
             "initializing" => Self::Initializing,
             "running" => Self::Running,
@@ -107,6 +117,10 @@ impl SessionStatus {
             // Parked before provisioning: no runner exists to do work, and no
             // token has been minted that could ask for any.
             AwaitingAuthorization => false,
+            // Parked before provisioning for CAPACITY: same posture as the
+            // authorization park — no runner has been launched and no token
+            // minted, so there is nothing that could ask to do work.
+            Queued => false,
             Cancelling | Finalizing => false,
             Completed | Failed | Cancelled | BudgetExceeded => false,
         }
@@ -127,6 +141,21 @@ impl SessionStatus {
                 // never be skipped.
                 | (Created, AwaitingAuthorization)
                 | (AwaitingAuthorization, Provisioning)
+                // The pre-provisioning CAPACITY park (design 2026-08-23 §7).
+                // Authorization comes first and capacity second, so a run that
+                // waited days on a human does not also burn its queue-age
+                // budget while waiting. Like the authorization pause there is
+                // deliberately no `(Queued, Running)` / `(Queued,
+                // Initializing)` edge — a dispatched run provisions like any
+                // other, so init can never be skipped.
+                | (Created, Queued)
+                | (AwaitingAuthorization, Queued)
+                | (Queued, Provisioning)
+                // The one backward edge besides `AwaitingApproval → Running`:
+                // the substrate refused for capacity (a namespace quota 403),
+                // which means the run is healthy and the world is full, so it
+                // re-parks with backoff instead of failing (design §7.4).
+                | (Provisioning, Queued)
                 | (Provisioning, Initializing)
                 | (Initializing, Running)
                 | (Running, AwaitingApproval)
@@ -139,6 +168,7 @@ impl SessionStatus {
                 | (
                     Created
                         | AwaitingAuthorization
+                        | Queued
                         | Provisioning
                         | Initializing
                         | Running
@@ -163,9 +193,10 @@ impl SessionStatus {
 mod tests {
     use super::SessionStatus::{self, *};
 
-    const ACTIVE: [SessionStatus; 6] = [
+    const ACTIVE: [SessionStatus; 7] = [
         Created,
         AwaitingAuthorization,
+        Queued,
         Provisioning,
         Initializing,
         Running,
@@ -241,13 +272,14 @@ mod tests {
             assert!(!s.can_transition_to(AwaitingApproval));
         }
         // "Active" and "accepts work" were once the same set. They are not
-        // any more: `awaiting_authorization` is active (it is neither terminal
-        // nor winding down, so the sweepers and concurrency counters correctly
-        // treat it as a live run) yet accepts NO work, because it is parked
-        // before any sandbox or token exists. Everything else still coincides.
+        // any more: the two PRE-SANDBOX parks — `awaiting_authorization` and
+        // `queued` — are active (neither terminal nor winding down, so the
+        // sweepers and concurrency counters correctly treat them as live runs)
+        // yet accept NO work, because they are parked before any sandbox or
+        // token exists. Everything else still coincides.
         for s in ACTIVE {
-            if s == AwaitingAuthorization {
-                assert!(!s.accepts_work());
+            if matches!(s, AwaitingAuthorization | Queued) {
+                assert!(!s.accepts_work(), "{s:?} is parked pre-sandbox");
                 continue;
             }
             assert!(s.accepts_work());
@@ -270,6 +302,31 @@ mod tests {
         // A released grant provisions like any other run.
         assert!(Created.can_transition_to(AwaitingAuthorization));
         assert!(AwaitingAuthorization.can_transition_to(Provisioning));
+        // The capacity park is the same shape: dispatch provisions, it never
+        // jumps the init phase.
+        assert!(!Queued.can_transition_to(Running));
+        assert!(!Queued.can_transition_to(Initializing));
+    }
+
+    #[test]
+    fn queued_parks_before_provisioning() {
+        // The capacity park mirrors the authorization park: in, through, and out.
+        assert!(Created.can_transition_to(Queued));
+        assert!(AwaitingAuthorization.can_transition_to(Queued)); // authorization-then-capacity
+        assert!(Queued.can_transition_to(Provisioning));
+        // The ONE backward edge besides AwaitingApproval->Running: a provider
+        // CapacityDenied re-parks the run (design 2026-08-23 section 7.4).
+        assert!(Provisioning.can_transition_to(Queued));
+        // No other state may re-enter the queue.
+        assert!(!Running.can_transition_to(Queued));
+        assert!(!Initializing.can_transition_to(Queued));
+        // Parked = no sandbox, no tokens, no work.
+        assert!(!Queued.accepts_work());
+        assert!(!Queued.is_terminal());
+        assert!(!Queued.is_winding_down());
+        // It can always be wound down: cancel or the queue-age sweeper.
+        assert!(Queued.can_transition_to(Cancelling));
+        assert!(Queued.can_transition_to(Finalizing));
     }
 
     #[test]
@@ -290,6 +347,7 @@ mod tests {
         for s in [
             Created,
             AwaitingAuthorization,
+            Queued,
             Provisioning,
             Initializing,
             Running,

--- a/crates/fluidbox-db/src/mcp_sessions.rs
+++ b/crates/fluidbox-db/src/mcp_sessions.rs
@@ -287,6 +287,9 @@ mod tests {
             // see it — and it never has an upstream MCP session to retire
             // anyway, because no sandbox and no broker call exist yet.
             AwaitingAuthorization,
+            // The capacity park, same reasoning: pre-provisioning, not
+            // terminal, and no upstream MCP session can exist yet.
+            Queued,
             Provisioning,
             Initializing,
             Running,
@@ -302,6 +305,7 @@ mod tests {
             match s {
                 Created
                 | AwaitingAuthorization
+                | Queued
                 | Provisioning
                 | Initializing
                 | Running

--- a/crates/fluidbox-server/src/metrics.rs
+++ b/crates/fluidbox-server/src/metrics.rs
@@ -612,10 +612,15 @@ pub async fn metrics_endpoint(State(state): State<AppState>) -> impl IntoRespons
 
 /// Whether a session status counts as an in-flight run for [`Metrics::active_runs`]:
 /// a sandbox exists / capacity is held from `provisioning` through `finalizing`.
-/// `created` and `awaiting_authorization` are both PRE-SANDBOX — a run parked
-/// for network authorization holds no compute, and counting it would make the
-/// gauge report capacity that is not held. The four terminal states have
-/// released it.
+/// `created`, `awaiting_authorization` and `queued` are all PRE-SANDBOX — a run
+/// parked for network authorization or for a capacity slot holds no compute,
+/// and counting it would make the gauge report capacity that is not held. The
+/// four terminal states have released it.
+///
+/// Note this gauge is deliberately REPLICA-LOCAL and is not the admission
+/// authority: the dispatcher derives occupancy by counting session rows inside
+/// its serialized decision (design 2026-08-23 §7.2), because a per-replica
+/// gauge cannot see the other replicas' runs.
 pub fn status_is_active(status: fluidbox_core::state::SessionStatus) -> bool {
     use fluidbox_core::state::SessionStatus::*;
     matches!(
@@ -701,6 +706,18 @@ mod tests {
         // Sum reconciles the observed integer milliseconds.
         assert!(out.contains("h_sum 555"), "{out}");
         assert_eq!(h.count(), 3);
+    }
+
+    #[test]
+    fn queued_is_not_active_for_the_gauge() {
+        use SessionStatus::*;
+        // The capacity park holds no sandbox, so it sits OUTSIDE the active
+        // band — dispatch is the edge in, a capacity bounce is the edge out.
+        assert!(!status_is_active(Queued));
+        assert_eq!(active_delta(Queued, Provisioning), 1); // dispatch enters the band
+        assert_eq!(active_delta(Provisioning, Queued), -1); // a capacity bounce leaves it
+        assert_eq!(active_delta(Created, Queued), 0); // parking moves nothing
+        assert_eq!(active_delta(AwaitingAuthorization, Queued), 0); // park to park
     }
 
     #[test]


### PR DESCRIPTION
Plan Task 1 · design §6 · **Closes #152**

The epic's entry ticket: the `Queued` session status, its edges, and its classifications. Pure `fluidbox-core` + one metrics classification — nothing yet writes the status, so this is inert by construction.

## What landed

- **`SessionStatus::Queued`** between `AwaitingAuthorization` and `Provisioning`, with a doc comment mirroring the authorization park's. It is deliberately its own variant, not a reuse of `awaiting_authorization`: the two parks **compose** (a run can need a human authorization *and then* a capacity slot), and 0028's own doc comment records why status reuse hides transitive-edge bugs from the direct-edge tests.
- **Edges:** `(Created|AwaitingAuthorization) → Queued`, `Queued → Provisioning`, the CapacityDenied-only back-edge `Provisioning → Queued`, and `Queued` joins the any-active → `Cancelling|Finalizing` wind-down source set. Deliberately **no** `Queued → Running|Initializing`.
- **Classifications:** `accepts_work() = false`, `is_terminal()/is_winding_down() = false`, `ACTIVE` widened to 7, `roundtrip_strings` extended.
- **`metrics::status_is_active`** stays `false` for `Queued` — made deliberate via the doc comment plus a test pinning the band edges. Also notes that the replica-local gauge is *not* the admission authority (occupancy is derived in the dispatcher's serialized decision, design §7.2).

## Verified

| Check | Result |
|---|---|
| `cargo test -p fluidbox-core state::` | 10 passed |
| `cargo test -p fluidbox-core` (whole crate) | 176 passed, 0 failed |
| `cargo test -p fluidbox-server metrics::` | 7 passed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| Inert by default | no code path writes `"queued"` yet |

No DB needed for this ticket.

## Two things worth flagging for review

1. **A pre-existing test needed generalizing, not just extending.** `winding_down_refuses_new_work` special-cased `AwaitingAuthorization` as the single "active but accepts no work" state. With `Queued` in `ACTIVE` that set has two members, so the assertion is now `matches!(s, AwaitingAuthorization | Queued)` with the comment rewritten to describe the pre-sandbox park *class*. The alternative — a second `if` — would have made the third park a third special case.

2. **The workspace clippy sweep found one other exhaustive `SessionStatus` match**, as the ticket predicted: `fluidbox-db::mcp_sessions::all_statuses`, a deliberate compile-time guard for the MCP-session sweeper. `Queued` is classified there exactly as `AwaitingAuthorization` is beside it (pre-provisioning, not terminal, no upstream MCP session can exist yet).