### PR TITLE
docs+chart: run-queue operator surfaces (helm, doctor, openapi, dashboard chip, runbook)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2145,8 +2145,13 @@ a.row:hover,
     animation: none;
   }
 }
-/* Both pauses read amber: a human is being waited on. `awaiting_approval` is
-   a mid-run tool decision; `awaiting_authorization` is the pre-provisioning
+/* `created` and `queued` deliberately have NO rule: they inherit the base
+   pill's neutral ink, which is what a run waiting on a machine should look
+   like. Do not give `queued` the amber below — amber means a HUMAN is being
+   waited on, and a capacity park is not waiting on anybody.
+
+   Both pauses below read amber: a human is being waited on. `awaiting_approval`
+   is a mid-run tool decision; `awaiting_authorization` is the pre-provisioning
    network-grant pause, where no sandbox exists yet. */
 .pill.awaiting_approval,
 .pill.awaiting_authorization {

--- a/apps/web/app/lib/activity.test.ts
+++ b/apps/web/app/lib/activity.test.ts
@@ -43,6 +43,18 @@ describe("runGroup", () => {
     expect(runGroup("finalizing")).toBe("live");
   });
 
+  test("the capacity park is a neutral wait, not an attention state", () => {
+    // `queued` is non-terminal and needs no human, so it shares the live
+    // group with `created`. It must NOT join the attention chip: unlike
+    // `awaiting_authorization` there is no decision outstanding, and a busy
+    // deployment would fill that chip with runs nobody can act on — which
+    // trains operators to ignore the one chip that should always mean
+    // "someone is blocked on you".
+    expect(runGroup("queued")).toBe("live");
+    expect(runGroup("created")).toBe("live");
+    expect(runGroup("queued")).not.toBe("attention");
+  });
+
   test("treats an unknown status as live so it stays visible", () => {
     expect(runGroup("some_future_status")).toBe("live");
   });

--- a/apps/web/app/lib/activity.ts
+++ b/apps/web/app/lib/activity.ts
@@ -13,13 +13,28 @@ export type ActivityFilter = "all" | "live" | "attention" | "failed" | "complete
 
 const ATTENTION_STATUSES = new Set(["awaiting_approval", "awaiting_authorization"]);
 const FAILED_STATUSES = new Set(["failed", "budget_exceeded"]);
+/**
+ * Not-yet-started but healthy: nothing is being waited on except a machine.
+ * `queued` is the capacity park — deliberately NOT "attention", because unlike
+ * `awaiting_authorization` no human decision is outstanding, and putting it in
+ * the attention chip would train operators to ignore that chip on a busy
+ * deployment.
+ *
+ * These share the "live" group with running work, which is the right answer
+ * among the five: they are non-terminal and they will start on their own.
+ */
+const WAITING_STATUSES = new Set(["created", "queued"]);
 
 /**
  * Map a raw session status onto a triage group. Unknown statuses read as
  * "live" on purpose: a status this UI has never heard of is an in-flight
  * shape from a newer server, and hiding it would be the one wrong answer.
+ * `WAITING_STATUSES` therefore changes no behaviour — it records that these
+ * two were CLASSIFIED rather than defaulted, which is the difference between
+ * "we decided" and "we never heard of it".
  */
 export function runGroup(status: string): RunGroup {
+  if (WAITING_STATUSES.has(status)) return "live";
   if (ATTENTION_STATUSES.has(status)) return "attention";
   if (FAILED_STATUSES.has(status)) return "failed";
   if (status === "completed") return "completed";

--- a/apps/web/public/docs/openapi.yaml
+++ b/apps/web/public/docs/openapi.yaml
@@ -4026,9 +4026,24 @@ components:
         `awaiting_authorization` is the pre-provisioning pause: the run's spec
         (including its network grant) is frozen, but no sandbox exists and no
         model spend is possible until a human authorizes the grant.
+
+        `queued` is the pre-provisioning capacity park: the run's spec is
+        frozen but no sandbox exists and no model spend is possible until the
+        dispatcher admits it under `FLUIDBOX_MAX_CONCURRENT_RUNS`. It appears
+        only on deployments that have configured that cap; without it runs
+        launch on creation and this value is never written. Runs are admitted
+        oldest-first, and a queued session carries `queued_at` plus a
+        `queue_position` field on the single-session response (the number of
+        older queued runs in the same organization — a lower bound on the
+        deployment-wide position, which is deliberately not exposed).
+
+        The two pauses compose: a run needing network authorization waits for a
+        human first and for capacity second, and its queue-wait clock starts
+        only when it becomes dispatchable.
       enum:
         - created
         - awaiting_authorization
+        - queued
         - provisioning
         - initializing
         - running

--- a/deploy/helm/fluidbox/templates/server.yaml
+++ b/deploy/helm/fluidbox/templates/server.yaml
@@ -281,6 +281,21 @@ spec:
             # redesigned rather than reconfigured.
             - { name: FLUIDBOX_WORKLOAD_IDENTITY, value: {{ . | quote }} }
             {{- end }}
+            {{- with .Values.server.maxConcurrentRuns }}
+            # Run admission: the app-level cap that turns over-capacity runs into
+            # a FIFO queue instead of a failure. Keep it at or below
+            # sandbox.quota.pods — see the comment on both values.
+            - { name: FLUIDBOX_MAX_CONCURRENT_RUNS, value: {{ . | quote }} }
+            {{- end }}
+            {{- with .Values.server.queueMaxDepth }}
+            - { name: FLUIDBOX_QUEUE_MAX_DEPTH, value: {{ . | quote }} }
+            {{- end }}
+            {{- with .Values.server.queueMaxWaitSecs }}
+            - { name: FLUIDBOX_QUEUE_MAX_WAIT_SECS, value: {{ . | quote }} }
+            {{- end }}
+            {{- with .Values.server.queueRequeueMax }}
+            - { name: FLUIDBOX_QUEUE_REQUEUE_MAX, value: {{ . | quote }} }
+            {{- end }}
             {{- if .Values.server.allowRlsBypass }}
             # Review M2 escape hatch: accept a pool role that bypasses RLS even in
             # multi-user mode. Local/single-user only — a hosted install must instead

--- a/deploy/helm/fluidbox/values.yaml
+++ b/deploy/helm/fluidbox/values.yaml
@@ -170,6 +170,39 @@ server:
   # distinguish another process in the same pod, a node-level attacker, or a
   # fabric that permits source-address spoofing. mTLS is the stronger follow-up.
   workloadIdentity: ""
+  # ── Run admission & queueing (design docs/plans/2026-08-23-run-queue-
+  # admission-design.md). "" = OFF, and off is byte-identical to before the
+  # feature existed: runs launch on creation and nothing is queued.
+  #
+  # Setting maxConcurrentRuns turns the app cap into the WAITING ROOM and leaves
+  # sandbox.quota below as the BACKSTOP. Keep it at or BELOW quota.pods: the
+  # quota counts pods the app cannot see (other workloads sharing the namespace,
+  # a stuck terminating pod), so a cap above it means the quota fires first and
+  # every over-cap run takes the slower bounce-and-retry path instead of simply
+  # waiting its turn.
+  #
+  # ROLLOUT ORDER MATTERS (the 0028 discipline): apply the migration, roll the
+  # new image to EVERY replica, and only then set this. A binary that predates
+  # the `queued` status reads a parked run as terminal. See
+  # docs/hosted/run-queue-operations.md.
+  maxConcurrentRuns: ""
+  # Depth backstop before new work is SHED rather than queued ("" = 4 × the cap,
+  # floor 50). Interactive callers get 429 + Retry-After; webhook and schedule
+  # firings get a recorded skip and a 2xx, deliberately never a 5xx that would
+  # invite redelivery amplification.
+  queueMaxDepth: ""
+  # How long a run may wait before it fails with an explained reason ("" = 3600).
+  # Measured from FIRST enqueue, so it bounds total time in queue across capacity
+  # bounces — and a run that sat in `awaiting_authorization` waiting on a human
+  # is not charged for that wait.
+  queueMaxWaitSecs: ""
+  # Provider capacity refusals (a quota 403) tolerated before a run fails with an
+  # explained reason ("" = 5). With the 30→300s backoff, five spans ~13 minutes
+  # of sustained external quota pressure.
+  queueRequeueMax: ""
+  # NOTE: the three knobs above are DEAD CONFIG without maxConcurrentRuns, and
+  # the server REFUSES TO BOOT rather than ignore them.
+  #
   # Archive PVC (survives Recreate upgrades so init can still pull). Rendered ONLY
   # for the node-local "" | "fs" archive store; archiveStore "s3" mounts nothing
   # local, so these fields are unused there.
@@ -253,14 +286,28 @@ sandbox:
   # BYTES, default 2Gi) PLUS the unpacked staging tree PLUS the baseline
   # during init — size it for archive + ~2× the unpacked workspace.
   volumeSizeLimit: 10Gi
-  # Namespace ResourceQuota. This is the ONLY admission gate on concurrent runs —
-  # there is deliberately no application-side counter (an earlier revision of this
-  # comment claimed one; it never existed). The quota is enforced by the API server
-  # for every replica at once and cannot be bypassed by any code path, which an
-  # in-process counter could not match; the price is that it counts PODS, not runs,
-  # and it REJECTS rather than queues: once `pods` is reached, pod creation returns
-  # 403 and the run FAILS at provisioning (it is not held and retried). Size the
-  # tier you actually want rather than relying on the quota as a waiting room.
+  # Namespace ResourceQuota — the BACKSTOP, not the waiting room.
+  #
+  # SET BOTH: server.maxConcurrentRuns above is the app-level cap that holds
+  # runs in a queue, and this quota is the substrate limit that catches what the
+  # app cannot see. They answer different questions and neither replaces the
+  # other:
+  #
+  #   * The quota is enforced by the API server for every replica at once and
+  #     cannot be bypassed by any code path — which is exactly why it also
+  #     counts pods fluidbox did not create (another workload in the namespace,
+  #     a pod stuck terminating). It counts PODS, not runs.
+  #   * The app cap counts RUNS and can HOLD them: over the cap, a run waits in
+  #     `queued` and is admitted FIFO. Over the quota, the API server returns
+  #     403 — which the control plane now classifies as capacity pressure and
+  #     re-parks with backoff (it no longer fails the run), but that is the
+  #     slower path and it exists for the pods the app cannot see.
+  #
+  # So keep maxConcurrentRuns <= pods. A cap ABOVE the quota means the quota
+  # fires first and every over-cap run takes the bounce-and-retry path instead
+  # of simply waiting its turn. With maxConcurrentRuns unset, the quota is
+  # again the only gate and a 403 still re-parks nothing — size the tier you
+  # actually want.
   #
   # requestsCpu / requestsMemory must be kept CONSISTENT with pods and with
   # sandbox.resources.requests above — the quota counts REQUESTS, so the three are

--- a/docs/hosted/README.md
+++ b/docs/hosted/README.md
@@ -13,6 +13,8 @@ These documents define the supported product boundary for the hosted, multi-user
 
 **Operator runbook.** [KMS operations](kms-operations.md) — the Phase D custody layer: envelope sealing (DEK/KEK, the `FLUIDBOX_KMS_MODE` boot matrix), the resumable re-seal + legacy-key retirement procedure, disaster recovery, per-tenant LiteLLM virtual keys, and Row-Level Security operations.
 
+**Capacity.** [Run queue operations](run-queue-operations.md) — enabling capacity admission (`FLUIDBOX_MAX_CONCURRENT_RUNS`): the migrate → roll-every-replica → enable order and why it is not advisory, sizing the app cap against the namespace `ResourceQuota`, what each metric means, what callers see when the queue is full, and the drain-first rollback.
+
 **Authority.** These documents *state* settled decisions; they make none. The normative sources are:
 
 - [`../plans/2026-07-14-multi-user-mcp-control-plane-design.md`](../plans/2026-07-14-multi-user-mcp-control-plane-design.md) (v4) — the multi-user architecture, security invariants 1–22, Gaps 1–14, Phases A–F

--- a/docs/hosted/run-queue-operations.md
+++ b/docs/hosted/run-queue-operations.md
@@ -1,0 +1,182 @@
+# Run queue operations — enabling, sizing, and rolling back capacity admission
+
+> Design: `docs/plans/2026-08-23-run-queue-admission-design.md`. Companion code:
+> `crates/fluidbox-server/src/{dispatcher,config}.rs`,
+> `crates/fluidbox-db/src/system_worker.rs`, migration `0034_run_queue.sql`.
+
+Without this feature, fluidbox has no admission control: every run launches the
+moment it is created, and the only quantity gate is the Kubernetes namespace
+`ResourceQuota` — which **fails runs terminally** on its 403 rather than holding
+them. Enabling capacity admission adds a `queued` session status, a per-replica
+dispatcher that admits runs oldest-first under a deployment-wide cap, bounded
+queue depth and age, and requeue-with-backoff on the quota 403.
+
+**With `FLUIDBOX_MAX_CONCURRENT_RUNS` unset, none of this is active** and
+behaviour is byte-identical to before the feature existed.
+
+---
+
+## 1. Enable it, in this order
+
+The order is not advisory. It is the same discipline migration 0028 needed.
+
+**① Apply the migration.** `0034_run_queue.sql` is additive — four nullable
+columns plus a partial index — and safe to apply well before you enable
+anything. Migrations run on server boot, so this happens with the first deploy
+of the new image.
+
+**② Roll the new image to EVERY replica.** Do not skip this, and do not
+overlap it with step ③.
+
+`SessionStatus::parse` maps an unrecognised status to `Failed` at the transition
+sites, so **a binary that predates `queued` reads a parked run as terminal**: it
+will not drive it, and its API reports the run failed. If one replica has the
+new image and sets the env while another is still old, the old replica
+misreports every parked run.
+
+The failure mode is bounded — the boot orphan sweep uses a *strict* parse and
+logs "unknown status (newer deploy?)" rather than reaping — so a premature
+rollback leaves **zombie queued rows, not destroyed state**. That is a
+recoverable mistake, not a data-loss one. Still, do the roll first.
+
+**③ Set the cap.** `FLUIDBOX_MAX_CONCURRENT_RUNS` (Helm:
+`server.maxConcurrentRuns`). Boot logs the resolved configuration:
+
+```
+run admission: ENABLED — cap 60 concurrent, queue depth 240, max wait 3600s, 5 capacity retries.
+```
+
+Every replica logs its own line, so `kubectl logs -l app=fluidbox-server | grep
+'run admission'` tells you which replicas have picked the feature up — useful
+mid-roll. A replica that has not logs `run admission: off`.
+
+---
+
+## 2. The four knobs
+
+| Env / Helm value | Default | What it does |
+|---|---|---|
+| `FLUIDBOX_MAX_CONCURRENT_RUNS` / `server.maxConcurrentRuns` | unset = **off** | Deployment-wide cap on sandbox-holding runs. |
+| `FLUIDBOX_QUEUE_MAX_DEPTH` / `server.queueMaxDepth` | `max(4 × cap, 50)` | Depth before new work is shed. |
+| `FLUIDBOX_QUEUE_MAX_WAIT_SECS` / `server.queueMaxWaitSecs` | `3600` | How long a run may wait before failing with an explained reason. |
+| `FLUIDBOX_QUEUE_REQUEUE_MAX` / `server.queueRequeueMax` | `5` | Provider capacity refusals tolerated before a terminal failure. |
+
+The last three are **dead config without the cap**, and the server *refuses to
+boot* rather than ignore them — a silently-ignored depth bound is a
+misconfiguration you would never discover. `just doctor` catches the same thing
+before you deploy. Every value must be an integer ≥ 1; `0` would either admit
+nothing or shed everything.
+
+`FLUIDBOX_QUEUE_MAX_WAIT_SECS` is measured from **first enqueue**, and the
+timestamp is stamped once, so it bounds *total* time in queue across capacity
+bounces. A run that sat in `awaiting_authorization` waiting on a human is not
+charged for that wait — its clock starts when it becomes dispatchable.
+
+---
+
+## 3. Sizing against the Kubernetes quota
+
+**Set both, and keep `maxConcurrentRuns ≤ sandbox.quota.pods`.**
+
+They answer different questions:
+
+- The **app cap** counts *runs* and can **hold** them. Over the cap, a run waits
+  in `queued` and is admitted FIFO.
+- The **namespace quota** counts *pods* — including pods fluidbox did not create
+  (another workload in the namespace, a pod stuck terminating) — and is enforced
+  by the API server for every replica at once. It cannot be bypassed by any code
+  path, which is exactly why it stays as the backstop.
+
+A cap *above* the quota means the quota fires first, and every over-cap run
+takes the slower bounce-and-retry path instead of simply waiting its turn. It
+still works — a quota 403 is now classified as capacity pressure and re-parks
+the run with backoff rather than failing it — but each bounce costs a
+provisioning round trip and 30–300 s of backoff. `just doctor` warns on this
+combination.
+
+Suggested starting point: `maxConcurrentRuns` equal to `quota.pods`, or one
+tier below it if the namespace is shared with anything else.
+
+---
+
+## 4. What to watch
+
+| Metric | Read it as |
+|---|---|
+| `fluidbox_runs_queued_depth` | How deep the queue is right now. Sustained non-zero means the cap is binding. |
+| `fluidbox_queue_oldest_wait_seconds` | How long the head has waited. Climbing toward `MAX_WAIT_SECS` means runs are about to be expired. |
+| `fluidbox_runs_dispatched_total` | Admissions. A redispatched bounce counts again. |
+| `fluidbox_queue_wait_seconds` | Wait distribution, observed at admission. |
+| `fluidbox_queue_shed_total{reason}` | `depth` = refused at create; `age` = expired while waiting; `requeue_exhausted` = bounced past the retry cap. |
+| `fluidbox_queue_requeues_total{reason="capacity"}` | The substrate refused a pod. **Non-zero means the quota is firing** — either the cap is above `quota.pods`, or something outside fluidbox is consuming the namespace. |
+
+Per-run, the answer to "why is my run not running" is on the run itself: the
+timeline carries a `StatusChanged` event with the reason (`parked at admission`,
+`provider at capacity: <verbatim 403>`), and `GET /v1/sessions/{id}` exposes
+`queued_at` plus `queue_position` while the run is queued.
+
+`queue_position` counts older queued runs **in the same organization**. It is a
+*lower bound* on the deployment-wide position, which is deliberately not
+exposed: a deployment-wide number would let a caller infer another
+organization's load by watching it move.
+
+---
+
+## 5. What callers see at the depth bound
+
+| Entry point | Response |
+|---|---|
+| Manual `POST /v1/sessions`, API invoke | **429** with `Retry-After: 30` |
+| Webhook fan-out | **2xx ack** with a recorded skip, reason `capacity` |
+| Schedule tick | Recorded skip, reason `capacity`; the next cron fire retries |
+
+Webhook and schedule shedding is deliberately **not** a 5xx. A 5xx asks the
+provider to redeliver, turning one shed event into many requests at exactly the
+moment the deployment is least able to take them.
+
+The cost is disclosed: **a shed PR event does not self-heal.** The review run
+does not happen, and only the skip row records it. If you see
+`queue_shed_total{reason="depth"}` climbing, raise the depth bound or the cap —
+depth shedding should be rare.
+
+---
+
+## 6. Rolling back
+
+**Drain first, then roll back.** The reverse order leaves parked runs that the
+old binary reads as failed.
+
+1. **Unset `FLUIDBOX_MAX_CONCURRENT_RUNS` on all replicas.** New runs revert to
+   launching on creation immediately.
+2. **Let the queue drain.** The dispatcher stops with the env, so already-queued
+   runs will *not* drain on their own — cancel them via the API
+   (`POST /v1/sessions/{id}/cancel`), or re-enable the cap briefly and let them
+   through before unsetting again.
+3. **Verify zero parked runs:**
+   ```sql
+   select count(*) from sessions where status = 'queued';
+   ```
+4. **Roll the old image.**
+
+Migration 0034 does not need reverting: with the env unset the four columns are
+simply never written, and `stale_nonstarted_sessions`' `coalesce(launched_at,
+created_at)` degrades to the pre-0034 behaviour for any row that carries no
+stamp.
+
+---
+
+## 7. Known limits (stage 1)
+
+- **No per-tenant fairness.** The queue is a single deployment-wide FIFO, so one
+  organization can fill it and others wait behind. Accepted while the pilot is
+  single-tenant; per-tenant ceilings plus round-robin ship when a second
+  organization onboards (design §11, stage 2).
+- **No priorities and no preemption**, ever by design: killing a running agent
+  destroys spent model budget and truncates an audit timeline.
+- **Docker classifies nothing as capacity.** Local exhaustion has no clean
+  signal, so a Docker provisioning failure stays terminal. Only the Kubernetes
+  provider maps the quota 403 and apiserver 429.
+- **Admission latency is up to ~1 s** (the dispatcher polls; there is no NOTIFY
+  wakeup). Invisible next to provisioning latency.
+- **FIFO is near-FIFO.** `for update skip locked` may reorder around contended
+  rows. Ordering is by `created_at` and is not a guarantee.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -420,6 +420,59 @@ case "$web_mode" in
       "must be \"admin\" or \"sso\" (or unset for the local admin default) — the dashboard proxy refuses to boot on any other value";;
 esac
 
+say "run admission (queueing)"
+# The four queue knobs, checked the way the server checks them — so an operator
+# learns about a bad value here rather than from a refused boot. The cap is the
+# feature switch; the other three are DEAD CONFIG without it, which the server
+# treats as a boot failure rather than silently ignoring.
+q_cap=$(env_get "$ENV" FLUIDBOX_MAX_CONCURRENT_RUNS)
+q_depth=$(env_get "$ENV" FLUIDBOX_QUEUE_MAX_DEPTH)
+q_wait=$(env_get "$ENV" FLUIDBOX_QUEUE_MAX_WAIT_SECS)
+q_requeue=$(env_get "$ENV" FLUIDBOX_QUEUE_REQUEUE_MAX)
+
+positive_int() { case "$1" in ''|*[!0-9]*) return 1;; *) [ "$1" -ge 1 ];; esac; }
+
+if [ -z "$q_cap" ]; then
+  orphans=""
+  [ -n "$q_depth" ]   && orphans="$orphans FLUIDBOX_QUEUE_MAX_DEPTH"
+  [ -n "$q_wait" ]    && orphans="$orphans FLUIDBOX_QUEUE_MAX_WAIT_SECS"
+  [ -n "$q_requeue" ] && orphans="$orphans FLUIDBOX_QUEUE_REQUEUE_MAX"
+  if [ -n "$orphans" ]; then
+    bad "queue knob(s) set without FLUIDBOX_MAX_CONCURRENT_RUNS:$orphans" \
+      "dead config — the server REFUSES TO BOOT rather than ignore them. Set FLUIDBOX_MAX_CONCURRENT_RUNS to enable the queue, or unset these."
+  else
+    ok "run admission off (FLUIDBOX_MAX_CONCURRENT_RUNS unset) — runs launch on creation"
+  fi
+else
+  if positive_int "$q_cap"; then
+    ok "FLUIDBOX_MAX_CONCURRENT_RUNS=$q_cap (runs above the cap wait in a FIFO queue)"
+  else
+    bad "FLUIDBOX_MAX_CONCURRENT_RUNS='$q_cap' is not an integer >= 1" \
+      "the server refuses to boot: 0 or negative admits no work at all, which would wedge every run"
+  fi
+  for pair in "FLUIDBOX_QUEUE_MAX_DEPTH:$q_depth" "FLUIDBOX_QUEUE_MAX_WAIT_SECS:$q_wait" "FLUIDBOX_QUEUE_REQUEUE_MAX:$q_requeue"; do
+    name=${pair%%:*}; val=${pair#*:}
+    if [ -n "$val" ] && ! positive_int "$val"; then
+      bad "$name='$val' is not an integer >= 1" "the server refuses to boot naming this variable"
+    fi
+  done
+  # Benign but a reliable sign of operator confusion: a queue wait longer than
+  # the session-token TTL. It is harmless — a redispatch mints fresh tokens —
+  # but someone who set it that high usually meant hours of RUNTIME, not hours
+  # of waiting.
+  if [ -n "$q_wait" ] && positive_int "$q_wait" && [ "$q_wait" -ge 10800 ]; then
+    warn "FLUIDBOX_QUEUE_MAX_WAIT_SECS=$q_wait is at or past the 3h session-token TTL" \
+      "harmless (a redispatch re-mints tokens) but usually a mix-up between how long a run may WAIT and how long it may RUN"
+  fi
+  # The misconfiguration that makes every over-cap run take the slow
+  # bounce-and-retry path instead of simply waiting its turn.
+  quota_pods=$(grep -A 6 '^  quota:' deploy/helm/fluidbox/values.yaml 2>/dev/null | grep -m1 '    pods:' | tr -d ' "' | cut -d: -f2)
+  if [ -n "$quota_pods" ] && positive_int "$q_cap" && positive_int "$quota_pods" && [ "$q_cap" -gt "$quota_pods" ]; then
+    warn "FLUIDBOX_MAX_CONCURRENT_RUNS=$q_cap exceeds the chart's sandbox.quota.pods=$quota_pods" \
+      "on Kubernetes the namespace quota would fire first, so over-cap runs bounce with backoff instead of queueing. Keep the cap <= quota.pods (values.yaml explains both)."
+  fi
+fi
+
 say "control plane"
 if curl -fsS -m 2 "http://127.0.0.1:8787/v1/health" >/dev/null 2>&1; then
   ok "server responding on :8787 (note: just e2e needs this port free — stop just dev first)"


### PR DESCRIPTION
Plan Task 11 · design §6, §8, §13 · **Closes #162** · depends on #156, #157 (both merged)

Everything an operator touches: the chart, `just doctor`, the API docs, the dashboard chip, and a runbook.

## Verified

| Check | Result |
|---|---|
| `helm template` with the values **unset** | zero `FLUIDBOX_QUEUE*` / `FLUIDBOX_MAX_CONCURRENT_RUNS` lines — the chart renders byte-identically |
| `helm template --set server.maxConcurrentRuns=60 --set server.queueMaxDepth=200` | both envs rendered |
| `helm lint` | 0 charts failed |
| `bash scripts/doctor.sh` | clean on the local `.env`; **all five branches** exercised against synthetic env files (off / healthy / orphan-knob / junk value / over-quota + long wait) |
| `npx vitest run app/lib/activity.test.ts` | **15 passed** |
| `cargo clippy --workspace --all-targets -- -D warnings` + `cargo fmt --all --check` | clean |

## Three review notes

### 1. The sandbox-quota comment had to be rewritten because this epic makes it false

It said, in `values.yaml`:

> This is the ONLY admission gate on concurrent runs — there is deliberately no application-side counter (an earlier revision of this comment claimed one; it never existed).

There is one now. Leaving that in place would have been a documented lie in the most load-bearing comment in the chart. The replacement explains that the two gates answer **different** questions — the app cap counts *runs* and can *hold* them; the quota counts *pods*, including ones fluidbox did not create, and is enforced by the API server for every replica at once — and instructs setting **both** with `maxConcurrentRuns ≤ quota.pods`, because a cap above the quota makes every over-cap run take the slower bounce-and-retry path instead of simply waiting its turn.

### 2. The dashboard change is a *recorded* classification, not a behaviour change

`queued` already resolved to `"live"` via the unknown-status fallback, and the base `.pill` is already neutral, so nothing renders differently. What changed is that the classification is now **deliberate** — the difference between "we decided" and "we never heard of it".

The test says why it must not join the attention chip: unlike `awaiting_authorization`, **no human decision is outstanding**. Filling the attention chip with runs nobody can act on trains operators to ignore the one chip that should always mean "someone is blocked on you". The CSS gets a comment saying `queued` needs no rule and must not be given the amber that means a human is being waited on.

### 3. Doctor covers the boot refusals, so an operator learns before deploying

The server *refuses to boot* on an orphan queue knob or a non-integer value. Doctor now reproduces both checks, so that is caught in the terminal rather than in a CrashLoopBackOff. It also warns on the two configurations that are legal but usually mistakes: a queue wait past the 3 h session-token TTL (benign — a redispatch re-mints — but usually a mix-up between how long a run may *wait* and how long it may *run*), and a cap exceeding the chart's `quota.pods`.

Sample of the branches, run against synthetic env files:

```
### orphan-knob
  FAIL queue knob(s) set without FLUIDBOX_MAX_CONCURRENT_RUNS: FLUIDBOX_QUEUE_MAX_DEPTH
### cap-zero
  FAIL FLUIDBOX_MAX_CONCURRENT_RUNS='0' is not an integer >= 1
### long-wait+over-quota
  WARN FLUIDBOX_QUEUE_MAX_WAIT_SECS=20000 is at or past the 3h session-token TTL
  WARN FLUIDBOX_MAX_CONCURRENT_RUNS=100 exceeds the chart's sandbox.quota.pods=20
```

## The runbook

`docs/hosted/run-queue-operations.md`, indexed from the hosted README: the migrate → roll-every-replica → enable order **and why it is not advisory** (an old binary reads `queued` as terminal; the failure mode is zombie rows, not destroyed state, because the boot sweep's strict parse leaves unknown statuses alone), the four knobs, sizing against the quota, what each metric means, what callers see at the depth bound, the **drain-first** rollback, and stage-1's known limits stated plainly — no per-tenant fairness, no preemption ever, Docker classifies nothing, ~1 s admission latency, near-FIFO not FIFO.