### PR TITLE
feat(db): serialized dispatch claim + capacity occupancy loaders

### DIFF
--- a/crates/fluidbox-db/src/lib.rs
+++ b/crates/fluidbox-db/src/lib.rs
@@ -4682,6 +4682,48 @@ pub async fn session_lease(
     Ok(row)
 }
 
+/// Gate a capacity-bounced run behind a not-before instant and RELEASE its
+/// driver lease (run admission, design 2026-08-23 §7.4).
+///
+/// Tenant-scoped, NOT a bypass: the caller is the orchestrator driving one
+/// known run, so it already holds a verified scope.
+///
+/// Two properties are deliberate:
+///
+/// * **The lease columns are cleared, the epoch is NOT bumped here.** Clearing
+///   the lease is what returns the row to the claim predicate; the next
+///   claimant is then a different owner, so the CLAIM's own
+///   `owner is distinct from` rule bumps the epoch. Bumping it here as well
+///   would fence the bounced driver twice for one handover and break the
+///   "epoch moves only on owner CHANGE" rule the whole fencing scheme rests on.
+/// * **`dispatch_after` is set AFTER the re-park transition, never with it.**
+///   A crash in between leaves a queued row with a live lease: it simply
+///   re-enters the claim pool when that lease expires, without a backoff gate.
+///   Bounded and harmless — the alternative (gate first, transition second)
+///   would gate a row that never re-parked.
+pub async fn set_dispatch_backoff(
+    pool: &PgPool,
+    scope: TenantScope,
+    id: Uuid,
+    not_before_secs: i64,
+) -> sqlx::Result<()> {
+    let mut tx = scoped_tx(pool, scope).await?;
+    sqlx::query(
+        "update sessions set
+            dispatch_after           = now() + make_interval(secs => $3),
+            orchestrator_owner_id    = null,
+            orchestrator_lease_until = null,
+            updated_at               = now()
+          where id = $1 and tenant_id = $2",
+    )
+    .bind(id)
+    .bind(scope.tenant_id())
+    .bind(not_before_secs.max(0) as f64)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await
+}
+
 /// Attach the sandbox handle — REFUSED (returns false) unless the session is
 /// still in an ACTIVE (pre-wind-down) state AND no finalization intent
 /// exists: the intent is the single source of truth for ownership, and it
