### PR TITLE
feat(server): queue observability — live gauges, requeue counter, queued position in the session API

### DIFF
--- a/crates/fluidbox-db/src/lib.rs
+++ b/crates/fluidbox-db/src/lib.rs
@@ -4682,6 +4682,38 @@ pub async fn session_lease(
     Ok(row)
 }
 
+/// How many queued runs are ahead of one — the per-run answer to "why is my run
+/// not running yet" (design 2026-08-23 §13). `0` = next up.
+///
+/// TENANT-SCOPED ON PURPOSE, and the choice is worth stating because the number
+/// is therefore NOT the run's position in the deployment-wide FIFO the
+/// dispatcher actually walks. A deployment-wide position would need a bypass
+/// and would leak another tenant's load through an ordinary run API — a caller
+/// could watch the number move and infer a competitor's traffic. Within one
+/// tenant it is exact; across tenants it is a lower bound, which is the honest
+/// thing to show a user who may not be able to see the rest of the deployment.
+///
+/// Anchored on `created_at` (the dispatcher's own ordering key), not
+/// `queued_at`, so the answer matches the order runs will actually be admitted
+/// in — a capacity-bounced run keeps its place rather than going to the back.
+pub async fn queued_position(
+    pool: &PgPool,
+    scope: TenantScope,
+    created_at: DateTime<Utc>,
+) -> sqlx::Result<i64> {
+    let mut tx = scoped_tx(pool, scope).await?;
+    let (n,): (i64,) = sqlx::query_as(
+        "select count(*) from sessions
+          where tenant_id = $1 and status = 'queued' and created_at < $2",
+    )
+    .bind(scope.tenant_id())
+    .bind(created_at)
+    .fetch_one(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(n)
+}
+
 /// Gate a capacity-bounced run behind a not-before instant and RELEASE its
 /// driver lease (run admission, design 2026-08-23 §7.4).
 ///
@@ -15787,6 +15819,118 @@ mod tests {
 
         for (tenant, _) in seeded {
             cleanup_sw_tenant(pool, tenant).await;
+        }
+        pool.close().await;
+    }
+
+    /// The two observability reads (design §13). `queue_gauges` answers the
+    /// deployment-wide operator question ("how deep, and how long has the head
+    /// been waiting"); `queued_position` answers the per-run user question
+    /// ("where am I") and is TENANT-SCOPED on purpose — a deployment-wide
+    /// number would leak cross-tenant load through a normal run API.
+    #[tokio::test]
+    async fn queue_gauges_and_position_answer_their_two_questions() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let _serial = DISPATCH_SERIAL.lock().await;
+        let pool = &test_connect(&dispatch_db_url(&url).await)
+            .await
+            .expect("connect to the dedicated dispatch database");
+
+        // Empty queue: zero depth, and zero — not an error, not a null —
+        // oldest wait, so the gauge renders a real number on a quiet
+        // deployment.
+        assert_eq!(system_worker::queue_gauges(pool).await.unwrap(), (0, 0));
+
+        let seeded = seed_queued(pool, 3).await;
+        let (depth, oldest) = system_worker::queue_gauges(pool).await.unwrap();
+        assert_eq!(depth, 3);
+        assert!(oldest >= 0);
+
+        // Age the head so the oldest-wait gauge has something to report.
+        sqlx::query("update sessions set queued_at = now() - interval '90 seconds' where id = $1")
+            .bind(seeded[0].1)
+            .execute(pool)
+            .await
+            .unwrap();
+        let (_, oldest) = system_worker::queue_gauges(pool).await.unwrap();
+        assert!(oldest >= 90, "oldest wait tracks the head, got {oldest}");
+
+        // Position counts only OLDER queued rows IN THE SAME TENANT.
+        for (i, (tenant, session)) in seeded.iter().enumerate() {
+            let scope = TenantScope::assume(*tenant);
+            let row = get_session(pool, scope, *session).await.unwrap().unwrap();
+            assert_eq!(
+                queued_position(pool, scope, row.created_at).await.unwrap(),
+                0,
+                "each seeded run is alone in its own tenant, so it is at the head"
+            );
+            assert_eq!(i, i); // keep the index meaningful to the reader
+        }
+
+        // Three runs in ONE tenant: 0, 1, 2 — and a fourth tenant's run is
+        // invisible to them.
+        let (tenant, first) = seed_tenant_session(pool).await;
+        let scope = TenantScope::assume(tenant);
+        let mut ids = vec![first];
+        for _ in 0..2 {
+            let row = create_session(
+                pool,
+                scope,
+                get_session(pool, scope, first)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .agent_id,
+                get_session(pool, scope, first)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .agent_revision_id,
+                "supervised",
+                "trusted",
+                "queued position",
+                &serde_json::json!({"kind":"none"}),
+                &serde_json::json!({}),
+                &serde_json::json!({}),
+                None,
+                None,
+                None,
+                None,
+                None,
+                &[],
+                None,
+            )
+            .await
+            .unwrap();
+            ids.push(row.id);
+        }
+        for id in &ids {
+            transition_session(
+                pool,
+                scope,
+                *id,
+                fluidbox_core::state::SessionStatus::Queued,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        }
+        for (want, id) in ids.iter().enumerate() {
+            let row = get_session(pool, scope, *id).await.unwrap().unwrap();
+            assert_eq!(
+                queued_position(pool, scope, row.created_at).await.unwrap(),
+                want as i64,
+                "position is the count of older queued runs in this tenant"
+            );
+        }
+
+        cleanup_sw_tenant(pool, tenant).await;
+        for (t, _) in seeded {
+            cleanup_sw_tenant(pool, t).await;
         }
         pool.close().await;
     }

--- a/crates/fluidbox-db/src/system_worker.rs
+++ b/crates/fluidbox-db/src/system_worker.rs
@@ -31,7 +31,9 @@
 //!     [`count_queued_sessions`] — the depth backstop the create path checks;
 //!     [`expired_queued_sessions`] — runs past the configured maximum wait;
 //!     [`orphaned_created_sessions`] — `created` rows nothing is driving, which
-//!     heals both the park crash window and the pre-existing orphan class) each
+//!     heals both the park crash window and the pre-existing orphan class;
+//!     [`queue_gauges`] — the deployment-wide depth and oldest-wait the metrics
+//!     endpoint reads at render time) each
 //!     act on ids/status across ALL tenants by construction (a global scan),
 //!     then scope every mutation to the `tenant_id` of the row they just
 //!     fetched. The capacity queue is DEPLOYMENT-WIDE on purpose: a per-tenant
@@ -944,6 +946,33 @@ pub async fn expired_queued_sessions(
     .await?;
     tx.commit().await?;
     Ok(out)
+}
+
+/// The two operator gauges: `(queue depth, oldest wait in seconds)`.
+///
+/// One query, deployment-wide, read at RENDER time rather than shadowed by an
+/// event-driven gauge — the registry's own doctrine for point-in-time values a
+/// durable source already holds. An event-driven depth gauge would drift on
+/// every restart and on every path that leaves the queue without passing
+/// through the counter's insertion point.
+///
+/// Returns `(0, 0)` on an empty queue rather than a null oldest-wait, so the
+/// exposition always carries a real number and a scrape on a quiet deployment
+/// is not a gap in the series.
+pub async fn queue_gauges(pool: &PgPool) -> sqlx::Result<(i64, i64)> {
+    let mut tx = crate::worker_tx(pool).await?;
+    let row: (i64, i64) = sqlx::query_as(
+        "select
+           count(*)::bigint,
+           coalesce(
+             extract(epoch from (now() - min(queued_at)))::bigint,
+             0)
+         from sessions where status = 'queued'",
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(row)
 }
 
 /// `created` rows nothing is driving — the park crash window (a replica that

--- a/crates/fluidbox-server/src/api.rs
+++ b/crates/fluidbox-server/src/api.rs
@@ -1519,6 +1519,22 @@ pub async fn get_session(
         .ok_or(ApiError::NotFound)?;
     rbac::ensure_run_visible(&principal, &session)?;
     let totals = fluidbox_db::usage_totals(&state.pool, scope, id).await?;
+    // "Why is my run not running yet" — the per-run half of the queue's
+    // observability story (design 2026-08-23 §13). Attached ONLY while the run
+    // is actually queued: on any other status the number would be stale the
+    // instant it was read, and a field that is sometimes meaningful and
+    // sometimes not is worse than an absent one.
+    //
+    // `queued_at` needs nothing here — it is a `SessionRow` column and already
+    // serializes with the row.
+    if session.status == fluidbox_core::state::SessionStatus::Queued.as_str() {
+        let position = fluidbox_db::queued_position(&state.pool, scope, session.created_at).await?;
+        return Ok(Json(json!({
+            "session": session,
+            "usage": totals,
+            "queue_position": position,
+        })));
+    }
     Ok(Json(json!({ "session": session, "usage": totals })))
 }
 

--- a/crates/fluidbox-server/src/metrics.rs
+++ b/crates/fluidbox-server/src/metrics.rs
@@ -325,6 +325,10 @@ pub struct Metrics {
     pub queue_shed: Family,
     /// Time from first enqueue to admission, observed at the claim.
     pub queue_wait_seconds: Histogram,
+    /// Runs re-parked after a provider refused them. `reason` = capacity today;
+    /// the `_other` slot exists so a future classification cannot silently
+    /// widen the label set (the registry's fixed-cardinality doctrine).
+    pub queue_requeues: Family,
     // ── Durability (design: database event and ledger write rates).
     pub ledger_events: Counter,
     /// Metrics-scrape failures (a live read — pool count etc. — that errored).
@@ -436,6 +440,11 @@ impl Default for Metrics {
                 &["depth", "age", "requeue_exhausted"],
             ),
             queue_wait_seconds: Histogram::new("fluidbox_queue_wait_seconds", QUEUE_WAIT_SECS),
+            queue_requeues: Family::new(
+                "fluidbox_queue_requeues_total",
+                "reason",
+                &["capacity", "_other"],
+            ),
             ledger_events: Counter::default(),
             scrape_errors: Counter::default(),
         }
@@ -455,6 +464,13 @@ pub struct Live {
     pub mcp_sessions: u64,
     /// Governor durable-tier degrade count (a DB-outage fell back to local-only).
     pub governor_degraded: u64,
+    /// Run-queue depth and head-of-queue wait, read from the sessions table at
+    /// render time. Deployment-wide (unlike [`Metrics::active_runs`], which is
+    /// replica-local), because the queue is. Both render `0` when the feature
+    /// is off — there is nothing to count, and a missing series is harder to
+    /// alert on than a flat zero.
+    pub queue_depth: i64,
+    pub queue_oldest_wait_secs: i64,
 }
 
 /// Render the full Prometheus text exposition. Deterministic: families and
@@ -548,6 +564,25 @@ pub fn render(m: &Metrics, live: &Live) -> String {
         .render(&mut out, "Work refused rather than queued, by reason.");
     m.queue_wait_seconds
         .render(&mut out, "Time from first enqueue to admission, seconds.");
+    m.queue_requeues.render(
+        &mut out,
+        "Runs re-parked after a provider refused them, by reason.",
+    );
+
+    gauge_i64(
+        &mut out,
+        "fluidbox_runs_queued_depth",
+        "gauge",
+        "Runs waiting for a capacity slot, deployment-wide.",
+        live.queue_depth,
+    );
+    gauge_i64(
+        &mut out,
+        "fluidbox_queue_oldest_wait_seconds",
+        "gauge",
+        "How long the run at the head of the queue has been waiting, seconds.",
+        live.queue_oldest_wait_secs,
+    );
 
     counter(
         &mut out,
@@ -615,12 +650,31 @@ const EXPOSITION_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8"
 /// scrape, including on the unauthenticated bind, cannot be turned into DB load.
 async fn snapshot(state: &AppState) -> Live {
     let mcp_sessions = state.mcp_sessions.lock().await.len() as u64;
+    // Only queried when the feature is on: an unconfigured deployment has no
+    // queued rows, so this would be a guaranteed-zero round trip on every
+    // scrape. A read error renders zeros and counts a scrape error — the
+    // existing Live convention — because a metrics endpoint that 500s takes the
+    // whole exposition down with it.
+    let (queue_depth, queue_oldest_wait_secs) = if state.cfg.queueing_enabled() {
+        match fluidbox_db::system_worker::queue_gauges(&state.pool).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("queue gauge read failed: {e}");
+                state.metrics.scrape_errors.inc();
+                (0, 0)
+            }
+        }
+    } else {
+        (0, 0)
+    };
     Live {
         pool_size: state.pool.size(),
         pool_idle: state.pool.num_idle() as u32,
         pool_max: state.cfg.db_pool.max_connections,
         mcp_sessions,
         governor_degraded: state.governor.degraded_count(),
+        queue_depth,
+        queue_oldest_wait_secs,
     }
 }
 
@@ -793,12 +847,18 @@ mod tests {
         m.brokered_outcomes.inc("ambiguous");
         m.broker_latency_ms.observe(42.0);
         m.active_runs.inc();
+        m.queue_dispatched.inc();
+        m.queue_shed.inc("depth");
+        m.queue_requeues.inc("capacity");
+        m.queue_wait_seconds.observe(12.5);
         let live = Live {
             pool_size: 8,
             pool_idle: 6,
             pool_max: 10,
             mcp_sessions: 3,
             governor_degraded: 0,
+            queue_depth: 7,
+            queue_oldest_wait_secs: 91,
         };
         let a = render(&m, &live);
         let b = render(&m, &live);
@@ -812,6 +872,14 @@ mod tests {
             "fluidbox_db_pool_idle 6",
             "fluidbox_db_pool_max 10",
             "fluidbox_mcp_sessions_active 3",
+            // Run admission (design 2026-08-23 §13): the four an operator
+            // alerts on, plus the histogram a dashboard plots.
+            "fluidbox_runs_dispatched_total 1",
+            "fluidbox_queue_shed_total{reason=\"depth\"} 1",
+            "fluidbox_queue_requeues_total{reason=\"capacity\"} 1",
+            "fluidbox_runs_queued_depth 7",
+            "fluidbox_queue_oldest_wait_seconds 91",
+            "fluidbox_queue_wait_seconds_count 1",
             "# TYPE fluidbox_gate_decisions_total counter",
             "# TYPE fluidbox_broker_call_latency_ms histogram",
         ] {
@@ -839,6 +907,8 @@ mod exposition_guard {
             pool_max: 1,
             mcp_sessions: 0,
             governor_degraded: 0,
+            queue_depth: 0,
+            queue_oldest_wait_secs: 0,
         };
         let text = render(&m, &live);
         let mut names = std::collections::HashSet::new();

--- a/crates/fluidbox-server/src/orchestrator.rs
+++ b/crates/fluidbox-server/src/orchestrator.rs
@@ -2033,6 +2033,7 @@ async fn requeue_capacity_denied(
     epoch: i64,
     detail: &str,
 ) -> anyhow::Result<()> {
+    state.metrics.queue_requeues.inc("capacity");
     if let Err(e) = fluidbox_db::revoke_session_tokens(&state.pool, scope, session_id).await {
         tracing::warn!("revoking tokens for bounced run {session_id} failed: {e}");
     }


### PR DESCRIPTION
Plan Task 10 · design §13 · **Closes #161** · depends on #157 (merged)

Two different questions, answered in the two places that can answer them.

## What landed

**Operator — "how deep, and how long has the head been waiting?"**
`system_worker::queue_gauges` → `fluidbox_runs_queued_depth` and `fluidbox_queue_oldest_wait_seconds`, plus `fluidbox_queue_requeues_total{reason}` incremented at the top of the bounce path.

**User — "where is my run in the queue?"**
`fluidbox_db::queued_position` → `queue_position` on `GET /v1/sessions/{id}`, attached only while the run is queued. `queued_at` needed nothing: it is a `SessionRow` column and already serializes (a consequence of #153, flagged there).

## Verified

| Check | Result |
|---|---|
| `cargo test -p fluidbox-db` | **153 passed, 0 failed** (one new DB test, red first) |
| `cargo test -p fluidbox-server` | **449 passed, 0 failed** |
| Pre-existing exposition uniqueness guard | validates all five new metric names |
| Render test | now spot-checks each new series |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

## Four review notes

### 1. `queued_position` is tenant-scoped, so it is *not* the deployment-wide FIFO position

This is the one place the number could mislead, so it is worth being explicit — and the fn doc says so too. The dispatcher walks a **deployment-wide** `order by created_at`. A position matching that walk would need a bypass *and* would leak another tenant's load through an ordinary run API: a caller could watch the number move and infer a competitor's traffic. So within one tenant it is exact, and across tenants it is a **lower bound** — the honest thing to show someone who cannot see the rest of the deployment.

It anchors on `created_at` (the dispatcher's own ordering key) rather than `queued_at`, so a capacity-bounced run keeps its place rather than going to the back of the line it was already at the front of.

### 2. The gauges are read at render time, not maintained as counters

The registry's own doctrine for point-in-time values a durable source already holds. An event-driven depth gauge would drift on every restart *and* on every path that leaves the queue without passing its insertion point — of which this feature has several (dispatch, age expiry, cancel, capacity bounce). Reading the table cannot drift.

Two robustness details: the query runs **only when the feature is on** (otherwise it is a guaranteed-zero round trip on every scrape), and a read error renders zeros plus a `scrape_errors` increment — a metrics endpoint that 500s takes the whole exposition down with it, so one bad series must not do that. Empty queue returns `(0, 0)` rather than a null wait, because a flat zero is far easier to alert on than a gap in the series.

### 3. `queue_position` is attached only while the run is queued

On any other status the number is stale the instant it is read. A field that is sometimes meaningful and sometimes not is worse than an absent one.

### 4. Sequencing — [noted on the ticket](https://github.com/hrishikeshdkakkad/fluidbox/issues/161#issuecomment-5389824619)

This ticket's plan step 4 says to extend `scripts/e2e-queue.sh`, which **#160 creates** and which the epic schedules *after* this ticket. Rather than have #160 ship a script a later PR immediately edits, the `queue_position` e2e assertion is written into P1 when #160 creates it. No behaviour is deferred — only the assertion's file location.