### PR TITLE
feat(server): capacity dispatcher + park-at-admission (inert unless configured)

### DIFF
--- a/crates/fluidbox-server/src/config.rs
+++ b/crates/fluidbox-server/src/config.rs
@@ -212,6 +212,15 @@ fn resolve_queue_cfg(
     }))
 }
 
+impl Config {
+    /// True iff run admission is configured — the single predicate every call
+    /// site branches on, so "is the queue on" is asked exactly one way and a
+    /// future knob cannot make two sites disagree about it.
+    pub fn queueing_enabled(&self) -> bool {
+        self.queue.is_some()
+    }
+}
+
 /// Read `FLUIDBOX_WORKLOAD_IDENTITY`. Split out (rather than inlined in
 /// [`Config::from_env`]) so the failure message is testable without an env var,
 /// and so the source guard below can prove `from_env` passes the SAME name it

--- a/crates/fluidbox-server/src/dispatcher.rs
+++ b/crates/fluidbox-server/src/dispatcher.rs
@@ -1,0 +1,206 @@
+//! Capacity dispatcher (design 2026-08-23 §7): the state-driven admission
+//! worker.
+//!
+//! One per replica, and there is deliberately no leader election. The dispatch
+//! DECISION is serialized in Postgres — an advisory try-lock taken inside
+//! [`fluidbox_db::system_worker::dispatch_claim`], with occupancy derived from
+//! the session rows inside that same section — so replicas cannot double-admit
+//! and a losing tick simply re-polls. That is what lets every replica run the
+//! identical loop with no coordination protocol of our own.
+//!
+//! Poll-only at 1 s by design. A `fluidbox_dispatch` NOTIFY channel is a NAMED
+//! omission (design §13): each `PgListener` is a permanent extra connection per
+//! replica, and a ≤1 s admission delay is invisible next to provisioning
+//! latency. It becomes worth building when a latency requirement names it.
+//!
+//! The whole module is inert unless `FLUIDBOX_MAX_CONCURRENT_RUNS` is set —
+//! [`spawn`] returns without starting anything.
+
+use crate::state::AppState;
+use fluidbox_core::state::SessionStatus;
+use fluidbox_db::TenantScope;
+use std::time::Duration;
+
+/// Ticks between sweep passes (age expiry + orphan adoption): ~15 s at a 1 s
+/// tick. The sweeps are backstops for bounded-rate events, not hot paths, and
+/// running them every tick would put two extra scans per second on the database
+/// to catch conditions that change on the scale of minutes.
+const SWEEP_EVERY_TICKS: u64 = 15;
+
+/// A `created` row this old with no live lease was orphaned between the
+/// create-commit and the park transition (or predates the feature being
+/// enabled). Comfortably longer than any healthy create-to-park gap, which is
+/// two statements; the live-lease predicate is what actually keeps this off
+/// rows a running `run()` is driving, so the age is a second belt.
+const ADOPT_CREATED_AFTER_SECS: i64 = 120;
+
+pub fn spawn(state: AppState) {
+    if state.cfg.queue.is_none() {
+        return; // inert by default
+    }
+    tokio::spawn(dispatch_loop(state));
+}
+
+async fn dispatch_loop(state: AppState) {
+    let q = state
+        .cfg
+        .queue
+        .clone()
+        .expect("spawn() gates on queue being configured");
+    let mut tick = crate::workers::periodic(Duration::from_secs(1));
+    let mut n: u64 = 0;
+    loop {
+        tick.tick().await;
+        n = n.wrapping_add(1);
+        match fluidbox_db::system_worker::dispatch_claim(
+            &state.pool,
+            q.max_concurrent_runs,
+            crate::workers::SWEEP_BATCH,
+            crate::orchestrator::replica_id(),
+            crate::orchestrator::SESSION_LEASE_TTL_SECS,
+        )
+        .await
+        {
+            Ok(Some(out)) => {
+                for run in out.claimed {
+                    // Observed at the CLAIM, which is the moment the wait
+                    // actually ends — not at `running`, which would fold
+                    // provisioning latency into the queue's number.
+                    if let Some(t) = run.queued_at {
+                        let waited = (chrono::Utc::now() - t).num_milliseconds().max(0);
+                        state
+                            .metrics
+                            .queue_wait_seconds
+                            .observe(waited as f64 / 1000.0);
+                    }
+                    state.metrics.queue_dispatched.inc();
+                    crate::orchestrator::spawn_run(state.clone(), run.id);
+                }
+            }
+            // Another replica holds the dispatch lock this instant; its work
+            // covers the deployment and this tick has nothing to add.
+            Ok(None) => {}
+            Err(e) => tracing::warn!("dispatch tick failed: {e}"),
+        }
+        if n.is_multiple_of(SWEEP_EVERY_TICKS) {
+            sweep(&state, &q).await;
+        }
+    }
+}
+
+/// Age expiry + orphan adoption (design §7.6).
+///
+/// Both arms are safe to run on every replica concurrently: `fail` is the
+/// idempotent request-side intent (deliberately UNFENCED — a run that has
+/// waited too long must be resolvable regardless of which replica holds the
+/// driver lease), and the adoption transition is CAS-guarded by
+/// `can_transition_to`, so a row that left `created` meanwhile is simply
+/// refused.
+async fn sweep(state: &AppState, q: &crate::config::QueueCfg) {
+    match fluidbox_db::system_worker::expired_queued_sessions(
+        &state.pool,
+        q.max_wait_secs,
+        crate::workers::SWEEP_BATCH,
+    )
+    .await
+    {
+        Ok(expired) => {
+            for s in expired {
+                tracing::warn!(
+                    "queue: {} waited longer than {}s — failing",
+                    s.id,
+                    q.max_wait_secs
+                );
+                state.metrics.queue_shed.inc("age");
+                // A DbError start is retried by the next sweep.
+                let _ = crate::orchestrator::fail(
+                    state,
+                    s.id,
+                    "queued for longer than the configured maximum wait \
+                     (FLUIDBOX_QUEUE_MAX_WAIT_SECS)",
+                )
+                .await;
+            }
+        }
+        Err(e) => tracing::warn!("queue expiry scan failed: {e}"),
+    }
+
+    match fluidbox_db::system_worker::orphaned_created_sessions(
+        &state.pool,
+        ADOPT_CREATED_AFTER_SECS,
+        crate::workers::SWEEP_BATCH,
+    )
+    .await
+    {
+        Ok(orphans) => {
+            for s in orphans {
+                let scope = TenantScope::assume(s.tenant_id);
+                crate::orchestrator::transition(
+                    state,
+                    scope,
+                    s.id,
+                    SessionStatus::Queued,
+                    Some("adopted by the dispatcher (orphaned before park)"),
+                )
+                .await;
+            }
+        }
+        Err(e) => tracing::warn!("orphan adoption scan failed: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The Gap-13 periodic-worker rule, applied to this module — the same
+    /// property `workers.rs`'s own source guard asserts for the watchdog,
+    /// budget sweeper and approval expiry: a worker that runs on EVERY replica
+    /// must not perform a side effect itself, because it would fire N times.
+    ///
+    /// The sweep arms obey it directly: `fail` is the single-winner intent
+    /// (`begin_finalization`'s `on conflict do nothing`) and the adoption
+    /// transition is a CAS the state machine refuses if the row moved.
+    ///
+    /// The dispatch arm is the interesting case, because it DOES cause a
+    /// provision — via `spawn_run`. It is safe for a different reason: the run
+    /// was CLAIMED inside `dispatch_claim`'s serialized section, which stamped
+    /// this replica's lease on the row, so exactly one replica can reach
+    /// `spawn_run` for a given run. This test pins that coupling — a future
+    /// edit that spawns something the claim did not return would reintroduce
+    /// the N-replicas problem the whole serialized decision exists to prevent.
+    ///
+    /// A source guard, so it needs no database. The needles are split with
+    /// `concat!` so this test's own text is not what it counts.
+    #[test]
+    fn the_dispatcher_only_spawns_what_it_claimed() {
+        let src = include_str!("dispatcher.rs");
+
+        for mutation in [
+            concat!(".provider.", "terminate("),
+            concat!(".provider.", "provision("),
+            concat!(".provider.", "collect_artifacts("),
+        ] {
+            assert!(
+                !src.contains(mutation),
+                "the dispatcher must not call {mutation} — it runs on every replica. \
+                 Claim the run and let the lease-holding driver act."
+            );
+        }
+
+        let spawn = concat!("spawn_", "run(");
+        assert_eq!(
+            src.matches(spawn).count(),
+            1,
+            "exactly one spawn site, and it must be the claimed one"
+        );
+        let claim = concat!("dispatch_", "claim(");
+        assert!(
+            src.find(claim).expect("the claim is what feeds the spawn")
+                < src.find(spawn).expect("the spawn exists"),
+            "the spawn must be fed by the claim, not issued beside it"
+        );
+
+        // The expiry arm records an INTENT; it never terminalises a session
+        // itself and never touches a sandbox.
+        assert!(src.contains(concat!("orchestrator::", "fail(")));
+    }
+}

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod connections;
 mod connectors;
 mod deliveries;
+mod dispatcher;
 mod egress;
 mod error;
 mod events;

--- a/crates/fluidbox-server/src/metrics.rs
+++ b/crates/fluidbox-server/src/metrics.rs
@@ -245,6 +245,13 @@ const PROVISION_LATENCY_MS: &[f64] = &[
     100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0, 60000.0, 120000.0,
 ];
 
+/// Queue-wait buckets, SECONDS. The interesting range is set by what the
+/// operator can act on: sub-5 s means the queue is effectively absent, the
+/// minutes band is a healthy backlog draining, and the top bucket brackets the
+/// 3600 s default age bound so "runs are being expired" is visible as mass
+/// piling into the last bucket rather than as a separate signal.
+const QUEUE_WAIT_SECS: &[f64] = &[1.0, 5.0, 15.0, 60.0, 300.0, 900.0, 1800.0, 3600.0, 7200.0];
+
 /// The process-wide metrics registry. One instance lives on [`crate::state::AppStateInner`].
 ///
 /// Fields are grouped by the design's §Operational-metrics bullets. Each is fed
@@ -305,6 +312,19 @@ pub struct Metrics {
     /// In-flight runs (provisioning..finalizing). Replica-local; resets on restart.
     pub active_runs: Gauge,
     pub run_provisioning_ms: Histogram,
+    // ── Run admission (design 2026-08-23 §13). Fixed cardinality, like the
+    // grant families above: no tenant label — per-tenant attribution is the
+    // ledger's job, and the deployment-wide queue is what these answer for.
+    /// Runs admitted by the dispatcher. Counts ADMISSIONS, not runs: a
+    /// capacity-bounced run that is redispatched increments this again, which
+    /// is what makes `dispatched - terminal` readable against the requeue
+    /// counter.
+    pub queue_dispatched: Counter,
+    /// Work refused rather than queued. `depth` = the create-time bound,
+    /// `age` = the queue-age sweeper.
+    pub queue_shed: Family,
+    /// Time from first enqueue to admission, observed at the claim.
+    pub queue_wait_seconds: Histogram,
     // ── Durability (design: database event and ledger write rates).
     pub ledger_events: Counter,
     /// Metrics-scrape failures (a live read — pool count etc. — that errored).
@@ -409,6 +429,13 @@ impl Default for Metrics {
                 "fluidbox_run_provisioning_latency_ms",
                 PROVISION_LATENCY_MS,
             ),
+            queue_dispatched: Counter::default(),
+            queue_shed: Family::new(
+                "fluidbox_queue_shed_total",
+                "reason",
+                &["depth", "age", "requeue_exhausted"],
+            ),
+            queue_wait_seconds: Histogram::new("fluidbox_queue_wait_seconds", QUEUE_WAIT_SECS),
             ledger_events: Counter::default(),
             scrape_errors: Counter::default(),
         }
@@ -510,6 +537,17 @@ pub fn render(m: &Metrics, live: &Live) -> String {
         &mut out,
         "Run provisioning latency (created to running), milliseconds.",
     );
+
+    counter(
+        &mut out,
+        "fluidbox_runs_dispatched_total",
+        "Runs admitted from the capacity queue (a redispatched bounce counts again).",
+        m.queue_dispatched.get(),
+    );
+    m.queue_shed
+        .render(&mut out, "Work refused rather than queued, by reason.");
+    m.queue_wait_seconds
+        .render(&mut out, "Time from first enqueue to admission, seconds.");
 
     counter(
         &mut out,

--- a/crates/fluidbox-server/src/netgrant.rs
+++ b/crates/fluidbox-server/src/netgrant.rs
@@ -401,7 +401,29 @@ pub async fn release_authorized_grant(state: &AppState, scope: TenantScope, sess
         // active.
         Ok(Some(_)) => {
             state.metrics.network_grants.inc("active");
-            crate::orchestrator::spawn_run(state.clone(), session_id);
+            if state.cfg.queueing_enabled() {
+                // Authorization first, capacity second (design 2026-08-23
+                // §4.3): the released run takes a queue slot like any other.
+                // The alternative — letting an authorized run jump the queue —
+                // would make the cap waivable by grant type and produce real
+                // overshoot. The human latency has already been absorbed, and
+                // the wait clock (`queued_at`) only starts here, so nothing
+                // that waited on a person is charged for that wait.
+                //
+                // `run()`'s own grant gate still re-verifies authority at
+                // provision time however long the queue wait was — that check
+                // is deliberately independent of how the session got there.
+                crate::orchestrator::transition(
+                    state,
+                    scope,
+                    session_id,
+                    fluidbox_core::state::SessionStatus::Queued,
+                    Some("network grant authorized; waiting for a capacity slot"),
+                )
+                .await;
+            } else {
+                crate::orchestrator::spawn_run(state.clone(), session_id);
+            }
         }
         // Another replica won, or the grant is no longer pending.
         Ok(None) => {}

--- a/crates/fluidbox-server/src/orchestrator.rs
+++ b/crates/fluidbox-server/src/orchestrator.rs
@@ -85,7 +85,7 @@ const COLLECT_TIMEOUT: Duration = Duration::from_secs(120);
 /// the TTL shortens the stall but raises the risk of stealing a session from a
 /// slow-but-live driver; releasing the lease at the end of `run()` is the real
 /// fix and is not built.
-const SESSION_LEASE_TTL_SECS: i64 = 30;
+pub(crate) const SESSION_LEASE_TTL_SECS: i64 = 30;
 
 /// This replica's identity, minted ONCE per process (Phase E, #33; Gap 13).
 ///
@@ -150,7 +150,7 @@ pub fn spawn_run(state: AppState, session_id: Uuid) {
     });
 }
 
-async fn transition(
+pub(crate) async fn transition(
     state: &AppState,
     scope: TenantScope,
     id: Uuid,
@@ -1239,7 +1239,12 @@ async fn run(state: AppState, session_id: Uuid) -> anyhow::Result<()> {
         anyhow::bail!("another replica owns this session's orchestrator lease");
     };
 
-    // created → provisioning
+    // → provisioning, from wherever the session lawfully sits. There are three
+    // lawful predecessors now — `created` (direct spawn), `awaiting_authorization`
+    // (a released network grant), and `queued` (dispatched by the capacity
+    // worker) — and this stays ONE writer of the edge because
+    // `transition_fenced` reads the current status under the same `for update`
+    // lock that guards the epoch and lets `can_transition_to` decide.
     if !transition_fenced(
         &state,
         scope,

--- a/crates/fluidbox-server/src/run_service.rs
+++ b/crates/fluidbox-server/src/run_service.rs
@@ -21,6 +21,7 @@ use fluidbox_core::spec::{
     Autonomy, Budgets, InvocationContext, InvocationKind, ResultDestination, RunSpec, TrustTier,
     WorkspaceSpec,
 };
+use fluidbox_core::state::SessionStatus;
 use fluidbox_db::TenantScope;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -603,7 +604,35 @@ pub async fn create_run(
         return Ok(RunCreation::Created(Box::new(parked)));
     }
 
-    // ── Tail 1 — FREEZE AND SPAWN ────────────────────────────────────────
+    // ── Tail 1 — FREEZE, THEN PARK OR SPAWN ──────────────────────────────
+    //
+    // Queueing enabled: EVERY run parks and the dispatcher admits it (design
+    // 2026-08-23 §7.1). The uniform path is deliberate — the rejected
+    // fast-path-when-under-cap alternative (§15) buys ≤1 s of latency and
+    // costs a create-time headroom check that genuinely races, a second launch
+    // path to test, and the orphan class surviving on that path.
+    //
+    // The park is POST-COMMIT, exactly like the network-grant park above, so
+    // the `create_session` transaction stays byte-for-byte untouched
+    // (invariant 3) and its exactly-once claim semantics are unaffected. The
+    // crash window that opens — a replica dying between the commit and this
+    // transition — is the same one the netgrant park already accepts, and
+    // unlike netgrant it is HEALED: the dispatcher's adoption arm converts
+    // stale `created` rows to `queued`.
+    if state.cfg.queueing_enabled() {
+        orchestrator::transition(
+            state,
+            scope,
+            session.id,
+            SessionStatus::Queued,
+            Some("parked at admission: waiting for a capacity slot"),
+        )
+        .await;
+        let parked = fluidbox_db::get_session(&state.pool, scope, session.id)
+            .await?
+            .unwrap_or(session);
+        return Ok(RunCreation::Created(Box::new(parked)));
+    }
     orchestrator::spawn_run(state.clone(), session.id);
 
     Ok(RunCreation::Created(Box::new(session)))

--- a/crates/fluidbox-server/src/workers.rs
+++ b/crates/fluidbox-server/src/workers.rs
@@ -13,7 +13,7 @@ use tokio::time::MissedTickBehavior;
 /// How many rows one tick of a periodic sweep may take. Each swept row costs at
 /// least one SERIAL follow-up write (a ledger append), so the batch — not the
 /// backlog — is what a tick's duration is sized against.
-const SWEEP_BATCH: i64 = 200;
+pub(crate) const SWEEP_BATCH: i64 = 200;
 
 /// How long after a run goes TERMINAL the deployment-wide GC may retire its
 /// leftover `mcp_upstream_sessions` rows (Phase F, Task 3).
@@ -39,7 +39,7 @@ const MCP_SESSION_GRACE_SECS: i64 = 900;
 /// "whatever is due NOW" — never work bound to a wall-clock slot — so nothing is
 /// lost by re-phasing, and `Skip` (which preserves the original phase) can still
 /// leave a fraction-of-a-period gap after a long tick.
-fn periodic(period: Duration) -> tokio::time::Interval {
+pub(crate) fn periodic(period: Duration) -> tokio::time::Interval {
     let mut tick = tokio::time::interval(period);
     tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
     tick
@@ -136,6 +136,10 @@ pub fn spawn_all(state: AppState) {
         tokio::spawn(archive_ttl_sweep(state.clone()));
     }
     tokio::spawn(reconcile_managed(state.clone()));
+    // Capacity admission (design 2026-08-23 §7). A no-op unless
+    // FLUIDBOX_MAX_CONCURRENT_RUNS is set, so an unconfigured deployment gains
+    // no worker and no polling.
+    crate::dispatcher::spawn(state.clone());
     tokio::spawn(finalize_worker(state));
 }
 
@@ -917,7 +921,24 @@ async fn network_grant_gate(state: AppState) {
             // never spawned. Re-spawn; `run()` performs the transition out of
             // the pause itself, and its own grant gate re-checks authority.
             if p.grant_status == "active" {
-                crate::orchestrator::spawn_run(state.clone(), p.session_id);
+                if state.cfg.queueing_enabled() {
+                    // Same enqueue as `release_authorized_grant`'s CAS-winner
+                    // arm. The transition CAS makes re-runs idempotent: a
+                    // session already `queued` has no `Queued → Queued` edge,
+                    // so it is refused and nothing duplicates. The scan
+                    // predicate keys on `awaiting_authorization`, so an
+                    // enqueued session leaves this worklist on its own.
+                    crate::orchestrator::transition(
+                        &state,
+                        scope,
+                        p.session_id,
+                        fluidbox_core::state::SessionStatus::Queued,
+                        Some("network grant authorized; waiting for a capacity slot"),
+                    )
+                    .await;
+                } else {
+                    crate::orchestrator::spawn_run(state.clone(), p.session_id);
+                }
                 continue;
             }
             // The grant was taken away while the run was parked — revoked by


### PR DESCRIPTION
Plan Task 6 · design §7.1, §7.2, §7.5, §7.6 · **Closes #157** · depends on #152, #153, #154, #156 (all merged)

The feature becomes end-to-end here: runs park, a dispatcher admits them, and both network-grant release sites route through the queue. Still inert with `FLUIDBOX_MAX_CONCURRENT_RUNS` unset.

## What landed

- **`dispatcher.rs`** — a 1 s worker registered in `spawn_all`, returning immediately when `cfg.queue` is `None`. Every ~15 ticks it also sweeps (age expiry + orphan adoption).
- **Park at admission** (`run_service.rs` Tail 1) — post-commit, so `create_session` stays byte-for-byte untouched.
- **Netgrant enqueue** — both `release_authorized_grant`'s CAS-winner arm and `network_grant_gate`'s crash-window arm.
- **Metrics** — `fluidbox_runs_dispatched_total`, `fluidbox_queue_shed_total{reason}`, `fluidbox_queue_wait_seconds` (observed at the claim).
- **`Config::queueing_enabled()`**, deferred from #156, now with its first callers.

## Verified

| Check | Result |
|---|---|
| `cargo test -p fluidbox-server` | **444 passed, 0 failed** |
| `cargo test -p fluidbox-core` | 176 passed |
| `cargo test -p fluidbox-db` | 152 passed |
| **Mutation test** of the new source guard | adding an unclaimed `spawn_run` fails it (`left: 2, right: 1`); restored → green |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

Behavioural tests land in #160's hermetic suite — a declared dependency in the plan, not an omission.

## Four review notes

### 1. No leader election, on purpose

Every replica runs the identical loop. The mutual exclusion lives in Postgres (the advisory try-lock inside `dispatch_claim`), not in a protocol of ours, so there is no election to get wrong, no split-brain window, and no failover delay — a losing tick simply re-polls.

### 2. The new source guard encodes a real safety coupling

`workers.rs` already asserts that its three periodic lifecycle workers perform no provider side effect, because a per-replica worker fires N times. The dispatcher is a fourth such worker but lives in its own module, so it gets the same guard — with one addition that matters more:

The dispatch arm *does* ultimately cause a `provider.provision`, via `spawn_run`. That is safe for a **different** reason than the other workers: the run was claimed inside `dispatch_claim`'s serialized section, which stamped this replica's lease on the row, so exactly one replica can reach the spawn for a given run. The test pins that coupling — exactly one spawn site, and the claim must precede it. A future edit that spawns something the claim did not return would silently reintroduce the N-replicas problem the serialized decision exists to prevent. Mutation-verified.

### 3. `run()` needed no change, and its comment was quietly wrong

`transition_fenced` reads the current status under the same `for update` lock that guards the epoch, so `Queued → Provisioning` is admitted by the state machine exactly like the other predecessors. The site's comment said `created → provisioning`; it now names all three lawful predecessors (`created`, `awaiting_authorization`, `queued`) and says *why* it stays one writer of the edge.

### 4. Authorization first, capacity second — and the wait clock is what makes it fair

Routing authorized grant releases through the queue is design §16 Q3's recommendation, adopted. The alternative (let an authorized run jump ahead) makes the cap waivable by grant type and produces real overshoot. The fairness objection — "that run already waited" — is answered by `queued_at`: the wait clock starts at the **park**, not at creation, so a run that spent three days waiting on a human enters the queue with a fresh clock and is not charged for that wait, nor expired by the age bound the moment it becomes dispatchable.