@@ -15593,6 +15635,331 @@ mod tests {
 
         cleanup_sw_tenant(&pool, tenant).await;
         cleanup_sw_tenant(&pool, tenant2).await;
+    }
+
+    // ─── Dispatch-claim tests run against a DEDICATED database ──────────────
+    //
+    // Capacity occupancy is DEPLOYMENT-WIDE by design (design 2026-08-23 §7.2 —
+    // "the count IS the truth"), so `dispatch_claim` counts every tenant's rows.
+    // In the shared test database that makes a cap assertion an assertion about
+    // every OTHER test's rows: `seed_tenant_session` leaves a session in
+    // `created`, which the occupancy predicate counts as active, and a sibling's
+    // `queued` row is claimed ahead of mine because `order by created_at` is
+    // global too.
+    //
+    // The GLOBAL_SCAN cure above does not reach this: it narrows the RETURNED
+    // BATCH, and here the interference is in the COUNT and in the ORDER. So
+    // these tests get their own database — created once, migrated exactly as
+    // production migrates — and hold [`DISPATCH_SERIAL`] while they run. That
+    // is the same isolation posture the hermetic queue e2e uses, and it turns
+    // probabilistic assertions into deterministic ones.
+    static DISPATCH_DB: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();
+    static DISPATCH_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// Swap the database component of a Postgres URL, preserving any query
+    /// string (`?sslmode=…`). Used to reach the maintenance database on the
+    /// same server so the dedicated one can be created.
+    fn swap_db(url: &str, db: &str) -> String {
+        let (head, query) = match url.split_once('?') {
+            Some((h, q)) => (h, Some(q)),
+            None => (url, None),
+        };
+        let base = head.rsplit_once('/').map(|(b, _)| b).unwrap_or(head);
+        match query {
+            Some(q) => format!("{base}/{db}?{q}"),
+            None => format!("{base}/{db}"),
+        }
+    }
+
+    /// The dedicated database's URL, created on first use.
+    ///
+    /// This deliberately caches the URL and NOT a `PgPool`. A pool stored in a
+    /// `static` belongs to the `#[tokio::test]` runtime that built it — sqlx
+    /// spawns the pool's connection tasks there — so when that first test's
+    /// runtime is dropped the pool goes inert and every later borrower blocks
+    /// until `acquire_timeout` and fails `PoolTimedOut`. Sharing the DATABASE
+    /// and letting each test build its own pool costs one cheap no-op migration
+    /// check and is runtime-safe.
+    async fn dispatch_db_url(url: &str) -> String {
+        DISPATCH_DB
+            .get_or_init(|| async move {
+                let admin = PgPool::connect(&swap_db(url, "postgres"))
+                    .await
+                    .expect("connect to the maintenance database");
+                sqlx::query("drop database if exists fluidbox_dispatch_test")
+                    .execute(&admin)
+                    .await
+                    .ok();
+                sqlx::query("create database fluidbox_dispatch_test")
+                    .execute(&admin)
+                    .await
+                    .expect("create the dedicated dispatch database");
+                admin.close().await;
+                swap_db(url, "fluidbox_dispatch_test")
+            })
+            .await
+            .clone()
+    }
+
+    /// Seed `n` sessions already parked in `queued`, oldest first, each in its
+    /// own tenant — the queue is deployment-wide, so cross-tenant rows are
+    /// exactly what the dispatcher must handle.
+    async fn seed_queued(pool: &PgPool, n: usize) -> Vec<(Uuid, Uuid)> {
+        let mut out = Vec::new();
+        for _ in 0..n {
+            let (tenant, session) = seed_tenant_session(pool).await;
+            transition_session(
+                pool,
+                TenantScope::assume(tenant),
+                session,
+                fluidbox_core::state::SessionStatus::Queued,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            out.push((tenant, session));
+        }
+        out
+    }
+
+    /// A capacity cap of 1 admits exactly one run, and — the mutation guard for
+    /// design §7.3 — a CLAIMED row still sitting in `queued` counts as occupied
+    /// through its live lease. Drop the `filter (… orchestrator_lease_until …)`
+    /// clause from the occupancy query and the second pass double-admits, so
+    /// this test fails.
+    #[tokio::test]
+    async fn dispatch_claim_honors_cap_counting_leased_queued_as_occupied() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let _serial = DISPATCH_SERIAL.lock().await;
+        let pool = &test_connect(&dispatch_db_url(&url).await)
+            .await
+            .expect("connect to the dedicated dispatch database");
+        let seeded = seed_queued(pool, 3).await;
+
+        let owner = Uuid::now_v7();
+        let one = system_worker::dispatch_claim(pool, 1, 200, owner, 30)
+            .await
+            .unwrap()
+            .expect("the lock is free");
+        assert_eq!(one.claimed.len(), 1, "cap 1 admits exactly one");
+        assert_eq!(one.active, 0, "queued rows are not active until dispatched");
+        assert_eq!(
+            one.claimed[0].dispatch_attempts, 1,
+            "the claim increments attempts"
+        );
+        assert!(
+            one.claimed[0].queued_at.is_some(),
+            "the wait clock is carried"
+        );
+
+        // The claimed row is STILL status='queued' — run() is the single writer
+        // of queued → provisioning. Its live lease is what must make it count
+        // as occupied, or the next tick admits it a second time.
+        let two = system_worker::dispatch_claim(pool, 1, 200, owner, 30)
+            .await
+            .unwrap()
+            .expect("the lock is free");
+        assert_eq!(two.claimed.len(), 0, "leased-queued must count as occupied");
+        assert_eq!(two.leased_queued, 1);
+
+        // Expire the lease → the row returns to the pool (crash reclaim, §7.3),
+        // and it is the SAME row: a crashed claimant costs one redispatch, not
+        // a lost run.
+        sqlx::query(
+            "update sessions set orchestrator_lease_until = now() - interval '1 second'
+             where id = $1",
+        )
+        .bind(one.claimed[0].id)
+        .execute(pool)
+        .await
+        .unwrap();
+        let three = system_worker::dispatch_claim(pool, 1, 200, owner, 30)
+            .await
+            .unwrap()
+            .expect("the lock is free");
+        assert_eq!(three.claimed.len(), 1);
+        assert_eq!(three.claimed[0].id, one.claimed[0].id);
+        assert_eq!(three.claimed[0].dispatch_attempts, 2);
+
+        for (tenant, _) in seeded {
+            cleanup_sw_tenant(pool, tenant).await;
+        }
+        pool.close().await;
+    }
+
+    /// FIFO is `order by created_at`, the `dispatch_after` backoff gate hides a
+    /// bounced row until its not-before passes, and a batch never exceeds the
+    /// headroom.
+    #[tokio::test]
+    async fn dispatch_claim_is_fifo_and_respects_the_backoff_gate() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let _serial = DISPATCH_SERIAL.lock().await;
+        let pool = &test_connect(&dispatch_db_url(&url).await)
+            .await
+            .expect("connect to the dedicated dispatch database");
+        let seeded = seed_queued(pool, 3).await;
+        let ids: Vec<Uuid> = seeded.iter().map(|(_, s)| *s).collect();
+
+        // Gate the OLDEST row behind a future not-before: FIFO must skip it and
+        // keep walking rather than head-blocking the queue.
+        sqlx::query("update sessions set dispatch_after = now() + interval '1 hour' where id = $1")
+            .bind(ids[0])
+            .execute(pool)
+            .await
+            .unwrap();
+
+        let owner = Uuid::now_v7();
+        let out = system_worker::dispatch_claim(pool, 10, 200, owner, 30)
+            .await
+            .unwrap()
+            .expect("the lock is free");
+        let claimed: Vec<Uuid> = out.claimed.iter().map(|c| c.id).collect();
+        assert_eq!(
+            claimed,
+            vec![ids[1], ids[2]],
+            "oldest-first, and the backoff-gated row is skipped, not head-blocking"
+        );
+
+        // Headroom, not the batch size, is what bounds a claim: three rows are
+        // now leased-queued, so a cap of 3 leaves no room for the gated one even
+        // after its gate passes.
+        sqlx::query("update sessions set dispatch_after = null where id = $1")
+            .bind(ids[0])
+            .execute(pool)
+            .await
+            .unwrap();
+        let full = system_worker::dispatch_claim(pool, 2, 200, owner, 30)
+            .await
+            .unwrap()
+            .expect("the lock is free");
+        assert_eq!(full.claimed.len(), 0, "headroom is exhausted");
+        assert_eq!(full.leased_queued, 2);
+
+        for (tenant, _) in seeded {
+            cleanup_sw_tenant(pool, tenant).await;
+        }
+        pool.close().await;
+    }
+
+    /// A losing tick YIELDS rather than queueing behind the winner: the dispatch
+    /// decision is serialized with `pg_try_advisory_xact_lock`, so a replica
+    /// that loses simply re-polls in a second (design §7.2).
+    #[tokio::test]
+    async fn dispatch_claim_yields_when_another_connection_holds_the_lock() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let _serial = DISPATCH_SERIAL.lock().await;
+        let pool = &test_connect(&dispatch_db_url(&url).await)
+            .await
+            .expect("connect to the dedicated dispatch database");
+        let mut holder = pool.begin().await.unwrap();
+        let (locked,): (bool,) = sqlx::query_as("select pg_try_advisory_xact_lock($1)")
+            .bind(system_worker::DISPATCH_ADVISORY_KEY)
+            .fetch_one(&mut *holder)
+            .await
+            .unwrap();
+        assert!(locked);
+
+        let out = system_worker::dispatch_claim(pool, 10, 200, Uuid::now_v7(), 30)
+            .await
+            .unwrap();
+        assert!(
+            out.is_none(),
+            "a losing tick yields instead of queueing behind the winner"
+        );
+        holder.rollback().await.unwrap();
+
+        // …and the lock is released with the holder's transaction, so the very
+        // next tick proceeds.
+        assert!(
+            system_worker::dispatch_claim(pool, 10, 200, Uuid::now_v7(), 30)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        pool.close().await;
+    }
+
+    /// The queue-age sweep measures from `queued_at`, NOT `created_at` — a run
+    /// that spent days parked for a human authorization must not be expired the
+    /// moment it becomes dispatchable. Adoption refuses a row a live driver
+    /// owns.
+    #[tokio::test]
+    async fn queue_scans_use_queued_at_and_skip_live_leases() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let _serial = DISPATCH_SERIAL.lock().await;
+        let pool = &test_connect(&dispatch_db_url(&url).await)
+            .await
+            .expect("connect to the dedicated dispatch database");
+
+        let seeded = seed_queued(pool, 1).await;
+        let (tenant, session) = seeded[0];
+        assert_eq!(system_worker::count_queued_sessions(pool).await.unwrap(), 1);
+
+        // Ancient created_at, fresh queued_at: it has waited seconds, not days.
+        sqlx::query("update sessions set created_at = now() - interval '2 hours' where id = $1")
+            .bind(session)
+            .execute(pool)
+            .await
+            .unwrap();
+        let expired = system_worker::expired_queued_sessions(pool, 60, 100)
+            .await
+            .unwrap();
+        assert!(
+            !expired.iter().any(|s| s.id == session),
+            "the age bound measures from queued_at, not created_at"
+        );
+
+        sqlx::query("update sessions set queued_at = now() - interval '2 hours' where id = $1")
+            .bind(session)
+            .execute(pool)
+            .await
+            .unwrap();
+        let expired = system_worker::expired_queued_sessions(pool, 60, 100)
+            .await
+            .unwrap();
+        assert!(expired.iter().any(|s| s.id == session));
+
+        // Adoption: a `created` row orphaned before its park is adopted, but a
+        // row a live driver is holding is left alone.
+        let (t2, orphan) = seed_tenant_session(pool).await;
+        let (t3, driven) = seed_tenant_session(pool).await;
+        sqlx::query(
+            "update sessions set created_at = now() - interval '10 minutes' where id = any($1)",
+        )
+        .bind(vec![orphan, driven])
+        .execute(pool)
+        .await
+        .unwrap();
+        acquire_session_lease(pool, TenantScope::assume(t3), driven, Uuid::now_v7(), 300)
+            .await
+            .unwrap()
+            .expect("lease");
+        let orphans = system_worker::orphaned_created_sessions(pool, 120, 100)
+            .await
+            .unwrap();
+        assert!(orphans.iter().any(|s| s.id == orphan));
+        assert!(
+            !orphans.iter().any(|s| s.id == driven),
+            "a row a live driver owns is not an orphan"
+        );
+
+        for t in [tenant, t2, t3] {
+            cleanup_sw_tenant(pool, t).await;
+        }
+        pool.close().await;
     }
 
     /// Design §3.10 — a LIVE bug in the shipped network-grants feature, not a

