### PR TITLE
feat(provider): typed CapacityDenied classification for quota and throttle rejections

### DIFF
--- a/crates/fluidbox-core/src/traits.rs
+++ b/crates/fluidbox-core/src/traits.rs
@@ -374,6 +374,23 @@ pub trait ExecutionProvider: Send + Sync {
 pub enum ProviderError {
     #[error("provider error: {0}")]
     Other(String),
+    /// The substrate refused for CAPACITY reasons (a namespace quota, an
+    /// apiserver throttle): the run is healthy, the world is full. Every
+    /// reference controller treats this as retryable pressure rather than a
+    /// workload failure, so the orchestrator re-parks the run with backoff
+    /// instead of failing it (run admission design 2026-08-23, section 7.4).
+    ///
+    /// Carries the VERBATIM substrate message: it rides `status_reason` into
+    /// the ledger's `StatusChanged` event, so an operator reading the timeline
+    /// sees the exact blocker ("exceeded quota: fluidbox-sandboxes, limited:
+    /// pods=20") rather than a paraphrase.
+    ///
+    /// Classification is deliberately NARROW — an RBAC 403 and an
+    /// admission-webhook 403 look similar and are NOT capacity; bouncing on
+    /// them would retry against a wall until the attempt cap. Everything a
+    /// provider does not positively recognize stays `Other`, i.e. terminal.
+    #[error("provider capacity denied: {0}")]
+    CapacityDenied(String),
 }
 
 // NOTE: there is deliberately no `Harness` trait. A harness is a runner

--- a/crates/fluidbox-provider-k8s/src/lib.rs
+++ b/crates/fluidbox-provider-k8s/src/lib.rs
@@ -270,6 +270,32 @@ fn map_err(e: impl std::fmt::Display) -> ProviderError {
     ProviderError::Other(e.to_string())
 }
 
+/// POD-CREATE-ONLY classification (design 2026-08-23 §7.4): tell capacity
+/// pressure apart from a real failure, so the orchestrator can re-park the run
+/// instead of failing it terminally.
+///
+/// A `ResourceQuota` rejection is a 403 whose `reason` is `Forbidden` and whose
+/// message contains "exceeded quota" — the same 403 shape RBAC and admission
+/// webhooks use, which is why the MESSAGE and not the code is what decides. An
+/// apiserver 429 is throttling and is retryable by definition. Everything else
+/// falls through to [`map_err`] and stays terminal: misreading an RBAC denial
+/// as capacity would bounce the run against a permission wall it can never get
+/// past until the attempt cap expires it.
+///
+/// Only the POD create is classified. The quota counts pods, so a Secret or
+/// NetworkPolicy create failing is a different problem and keeps the generic
+/// mapping.
+fn classify_create_err(e: kube::Error) -> ProviderError {
+    if let kube::Error::Api(ref ae) = e {
+        let quota =
+            ae.code == 403 && ae.reason == "Forbidden" && ae.message.contains("exceeded quota");
+        if quota || ae.code == 429 {
+            return ProviderError::CapacityDenied(ae.message.clone());
+        }
+    }
+    map_err(e)
+}
+
 /// Grace for `CreateContainerConfigError`: Pod-first/Secret-second means the
 /// kubelet reports it TRANSIENTLY between Pod creation and the Secret landing
 /// (~1 s in practice) — by design, not misconfiguration. Only a config error
@@ -480,7 +506,7 @@ impl ExecutionProvider for KubernetesProvider {
             .pods
             .create(&Default::default(), &pod)
             .await
-            .map_err(map_err)?;
+            .map_err(classify_create_err)?;
         let uid = created
             .metadata
             .uid
@@ -1023,6 +1049,81 @@ mod tests {
         ContainerState, ContainerStateRunning, ContainerStateTerminated, ContainerStateWaiting,
         ContainerStatus, PodStatus,
     };
+
+    /// The quota 403 is CAPACITY, the RBAC 403 is not, and an apiserver 429 is
+    /// throttling. Getting this wrong in either direction is expensive: a
+    /// misclassified RBAC failure would bounce forever behind a wall it can
+    /// never get past, and a misclassified quota rejection keeps today's
+    /// terminal failure — the headline problem the feature exists to fix.
+    #[test]
+    fn quota_403_and_apiserver_429_classify_as_capacity() {
+        // `kube::core::ErrorResponse` is a deprecated alias for `Status` in
+        // kube 4, whose `status` field is an enum and which carries two more
+        // fields. `..Default::default()` sets only what the classifier reads,
+        // so a future kube bump that adds a field cannot break this test.
+        let api = |code: u16, reason: &str, message: &str| {
+            kube::Error::Api(Box::new(kube::core::Status {
+                status: Some(kube::core::response::StatusSummary::Failure),
+                code,
+                message: message.into(),
+                reason: reason.into(),
+                ..Default::default()
+            }))
+        };
+
+        let quota = api(
+            403,
+            "Forbidden",
+            r#"pods "fbx-run-x" is forbidden: exceeded quota: fluidbox-sandboxes, requested: pods=1, used: pods=20, limited: pods=20"#,
+        );
+        assert!(matches!(
+            classify_create_err(quota),
+            ProviderError::CapacityDenied(_)
+        ));
+
+        let throttle = api(429, "TooManyRequests", "too many requests");
+        assert!(matches!(
+            classify_create_err(throttle),
+            ProviderError::CapacityDenied(_)
+        ));
+
+        // An RBAC 403 is NOT capacity — it must stay terminal, or the run
+        // bounces against a permission wall until the attempt cap.
+        let rbac = api(
+            403,
+            "Forbidden",
+            r#"pods is forbidden: User "system:serviceaccount:fluidbox:runner" cannot create resource "pods""#,
+        );
+        assert!(matches!(classify_create_err(rbac), ProviderError::Other(_)));
+
+        // Neither is an admission-webhook rejection, a 404, or a transport
+        // error: everything unrecognized stays on the terminal path.
+        let webhook = api(
+            403,
+            "Forbidden",
+            "admission webhook \"policy.example\" denied the request",
+        );
+        assert!(matches!(
+            classify_create_err(webhook),
+            ProviderError::Other(_)
+        ));
+        assert!(matches!(
+            classify_create_err(api(404, "NotFound", "namespaces \"fluidbox\" not found")),
+            ProviderError::Other(_)
+        ));
+
+        // The verbatim substrate message rides the variant — it is what the
+        // ledger's status_reason shows the operator (the Kueue practice of
+        // preserving the exact blocker).
+        let ProviderError::CapacityDenied(detail) = classify_create_err(api(
+            403,
+            "Forbidden",
+            "exceeded quota: fluidbox-sandboxes, limited: pods=20",
+        )) else {
+            panic!("expected CapacityDenied");
+        };
+        assert!(detail.contains("fluidbox-sandboxes"));
+    }
 
     fn pod_with(runner: Option<ContainerState>, inits: Vec<ContainerStatus>) -> Pod {
         Pod {


### PR DESCRIPTION
Plan Task 4 · design §7.4 · **Closes #155** · no dependencies (parallel lane)

Turns the Kubernetes quota 403 from a terminal run failure into a typed, retryable capacity signal. Inert until #158 matches on it.

## What landed

- **`ProviderError::CapacityDenied(String)`** carrying the *verbatim* substrate message — it rides `status_reason` into the ledger's `StatusChanged` event, so the operator sees the exact blocker (the Kueue practice of preserving the blocker text).
- **`classify_create_err`** in `fluidbox-provider-k8s`, wired onto the **pod create only**. Quota 403 (`reason == "Forbidden"` **and** message contains `"exceeded quota"`) or code 429 ⇒ `CapacityDenied`; everything else falls through to the existing `map_err` and stays terminal.

## Verified

| Check | Result |
|---|---|
| `cargo test -p fluidbox-provider-k8s` | **57 passed, 0 failed** |
| `cargo check --workspace --all-targets` | clean — no exhaustive `ProviderError` match anywhere, so the variant is purely additive |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

## Review notes

### 1. The classification is narrow on purpose, and the test pins the negatives

A ResourceQuota rejection, an RBAC denial and an admission-webhook rejection are **all** 403 with `reason: "Forbidden"`. Only the message distinguishes them, which is why the message and not the status code is what decides. Getting this wrong is expensive in both directions:

- Too broad → an RBAC failure bounces against a permission wall it can never get past, burning the full attempt budget and delaying the real error by ~13 minutes of backoff.
- Too narrow → the quota 403 stays terminal, which is the headline problem the epic exists to fix.

So the test asserts four cases, not two: quota 403 ⇒ capacity, 429 ⇒ capacity, RBAC 403 ⇒ **terminal**, admission-webhook 403 ⇒ **terminal** (plus a 404). It also asserts the quota text survives into the variant.

### 2. Pod-create only

The quota counts *pods*. A Secret or NetworkPolicy create failing is a different problem, so those keep the generic mapping — matching the plan's instruction exactly.

### 3. Plan drift, [raised on the ticket first](https://github.com/hrishikeshdkakkad/fluidbox/issues/155#issuecomment-5389708346)

The plan's test literal is the kube 0.x `ErrorResponse` shape. This repo pins **kube 4**, where `ErrorResponse` is a deprecated alias for `kube::core::Status` — `status` is an `Option<StatusSummary>` enum rather than a string, there are two additional fields, and `Error::Api` wraps it in a `Box`. The test now builds it through a small helper with `..Default::default()`, so only the three fields the classifier reads are set and a future kube bump that adds a field cannot break it.

### 4. Disclosed residual: Docker maps nothing

Local capacity exhaustion has no clean signal, so the Docker provider's failures stay `Other` and terminal — unchanged from today, and explicitly the design's stage-1 position (§7.4).