### PR TITLE
feat(db): run-queue columns (0034), transition stamps, launch-anchored stale sweep

### DIFF
--- a/crates/fluidbox-db/src/lib.rs
+++ b/crates/fluidbox-db/src/lib.rs
@@ -764,6 +764,20 @@ pub struct SessionRow {
     pub last_heartbeat_at: Option<DateTime<Utc>>,
     pub started_at: Option<DateTime<Utc>>,
     pub finished_at: Option<DateTime<Utc>>,
+    /// First entry into `queued` (coalesce-stamped, like `started_at`). The
+    /// queue-age bound measures from here, never `created_at`, so a run that
+    /// spent days parked for a human authorization is not expired the moment
+    /// it becomes dispatchable (design 2026-08-23 §5).
+    pub queued_at: Option<DateTime<Utc>>,
+    /// First entry into `provisioning` — the stale-launch watchdog's age
+    /// anchor. `created_at` is refreshed by nothing, which is why the watchdog
+    /// used it; but a run may lawfully sit parked for days before launching,
+    /// so launch age needs its own timestamp (design §3.10).
+    pub launched_at: Option<DateTime<Utc>>,
+    /// Not-before gate for redispatch after a provider capacity bounce.
+    pub dispatch_after: Option<DateTime<Utc>>,
+    /// Dispatch attempts (the claim increments it); bounded by config.
+    pub dispatch_attempts: i32,
     /// Who invoked this run (design "tenant/user audit fields"): the invocation
     /// class, and the authenticated user id when one exists (None for
     /// operator-token / trigger / schedule / webhook). Drives run visibility.
@@ -4507,6 +4521,10 @@ pub async fn transition_session(
             updated_at = now(),
             started_at = case when $2 = 'running'
                               then coalesce(started_at, now()) else started_at end,
+            queued_at = case when $2 = 'queued'
+                             then coalesce(queued_at, now()) else queued_at end,
+            launched_at = case when $2 = 'provisioning'
+                               then coalesce(launched_at, now()) else launched_at end,
             finished_at = case when $2 in ('completed','failed','cancelled','budget_exceeded')
                                then now() else finished_at end
          where id = $1 and tenant_id = $4 returning *",
@@ -4570,6 +4588,10 @@ pub async fn transition_session_fenced(
             updated_at = now(),
             started_at = case when $2 = 'running'
                               then coalesce(started_at, now()) else started_at end,
+            queued_at = case when $2 = 'queued'
+                             then coalesce(queued_at, now()) else queued_at end,
+            launched_at = case when $2 = 'provisioning'
+                               then coalesce(launched_at, now()) else launched_at end,
             finished_at = case when $2 in ('completed','failed','cancelled','budget_exceeded')
                                then now() else finished_at end
          where id = $1 and tenant_id = $4 and orchestrator_epoch = $5 returning *",
@@ -15489,6 +15511,162 @@ mod tests {
             sqlx::query(stmt).bind(tenant).execute(&mut *tx).await.ok();
         }
         tx.commit().await.unwrap();
+    }
+
+    /// Migration 0034's queue timestamps ride the two transition functions the
+    /// way `started_at` always has. The `coalesce` is load-bearing: a
+    /// capacity-bounced run keeps its ORIGINAL `queued_at`, so the age bound
+    /// measures TOTAL time-in-queue across bounce cycles and the requeue loop
+    /// cannot be infinite even if the attempt cap were misconfigured.
+    #[tokio::test]
+    async fn queue_timestamps_stamp_once_and_survive_a_bounce() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let pool = test_connect(&url).await.expect("connect");
+        let (tenant, session) = seed_tenant_session(&pool).await;
+        let scope = TenantScope::assume(tenant);
+        use fluidbox_core::state::SessionStatus::*;
+
+        // created → queued stamps queued_at, and nothing else.
+        let (_, row) = transition_session(&pool, scope, session, Queued, Some("park"))
+            .await
+            .unwrap()
+            .unwrap();
+        let first_queued_at = row.queued_at.expect("queued_at stamped on first park");
+        assert!(row.launched_at.is_none());
+        assert!(row.started_at.is_none());
+
+        // queued → provisioning stamps launched_at (the watchdog's anchor).
+        let (_, row) = transition_session(&pool, scope, session, Provisioning, None)
+            .await
+            .unwrap()
+            .unwrap();
+        let first_launched_at = row
+            .launched_at
+            .expect("launched_at stamped on first launch");
+        assert_eq!(
+            row.queued_at,
+            Some(first_queued_at),
+            "queued_at is stamped once"
+        );
+
+        // provisioning → queued (a capacity bounce) keeps the ORIGINAL
+        // queued_at: the age bound is total time-in-queue.
+        let (_, row) = transition_session(&pool, scope, session, Queued, Some("bounce"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.queued_at, Some(first_queued_at));
+        assert_eq!(
+            row.dispatch_attempts, 0,
+            "the CLAIM increments attempts, not the transition"
+        );
+
+        // …and a redispatch keeps the original launched_at too.
+        let (_, row) = transition_session(&pool, scope, session, Provisioning, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.launched_at, Some(first_launched_at));
+
+        // The fenced sibling stamps identically — both transition functions
+        // carry the columns, or a fenced driver silently skips them.
+        let (tenant2, session2) = seed_tenant_session(&pool).await;
+        let scope2 = TenantScope::assume(tenant2);
+        let epoch = acquire_session_lease(&pool, scope2, session2, Uuid::now_v7(), 60)
+            .await
+            .unwrap()
+            .expect("fresh lease");
+        let (_, row) = transition_session_fenced(&pool, scope2, session2, Queued, None, epoch)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(row.queued_at.is_some(), "the fenced transition stamps too");
+        let (_, row) =
+            transition_session_fenced(&pool, scope2, session2, Provisioning, None, epoch)
+                .await
+                .unwrap()
+                .unwrap();
+        assert!(row.launched_at.is_some());
+
+        cleanup_sw_tenant(&pool, tenant).await;
+        cleanup_sw_tenant(&pool, tenant2).await;
+    }
+
+    /// Design §3.10 — a LIVE bug in the shipped network-grants feature, not a
+    /// queue-only concern. `stale_nonstarted_sessions` aged every pre-launch
+    /// status from `created_at`, but `awaiting_authorization` can lawfully park
+    /// a run for up to the approval TTL (7 days). A run authorized more than
+    /// FLUIDBOX_STALE_LAUNCH_MINS after creation re-entered `provisioning`
+    /// carrying an ancient `created_at`, and the next watchdog tick failed it as
+    /// "stalled before launch" moments after release. Queued runs inherit the
+    /// identical trap, so both are fixed by anchoring launch age to
+    /// `launched_at`.
+    #[tokio::test]
+    async fn stale_launch_sweep_uses_the_launch_anchor_not_created_at() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let pool = test_connect(&url).await.expect("connect");
+        let (tenant, session) = seed_tenant_session(&pool).await;
+        let scope = TenantScope::assume(tenant);
+        use fluidbox_core::state::SessionStatus::*;
+        transition_session(&pool, scope, session, Queued, None)
+            .await
+            .unwrap()
+            .unwrap();
+        transition_session(&pool, scope, session, Provisioning, None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // A run that waited two hours before dispatch: created_at is ancient,
+        // launched_at is fresh. It is launching normally RIGHT NOW.
+        sqlx::query("update sessions set created_at = now() - interval '2 hours' where id = $1")
+            .bind(session)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let stale = system_worker::stale_nonstarted_sessions(&pool, 30)
+            .await
+            .unwrap();
+        assert!(
+            !stale.iter().any(|s| s.id == session),
+            "a freshly-launched run must not read as stalled just because it waited"
+        );
+
+        // …but an actually-stalled launch (old launched_at) IS swept.
+        sqlx::query("update sessions set launched_at = now() - interval '2 hours' where id = $1")
+            .bind(session)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let stale = system_worker::stale_nonstarted_sessions(&pool, 30)
+            .await
+            .unwrap();
+        assert!(stale.iter().any(|s| s.id == session));
+
+        // And `created` keeps its own anchor: a row that never launched has no
+        // launched_at to measure, so created_at remains the only age it has.
+        let (tenant2, session2) = seed_tenant_session(&pool).await;
+        sqlx::query("update sessions set created_at = now() - interval '2 hours' where id = $1")
+            .bind(session2)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let stale = system_worker::stale_nonstarted_sessions(&pool, 30)
+            .await
+            .unwrap();
+        assert!(
+            stale.iter().any(|s| s.id == session2),
+            "an orphaned `created` row is still aged from created_at"
+        );
+
+        cleanup_sw_tenant(&pool, tenant).await;
+        cleanup_sw_tenant(&pool, tenant2).await;
     }
 
     /// Phase D (#32, #75) — RLS wave B, system_worker bypass. Proves (b) the

--- a/crates/fluidbox-db/src/system_worker.rs
+++ b/crates/fluidbox-db/src/system_worker.rs
@@ -281,10 +281,28 @@ pub async fn sessions_in_status(pool: &PgPool, statuses: &[&str]) -> sqlx::Resul
 /// for a big repo copy), so a stale row means the control plane died
 /// mid-launch and nothing owns the session anymore.
 ///
-/// Age is measured from `created_at` — a timestamp NOTHING refreshes. It used
-/// to be `updated_at`, which every runner heartbeat bumps: a crash between
-/// runner start and `set_sandbox_handle` left a heartbeating `initializing`
-/// session this sweep could never age out (M5).
+/// **The age anchor is SPLIT, and the split is a bug fix** (design 2026-08-23
+/// §3.10). Both halves measure from a timestamp NOTHING refreshes — never
+/// `updated_at`, which every runner heartbeat bumps, so a crash between runner
+/// start and `set_sandbox_handle` used to leave a heartbeating `initializing`
+/// session this sweep could never age out (M5). But `created_at` is only the
+/// right anchor for a row that never left `created`:
+///
+/// * `created` ages from `created_at` — it has no launch to measure.
+/// * `provisioning`/`initializing` age from `coalesce(launched_at, created_at)`
+///   — the moment the run actually STARTED launching. A session may lawfully
+///   sit parked for a long time first: `awaiting_authorization` holds for up to
+///   the approval TTL (7 days), and `queued` holds for the configured queue
+///   wait. Anchored to `created_at`, any run released more than
+///   `FLUIDBOX_STALE_LAUNCH_MINS` (default 30) after creation re-entered
+///   `provisioning` already "stale" and the very next watchdog tick failed it
+///   as "stalled before launch". That was live for network grants before
+///   migration 0034 added `launched_at`; the `coalesce` keeps pre-0034 rows
+///   behaving exactly as they did.
+///
+/// The parked statuses themselves are deliberately absent from both arms:
+/// `awaiting_authorization` is reaped by the approval TTL and `queued` by the
+/// queue-age sweeper, each of which knows the bound that actually applies.
 pub async fn stale_nonstarted_sessions(
     pool: &PgPool,
     max_age_mins: i32,
@@ -292,13 +310,12 @@ pub async fn stale_nonstarted_sessions(
     let mut tx = crate::worker_tx(pool).await?;
     let out = sqlx::query_as(
         "select * from sessions
-         where status = any($1) and created_at < now() - make_interval(mins => $2)",
+          where (status = 'created'
+                 and created_at < now() - make_interval(mins => $1))
+             or (status in ('provisioning','initializing')
+                 and coalesce(launched_at, created_at)
+                     < now() - make_interval(mins => $1))",
     )
-    .bind(vec![
-        "created".to_string(),
-        "provisioning".to_string(),
-        "initializing".to_string(),
-    ])
     .bind(max_age_mins)
     .fetch_all(&mut *tx)
     .await?;

--- a/migrations/0034_run_queue.sql
+++ b/migrations/0034_run_queue.sql
@@ -1,0 +1,44 @@
+-- Run admission & queueing (design 2026-08-23): the park-and-dispatch columns.
+--
+-- The queue IS the sessions table: a run's queue entry and its audit record are
+-- the same row, claimed via the 0021 orchestrator lease. No new table, so the
+-- 0018 RLS posture (ENABLE+FORCE, tenant policy, enumerated table-level grants)
+-- already covers everything here — the drift guard does not fire on column
+-- additions to an already-enumerated table.
+--
+-- ROLLOUT DISCIPLINE — deploy everywhere FIRST, then enable (the 0028 rule).
+-- `SessionStatus::parse` maps an unrecognized status to `Failed` at the
+-- transition sites, so a binary that predates `queued` reads a parked run as
+-- TERMINAL: it will not drive it and its API reports it failed. (The boot
+-- orphan sweep's STRICT parse deliberately leaves unknown statuses alone, so
+-- nothing is destroyed — the failure mode of a premature rollback is zombie
+-- queued rows, not lost state.) Roll the binary to every replica before setting
+-- FLUIDBOX_MAX_CONCURRENT_RUNS anywhere. The migration itself is additive and
+-- safe to apply early; with the env unset the columns are simply never written.
+
+alter table sessions
+    -- First entry into `queued` (coalesce-stamped like started_at). The age
+    -- bound (FLUIDBOX_QUEUE_MAX_WAIT_SECS) measures from here, NOT created_at,
+    -- so a run that spent days in awaiting_authorization is not expired the
+    -- moment it becomes dispatchable.
+    add column queued_at timestamptz,
+    -- First entry into `provisioning` (coalesce-stamped). The stale-launch
+    -- watchdog measures provisioning/initializing age from
+    -- coalesce(launched_at, created_at): fixes the latent 0028 bug where a run
+    -- released from a >30-minute authorization pause is killed by the watchdog
+    -- as "stalled before launch" (design §3.10), and gives queued runs the
+    -- same protection.
+    add column launched_at timestamptz,
+    -- Not-before gate for redispatch after a provider CapacityDenied bounce
+    -- (exponential backoff, floor 30s >= the lease TTL, cap 300s). NULL = no gate.
+    add column dispatch_after timestamptz,
+    -- Dispatch attempts (the claim increments it). Bounded by
+    -- FLUIDBOX_QUEUE_REQUEUE_MAX; exceeding it is a terminal, explained failure.
+    add column dispatch_attempts int not null default 0;
+
+-- The dispatch scan's hot path: oldest-first over ONLY the queued rows, so the
+-- audit-retained terminal mass (never pruned — sessions is the audit record)
+-- costs the dispatcher nothing.
+create index sessions_queued_dispatch
+    on sessions (created_at)
+    where status = 'queued';


### PR DESCRIPTION
Plan Task 2 · design §5 + §3.10 · **Closes #153** · depends on #152 (merged)

## What landed

**`migrations/0034_run_queue.sql`** — `queued_at`, `launched_at`, `dispatch_after` (all `timestamptz`), `dispatch_attempts int not null default 0`, and the partial index `sessions_queued_dispatch on sessions (created_at) where status = 'queued'`. Confirmed 0034 is still the next free number (`0033_atlassian_authv2_jira_scopes.sql` is the tail). The header carries the 0028-style ROLLOUT DISCIPLINE block verbatim. No new table, so invariant 5's RLS+policy+grant triple does not apply — `sessions` is already `ENABLE`+`FORCE`d and policied by 0018, its grants are table-level, and the 0018 drift guard does not fire on column additions to an already-enumerated table.

**Stamping in BOTH transition functions.** `queued_at` on `'queued'`, `launched_at` on `'provisioning'`, each `coalesce`d — the `started_at` pattern.

**Live-bug fix (design §3.10).** `stale_nonstarted_sessions` now splits its age anchor.

## Verified

| Check | Result |
|---|---|
| `cargo test -p fluidbox-db queue_timestamps` | pass (failed first — assertion, not SQL error, proving 0034 applied) |
| `cargo test -p fluidbox-db stale_launch_sweep` | pass (reproduced the live bug before fixing it) |
| `cargo test -p fluidbox-db` (whole crate) | **148 passed, 0 failed** |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

DB target was the local container Postgres (`127.0.0.1:5433/fluidbox_e2e`), verified before each run — never Neon, never via `just`.

## Three review notes

1. **The stamping had to land in both transition functions, and the test pins that.** `transition_session_fenced` is the path the *dispatcher* takes. If the stamp had gone into only the unfenced sibling, every dispatcher-driven transition would silently skip it and the age bound would read `NULL` forever — invisible to a test that only exercises the unfenced path. The test therefore seeds a second session, takes a real lease, and drives it through the fenced function.

2. **The stale-sweep fix is a deliberate behavior change with the queue feature OFF** — that is the point of the ticket (the epic calls it out as a bonus fix). Worth noting the blast radius is narrower than it looks: `coalesce(launched_at, created_at)` means **pre-0034 rows behave byte-identically to before**, because they carry no `launched_at`. Only rows that have since been stamped get the new anchor. The two parked statuses stay absent from both arms — `awaiting_authorization` is reaped by the approval TTL, `queued` by the queue-age sweeper (Task 6), each of which knows the bound that actually applies.

3. **`SessionRow` is serialized directly into `GET /v1/sessions/{id}` and the list endpoint** (`api.rs` returns `json!({ "session": session, ... })` with no projection struct), so the four new fields appear in those responses as `null`/`0`. That is additive and non-breaking, and it is the direction design §9 wants — it means Task 10 gets `queued_at` on the API for free and only has to add the computed `queue_position`. Flagging it because it is a visible API surface change that the ticket text does not spell out.