### PR TITLE
feat(server): bounded queue depth with per-entry-point shed semantics

### DIFF
--- a/crates/fluidbox-server/src/error.rs
+++ b/crates/fluidbox-server/src/error.rs
@@ -32,6 +32,14 @@ pub enum ApiError {
     /// Kubernetes netpol enforcement probe hasn't passed). 503.
     #[error("{0}")]
     ServiceUnavailable(String),
+    /// The run queue is at its depth bound (run admission, design 2026-08-23
+    /// §9). **429, deliberately not 503.** A shed is a policy decision, not an
+    /// outage, and a 5xx is the signal that invites retry amplification —
+    /// webhook providers redeliver on it, turning one shed event into many
+    /// requests exactly when the deployment is least able to take them. 429
+    /// with `Retry-After` says "later, and here is how much later".
+    #[error("at capacity: the run queue is full; retry after {retry_after_secs}s")]
+    AtCapacity { retry_after_secs: u64 },
     #[error(transparent)]
     Db(#[from] sqlx::Error),
     #[error("{0}")]
@@ -52,6 +60,19 @@ impl IntoResponse for ApiError {
             }
             ApiError::Upstream(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
             ApiError::ServiceUnavailable(_) => (StatusCode::SERVICE_UNAVAILABLE, self.to_string()),
+            // The one arm that returns early: it carries a header, and the
+            // shared tail below builds a header-less response.
+            ApiError::AtCapacity { retry_after_secs } => {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    [(
+                        axum::http::header::RETRY_AFTER,
+                        retry_after_secs.to_string(),
+                    )],
+                    Json(json!({ "error": self.to_string() })),
+                )
+                    .into_response();
+            }
             ApiError::Db(e) => {
                 tracing::error!("db error: {e}");
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
@@ -78,3 +99,36 @@ impl From<serde_json::Error> for ApiError {
 }
 
 pub type ApiResult<T> = Result<T, ApiError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shed signal for interactive callers. Two properties matter and both
+    /// are asserted: the STATUS must be 429 (a 503 would invite the retry
+    /// amplification the design forbids, and a 500 would read as our bug rather
+    /// than as backpressure), and `Retry-After` must be present so a client has
+    /// a number to obey instead of a hot loop.
+    #[test]
+    fn at_capacity_maps_to_429_with_retry_after() {
+        let resp = ApiError::AtCapacity {
+            retry_after_secs: 30,
+        }
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(resp.headers().get("retry-after").unwrap(), "30");
+    }
+
+    /// …and the header rides the STANDARD error envelope, not a bespoke body:
+    /// every other client-visible error in this API is `{"error": "…"}`, and a
+    /// shed is not the place to introduce a second shape.
+    #[test]
+    fn at_capacity_keeps_the_house_error_envelope() {
+        let msg = ApiError::AtCapacity {
+            retry_after_secs: 5,
+        }
+        .to_string();
+        assert!(msg.contains("capacity"), "got: {msg}");
+        assert!(msg.contains('5'), "the message states the wait: {msg}");
+    }
+}

--- a/crates/fluidbox-server/src/events.rs
+++ b/crates/fluidbox-server/src/events.rs
@@ -207,6 +207,35 @@ pub(crate) async fn process_delivery(
                     "running_session_id": running_session_id,
                 }));
             }