--- a/crates/fluidbox-db/src/system_worker.rs
+++ b/crates/fluidbox-db/src/system_worker.rs
@@ -24,9 +24,21 @@
 //!     restart-recoverable finalize
 //!     driver, the managed-sandbox reconciler, and the delivery worker
 //!     ([`claim_due_deliveries`] — Phase E: the scan now STAMPS a per-row claim
-//!     under `for update skip locked` so replicas take disjoint sets) each act on
-//!     ids/status across ALL tenants by construction (a global scan), then scope
-//!     every mutation to the `tenant_id` of the row they just fetched.
+//!     under `for update skip locked` so replicas take disjoint sets), and the
+//!     capacity dispatcher's four ([`dispatch_claim`] — the SERIALIZED
+//!     admission decision: advisory try-lock, deployment-wide occupancy count,
+//!     and a lease-stamping `for update skip locked` claim in ONE transaction;
+//!     [`count_queued_sessions`] — the depth backstop the create path checks;
+//!     [`expired_queued_sessions`] — runs past the configured maximum wait;
+//!     [`orphaned_created_sessions`] — `created` rows nothing is driving, which
+//!     heals both the park crash window and the pre-existing orphan class) each
+//!     act on ids/status across ALL tenants by construction (a global scan),
+//!     then scope every mutation to the `tenant_id` of the row they just
+//!     fetched. The capacity queue is DEPLOYMENT-WIDE on purpose: a per-tenant
+//!     count could not answer "is the deployment at its cap", which is the only
+//!     question admission asks (design 2026-08-23, run admission section 7.2).
+//!     Per-tenant fairness is stage 2 and slots into the same claim query
+//!     without restructuring it.
 //!
 //! (b) **Credential-verification bootstrap resolvers for UNAUTHENTICATED
 //!     ingress/callbacks.** Webhook ingress (HMAC via [`get_connection`]),