+            // A deliberate capacity shed is NOT an error, and the difference
+            // is visible to the operator: `skipped/capacity` reads as "the
+            // deployment was full", not "this subscription is misconfigured".
+            //
+            // It stays a 2xx ack, like every other dispatch-level outcome here.
+            // Answering 5xx would ask the provider to redeliver — turning one
+            // shed event into many requests at exactly the moment the
+            // deployment is least able to take them, which is the retry
+            // amplification the overload literature names as the thing that
+            // SUSTAINS an overload after its trigger clears. The disclosed cost
+            // (design §16 Q2) is that a shed PR event does not self-heal: the
+            // review run simply does not happen, and only the skip row says so.
+            Err(crate::error::ApiError::AtCapacity { .. }) => {
+                fluidbox_db::mark_dispatch_outcome(
+                    &state.pool,
+                    scope,
+                    claim.id,
+                    "skipped",
+                    Some("capacity"),
+                )
+                .await
+                .ok();
+                tracing::warn!(
+                    "dispatch {} for delivery {}: shed at the queue depth bound",
+                    sub.id,
+                    delivery.id
+                );
+                skipped.push(json!({ "subscription_id": sub.id, "reason": "capacity" }));
+            }
             Err(e) => {
                 // Recorded, not retried (scheduler precedent): a config
                 // error must not turn provider retries into a run factory.
@@ -393,6 +422,41 @@ pub async fn connection_deliveries(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Design §9 / §16 Q2, asserted rather than left to prose: a capacity shed
+    /// during webhook fan-out is recorded as a SKIP and the delivery is still
+    /// ACKed. It must never become a 5xx.
+    ///
+    /// This is the decision most at risk of being "simplified" away later —
+    /// the two `Err` arms look redundant until you know why they differ. A 5xx
+    /// here asks the provider to redeliver, turning one shed event into many
+    /// requests at exactly the moment the deployment is least able to take
+    /// them: the retry amplification that SUSTAINS an overload after its
+    /// trigger has cleared. A source guard, so it needs no database or fake
+    /// GitHub.
+    #[test]
+    fn a_capacity_shed_is_a_recorded_skip_not_an_error() {
+        let src = include_str!("events.rs");
+        let end = src
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("this file has a test module");
+        let production = &src[..end];
+
+        let at = production
+            .find(concat!("ApiError::", "AtCapacity"))
+            .expect("the fan-out distinguishes a capacity shed");
+        let arm: String = production[at..].chars().take(400).collect();
+        assert!(
+            arm.contains(r#""skipped""#) && arm.contains(r#"Some("capacity")"#),
+            "a capacity shed records skipped/capacity, got: {arm}"
+        );
+        // Nothing in the fan-out may answer 5xx for a shed. The handler's
+        // return type is the ack, so the guard is that the arm does not bail.
+        assert!(
+            !arm.contains("return Err") && !arm.contains('?'),
+            "a shed must keep the 2xx ack, got: {arm}"
+        );
+    }
 
     #[test]
     fn matcher_requires_an_event_filter_and_honors_it() {

--- a/crates/fluidbox-server/src/run_service.rs
+++ b/crates/fluidbox-server/src/run_service.rs
@@ -22,6 +22,12 @@ use fluidbox_core::spec::{
     WorkspaceSpec,
 };
 use fluidbox_core::state::SessionStatus;
+
+/// What a shed 429 tells the caller to wait. One dispatcher tick is 1 s, so any
+/// value large enough to be worth obeying is arbitrary; 30 s is the same scale
+/// as the capacity-bounce backoff floor and is short enough that a human
+/// retrying by hand is not misled about the deployment being wedged.
+const QUEUE_SHED_RETRY_AFTER_SECS: u64 = 30;
 use fluidbox_db::TenantScope;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -133,6 +139,31 @@ pub async fn create_run(
              runs are blocked until the NetworkPolicy enforcement probe passes"
                 .into(),
         ));
+    }
+
+    // Queue depth backstop (design 2026-08-23 §7.1). Deliberately BEFORE the
+    // create transaction and deliberately racy by a bounded amount: two
+    // concurrent creates can both pass at depth `bound - 1`. The bound is a
+    // protective backstop against a runaway webhook loop or CI storm, not an
+    // invariant, and overshoot is limited to the number of in-flight creates.
+    // Checking INSIDE the create transaction would put a cross-tenant count
+    // into the byte-for-byte-load-bearing tx, which invariant 3 forbids.
+    //
+    // Placed ahead of agent resolution so a full queue costs one count rather
+    // than the whole resolution path — and so the shed answer does not depend
+    // on whether the caller's agent name happened to be valid.
+    if let Some(q) = &state.cfg.queue {
+        let depth = fluidbox_db::system_worker::count_queued_sessions(&state.pool).await?;
+        if depth >= q.max_depth {
+            tracing::warn!(
+                "run queue at depth {depth} (bound {}) — shedding",
+                q.max_depth
+            );
+            state.metrics.queue_shed.inc("depth");
+            return Err(ApiError::AtCapacity {
+                retry_after_secs: QUEUE_SHED_RETRY_AFTER_SECS,
+            });
+        }
     }
 
     // Resolve agent by id or name — SQL-scoped to the caller's tenant.

--- a/crates/fluidbox-server/src/scheduler.rs
+++ b/crates/fluidbox-server/src/scheduler.rs
@@ -150,6 +150,27 @@ async fn fire_one(state: &AppState, sched: &ScheduleRow) {
                     );
                     advance(state, scope, sched, fire_time, next, None).await;
                 }
+                // A deliberate capacity shed, recorded as such rather than as
+                // an "error: …" string. The distinction is operator-facing:
+                // `capacity` says the deployment was full at this fire time and
+                // the NEXT cron fire retries naturally, where an error string
+                // reads as a broken schedule needing attention.
+                Err(crate::error::ApiError::AtCapacity { .. }) => {
+                    fluidbox_db::mark_invocation_skipped(
+                        &state.pool,
+                        scope,
+                        invocation_id,
+                        "capacity",
+                    )
+                    .await
+                    .ok();
+                    tracing::warn!(
+                        "schedule {}: firing {} shed at the queue depth bound",
+                        sched.id,
+                        key
+                    );
+                    advance(state, scope, sched, fire_time, next, None).await;
+                }
                 Err(e) => {
                     // A failed firing is recorded, not retried — retrying a
                     // config error every tick would loop forever.


### PR DESCRIPTION
Plan Task 8 · design §7.1, §9 · **Closes #159** · depends on #154, #156, #157 (all merged)

Bounds the queue and gives each entry point the shed behaviour its caller can actually act on.

## What landed

- **`ApiError::AtCapacity { retry_after_secs }`** → 429 + `Retry-After`, in the standard `{"error": …}` envelope.
- **The depth check** at the head of `create_run`, inside `if let Some(q) = &state.cfg.queue`.
- **Per entry point:** manual + API invoke → 429 (no change needed, `ApiError` propagates); webhook fan-out → `skipped/capacity` with the 2xx ack kept; scheduler → skip reason `"capacity"` instead of `"error: …"`.

## Verified

| Check | Result |
|---|---|
| `cargo test -p fluidbox-server` | **449 passed, 0 failed** |
| `cargo test -p fluidbox-server error::` | 2 new tests, red first (`no variant named AtCapacity`) |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

Live shed behaviour is asserted in #160's hermetic suite, per the plan.

## Four review notes

### 1. 429, not 503 — and the webhook arm keeps its 2xx

This is the design's §16 Q2 recommendation, adopted. A shed is a *policy decision*, not an outage. A 5xx asks the provider to redeliver, turning one shed event into many requests at exactly the moment the deployment is least able to take them — the retry amplification the overload literature identifies as what **sustains** an overload after its trigger has cleared. The repo already chose recorded-skip for dispatch-level failures, so this follows its own precedent.

**Disclosed cost, unchanged:** a shed PR event does not self-heal. The review run simply does not happen and only the skip row says so.

### 2. A source guard on the webhook arm, because it is the most "simplifiable" decision in the epic

The two `Err` arms in the fan-out look redundant until you know why they differ, which makes them a prime target for a future cleanup. The guard asserts the capacity arm records `skipped`/`capacity` and does not bail — so collapsing them into something that 5xxes fails a test instead of quietly re-arming redelivery amplification.

### 3. The depth check is deliberately racy, and deliberately early

- **Outside the create transaction**, because invariant 3 forbids putting a cross-tenant count into the byte-for-byte-load-bearing tx. Two concurrent creates can both pass at `bound - 1`; overshoot is limited to the number of in-flight creates, and the bound is a backstop against a runaway loop rather than an invariant.
- **Ahead of agent resolution** (a placement the plan left open): a full queue then costs one count instead of the whole resolution path, and the shed answer does not depend on whether the caller's agent name happened to be valid.

### 4. Match-arm ordering is compiler-enforced here

The specific `Err(ApiError::AtCapacity { .. })` arm must precede the general `Err(e)`. If someone reverses them, the specific arm becomes unreachable and `-D warnings` fails the build — so this ordering cannot silently regress.