@@ -731,6 +743,230 @@ pub async fn claim_due_deliveries(
     .bind(owner)
     .bind(limit)
     .bind(ttl_secs.max(1) as f64)
+    .fetch_all(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(out)
+}
+
+// ─── Run admission & queueing (design 2026-08-23 §7; category (a)) ─────────
+
+/// The single-purpose advisory key the dispatch decision serializes on
+/// ("fluidbxq" in ASCII). Nothing else takes it, and nothing takes it AFTER a
+/// `sessions` row lock — the dispatcher's order is advisory-lock → sessions
+/// rows, and it never touches approvals, execution claims, or LLM reservations
+/// — so it cannot participate in a cycle with the `approvals → sessions` or
+/// `sessions → claims/reservations` orders (invariant 7).
+///
+/// The other two advisory keys in this crate ([`crate::registration_lock_key`],
+/// [`crate::oauth_lock_key`]) are DERIVED from data (a sha256 prefix, a uuid
+/// prefix); this one is a constant, so it can only collide by an astronomically
+/// unlikely coincidence with one of those digests. A collision would cost a
+/// yielded tick, not a correctness failure.
+pub const DISPATCH_ADVISORY_KEY: i64 = 0x666c_7569_6462_7871;
+
+/// One run the dispatcher just claimed. `queued_at` feeds the wait histogram;
+/// `dispatch_attempts` is what the requeue path bounds against.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ClaimedRun {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub queued_at: Option<DateTime<Utc>>,
+    pub dispatch_attempts: i32,
+}
+
+/// What one dispatch tick decided. `active` and `leased_queued` are the
+/// occupancy the headroom was computed from — returned so the caller can log or
+/// gauge the decision it actually made rather than re-deriving it.
+#[derive(Debug, Clone)]
+pub struct DispatchOutcome {
+    pub active: i64,
+    pub leased_queued: i64,
+    pub claimed: Vec<ClaimedRun>,
+}
+
+/// ONE dispatch tick: serialize, count, admit — all inside a single
+/// transaction (design §7.2, §7.3).
+///
+/// `Ok(None)` means another replica holds the dispatch lock at this instant.
+/// The lock is a `try` variant on purpose: replicas never queue behind each
+/// other, a losing tick simply yields and re-polls, and the winner's work
+/// covers the deployment.
+///
+/// **Why an advisory lock here when [`crate::acquire_session_lease`]'s
+/// doc-comment rejects them.** That rejection is about session-LIFETIME leases:
+/// an advisory lock held for a run's life pins a pool connection, dies
+/// invisibly on reconnect or Neon scale-to-zero, and is unobservable. This is
+/// the other category — a transaction-scoped mutex held for single-digit
+/// milliseconds that self-releases at commit, the same category as the DCR
+/// singleflight lock this crate already ships.
+///
+/// **Why the count is derived rather than kept in a counter row.** A count
+/// taken from the very rows that hold the state cannot drift: there is no
+/// release bookkeeping to miss on any terminal path and no reconciliation
+/// sweeper to write. Occupancy only GROWS through this serialized section and
+/// only SHRINKS through terminal transitions, so a stale-high count
+/// under-admits for one tick (self-correcting) and a stale-low count is
+/// impossible. Overshoot past the cap is therefore structurally impossible; the
+/// cost is at most ~1 s of transient under-admission.
+///
+/// **The `leased_queued` filter is load-bearing.** A claimed row is still
+/// `status = 'queued'` — `run()` remains the single writer of
+/// `queued → provisioning` — so without counting live-leased queued rows as
+/// occupied, the very next tick would admit the same run again. A claimant that
+/// crashes leaves a leased row whose lease expires in `lease_ttl_secs`, at which
+/// point it re-enters the claim predicate: reclaim by machinery that already
+/// exists.
+///
+/// FIFO is `order by created_at`, which `for update skip locked` makes NEAR-FIFO
+/// (Postgres may reorder around contended rows). That is accepted and disclosed;
+/// strict FIFO is unobtainable from SKIP LOCKED and is not required.
+pub async fn dispatch_claim(
+    pool: &PgPool,
+    cap: i64,
+    batch: i64,
+    owner: Uuid,
+    lease_ttl_secs: i64,
+) -> sqlx::Result<Option<DispatchOutcome>> {
+    let mut tx = crate::worker_tx(pool).await?;
+
+    let (locked,): (bool,) = sqlx::query_as("select pg_try_advisory_xact_lock($1)")
+        .bind(DISPATCH_ADVISORY_KEY)
+        .fetch_one(&mut *tx)
+        .await?;
+    if !locked {
+        tx.commit().await?;
+        return Ok(None);
+    }
+
+    // `awaiting_authorization` holds no sandbox and is excluded; `cancelling`
+    // and `finalizing` still hold one until reaped and are conservatively
+    // included.
+    let (active, leased_queued): (i64, i64) = sqlx::query_as(
+        "select
+           count(*) filter (where status in
+               ('created','provisioning','initializing','running',
+                'awaiting_approval','cancelling','finalizing'))                as active,
+           count(*) filter (where status = 'queued'
+                and orchestrator_lease_until is not null
+                and orchestrator_lease_until >= now())                          as leased_queued
+         from sessions
+         where status in ('created','provisioning','initializing','running',
+                          'awaiting_approval','cancelling','finalizing','queued')",
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let headroom = cap - active - leased_queued;
+    if headroom <= 0 {
+        tx.commit().await?;
+        return Ok(Some(DispatchOutcome {
+            active,
+            leased_queued,
+            claimed: Vec::new(),
+        }));
+    }
+
+    // No status write: `run()` stays the single writer of queued →
+    // provisioning. It re-acquires this same lease as the same owner (no epoch
+    // bump) and then transitions under the fence.
+    let claimed: Vec<ClaimedRun> = sqlx::query_as(
+        "with picks as (
+             select id from sessions
+              where status = 'queued'
+                and (dispatch_after is null or dispatch_after <= now())
+                and (orchestrator_owner_id is null
+                     or orchestrator_lease_until is null
+                     or orchestrator_lease_until < now())
+              order by created_at
+              limit $1
+              for update skip locked
+         )
+         update sessions s set
+            orchestrator_owner_id    = $2,
+            orchestrator_lease_until = now() + make_interval(secs => $3),
+            orchestrator_epoch       = s.orchestrator_epoch
+                + case when s.orchestrator_owner_id is distinct from $2 then 1 else 0 end,
+            dispatch_attempts        = s.dispatch_attempts + 1,
+            updated_at               = now()
+          from picks
+         where s.id = picks.id
+         returning s.id, s.tenant_id, s.queued_at, s.dispatch_attempts",
+    )
+    .bind(headroom.min(batch))
+    .bind(owner)
+    .bind(lease_ttl_secs.max(1) as f64)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+    Ok(Some(DispatchOutcome {
+        active,
+        leased_queued,
+        claimed,
+    }))
+}
+
+/// Deployment-wide queue depth — the backstop the create path checks before
+/// accepting more work. Deliberately cross-tenant: the depth bound protects the
+/// deployment, not a tenant.
+pub async fn count_queued_sessions(pool: &PgPool) -> sqlx::Result<i64> {
+    let mut tx = crate::worker_tx(pool).await?;
+    let (n,): (i64,) = sqlx::query_as("select count(*) from sessions where status = 'queued'")
+        .fetch_one(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(n)
+}
+
+/// Runs that have waited longer than the configured maximum. The anchor is
+/// `queued_at`, never `created_at`: a run may lawfully have spent days in
+/// `awaiting_authorization` first, and the wait clock starts when it becomes
+/// dispatchable. Because `queued_at` is coalesce-stamped, the bound measures
+/// TOTAL time in queue across capacity bounces.
+pub async fn expired_queued_sessions(
+    pool: &PgPool,
+    max_wait_secs: i64,
+    limit: i64,
+) -> sqlx::Result<Vec<SessionRow>> {
+    let mut tx = crate::worker_tx(pool).await?;
+    let out = sqlx::query_as(
+        "select * from sessions
+          where status = 'queued'
+            and queued_at is not null
+            and queued_at < now() - make_interval(secs => $1)
+          order by queued_at
+          limit $2",
+    )
+    .bind(max_wait_secs.max(0) as f64)
+    .bind(limit)
+    .fetch_all(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(out)
+}
+
+/// `created` rows nothing is driving — the park crash window (a replica that
+/// died between the create commit and the post-commit park) and the
+/// pre-existing orphan class (a run whose replica died before it launched,
+/// today only swept to `failed` after 30 minutes). The live-lease predicate is
+/// what keeps this off rows a healthy `run()` is currently driving.
+pub async fn orphaned_created_sessions(
+    pool: &PgPool,
+    older_than_secs: i64,
+    limit: i64,
+) -> sqlx::Result<Vec<SessionRow>> {
+    let mut tx = crate::worker_tx(pool).await?;
+    let out = sqlx::query_as(
+        "select * from sessions
+          where status = 'created'
+            and created_at < now() - make_interval(secs => $1)
+            and (orchestrator_lease_until is null or orchestrator_lease_until < now())
+          order by created_at
+          limit $2",
+    )
+    .bind(older_than_secs.max(0) as f64)
+    .bind(limit)
     .fetch_all(&mut *tx)
     .await?;
     tx.commit().await?;


### PR DESCRIPTION
Plan Task 3 · design §7.2–§7.3 · **Closes #154** · depends on #152, #153 (both merged)

The heart of the mechanism: the dispatch decision serialized in Postgres, with occupancy derived from the rows that hold the state.

## What landed

**`system_worker::dispatch_claim`** — one `worker_tx` transaction doing all three steps, so the lock, the count and the claim share a snapshot:

1. `pg_try_advisory_xact_lock(DISPATCH_ADVISORY_KEY)` — `Ok(None)` on a miss. The **try** variant is the point: replicas never queue behind each other, a losing tick just re-polls in a second.
2. The occupancy pair, design §7.3 verbatim (`awaiting_authorization` excluded — it holds no sandbox; `cancelling`/`finalizing` conservatively included — they still do).
3. The claim CTE — River's shape, `for update skip locked`, stamping the 0021 lease with `acquire_session_lease`'s exact epoch rule, incrementing `dispatch_attempts`, `returning id, tenant_id, queued_at, dispatch_attempts`. **No status write:** `run()` stays the single writer of `queued → provisioning`.

Plus `count_queued_sessions`, `expired_queued_sessions` (anchored on `queued_at`), `orphaned_created_sessions` (live-lease-excluded), and the tenant-scoped `set_dispatch_backoff`. All four bypass-bearing loaders are in the module-doc inventory (invariant 6).

## Verified

| Check | Result |
|---|---|
| `cargo test -p fluidbox-db` | **152 passed, 0 failed** (incl. 4 new dispatch tests + doctests) |
| **Mutation test** of the occupancy `FILTER` | replacing it with `0::bigint` → `dispatch_claim_honors_cap…` FAILS with "leased-queued must count as occupied"; restored → green |
| `cargo test -p fluidbox-core` | 176 passed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| Inert by default | nothing calls any of this yet |

## Three review notes

### 1. The dispatch tests needed their own database — [raised on the ticket before implementing](https://github.com/hrishikeshdkakkad/fluidbox/issues/154#issuecomment-5389642627)

The plan's test does `dispatch_claim(&pool, 1, …)` and asserts one claim, which requires deployment-wide occupancy to be zero. It cannot be: occupancy is deployment-wide **by design** (§7.2, "the count IS the truth"), `seed_tenant_session` leaves a `created` row that the predicate counts as active, and the suite runs ~150 tests concurrently against one database.

The repo's existing cure (`GLOBAL_SCAN` + filter-my-rows-from-the-batch) does not reach this: **the interference is in the COUNT and in the ORDER, not in the returned rows.** A sibling's `created` row zeroes my headroom; a sibling's older `queued` row is claimed ahead of mine because `order by created_at` is global.

So the dispatch tests share a dedicated `fluidbox_dispatch_test` database, created once and migrated exactly as production migrates, with the tests serialized on a mutex. Same isolation posture the epic already sanctions for `scripts/e2e-queue.sh`. Every assertion the plan asked for survives — cap-1-admits-one, the leased-queued guard, lease-expiry reclaim, FIFO, the `dispatch_after` gate, the advisory-lock yield.

### 2. The `OnceCell` caches the database URL, not a `PgPool` — and that distinction was a real bug

First attempt cached the pool. Result: the first dispatch test passed and the other two failed `PoolTimedOut`. **A `PgPool` in a `static` belongs to the `#[tokio::test]` runtime that built it** — sqlx spawns its connection tasks there — so when that first test's runtime is dropped the pool goes inert. Server connections peaked at 35/100, so it was never exhaustion. Caching the URL and letting each test build its own pool costs one no-op migration check and is runtime-safe.

### 3. `set_dispatch_backoff` clears the lease but deliberately does not bump the epoch

Clearing the lease is what returns the row to the claim predicate. The next claimant is then a *different* owner, so the claim's own `owner is distinct from` rule bumps the epoch. Bumping here too would move the fencing token twice for one handover, breaking the "epoch moves only on owner CHANGE" rule the whole scheme rests on. The doc comment states this, and also states why `dispatch_after` is set *after* the re-park rather than with it (a crash in between costs an un-gated redispatch at lease expiry — bounded and harmless; the reverse order would gate a row that never re-parked).