### PR TITLE
feat(test): feature-gated NullProvider + hermetic queue-admission e2e

### DIFF
--- a/crates/fluidbox-core/src/state.rs
+++ b/crates/fluidbox-core/src/state.rs
@@ -151,11 +151,34 @@ impl SessionStatus {
                 | (Created, Queued)
                 | (AwaitingAuthorization, Queued)
                 | (Queued, Provisioning)
-                // The one backward edge besides `AwaitingApproval → Running`:
-                // the substrate refused for capacity (a namespace quota 403),
-                // which means the run is healthy and the world is full, so it
-                // re-parks with backoff instead of failing (design §7.4).
+                // The capacity-bounce back-edges: the substrate refused for
+                // capacity (a namespace quota 403), which means the run is
+                // healthy and the world is full, so it re-parks with backoff
+                // instead of failing (design §7.4).
+                //
+                // TWO source states, and `Initializing` is the one that
+                // actually fires. The design's state diagram said
+                // `provisioning → queued`, but `run()` transitions to
+                // `initializing` BEFORE it materializes the workspace and
+                // calls `provision()` — so a capacity denial is raised while
+                // the session reads `initializing`. With only the
+                // `Provisioning` edge the re-park was refused and the run
+                // stranded in `initializing` with revoked tokens until the
+                // stale-launch watchdog reaped it (found by the hermetic queue
+                // e2e; unit tests could not see it because every piece was
+                // individually correct).
+                //
+                // `Provisioning` is KEPT even though nothing reaches it today:
+                // `run()` can bail between the two transitions, and a capacity
+                // denial must never strand a run, so a future reordering of the
+                // launch sequence must not silently reintroduce that bug.
+                //
+                // Neither edge can leak a sandbox. Both are reachable ONLY from
+                // the requeue path, which runs when `provision` returned an
+                // ERROR — so no sandbox exists to leave behind. Nothing else
+                // may use them.
                 | (Provisioning, Queued)
+                | (Initializing, Queued)
                 | (Provisioning, Initializing)
                 | (Initializing, Running)
                 | (Running, AwaitingApproval)
@@ -317,9 +340,18 @@ mod tests {
         // The ONE backward edge besides AwaitingApproval->Running: a provider
         // CapacityDenied re-parks the run (design 2026-08-23 section 7.4).
         assert!(Provisioning.can_transition_to(Queued));
-        // No other state may re-enter the queue.
+        // `Initializing` re-parks too, and it is the edge that actually
+        // fires: `run()` enters `initializing` BEFORE it materializes the
+        // workspace and calls `provision()`, so a capacity denial is raised
+        // while the session reads `initializing`, not `provisioning`. The
+        // design's diagram had this wrong and the hermetic queue e2e caught
+        // it — without this edge a bounced run is stranded in `initializing`
+        // with revoked tokens until the stale-launch watchdog reaps it.
+        assert!(Initializing.can_transition_to(Queued));
+        // A run whose agent is live has a sandbox: re-parking it would leak
+        // one, so there is no edge back from here.
         assert!(!Running.can_transition_to(Queued));
-        assert!(!Initializing.can_transition_to(Queued));
+        assert!(!AwaitingApproval.can_transition_to(Queued));
         // Parked = no sandbox, no tokens, no work.
         assert!(!Queued.accepts_work());
         assert!(!Queued.is_terminal());

--- a/crates/fluidbox-provider/Cargo.toml
+++ b/crates/fluidbox-provider/Cargo.toml
@@ -4,6 +4,12 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# The NullProvider (design 2026-08-23 §12): a provider that provisions nothing,
+# for exercising admission and lifecycle without containers or model spend. OFF
+# by default so a release build physically lacks it.
+test-provider = []
+
 [dependencies]
 fluidbox-core.workspace = true
 fluidbox-workspace.workspace = true

--- a/crates/fluidbox-provider/src/lib.rs
+++ b/crates/fluidbox-provider/src/lib.rs
@@ -9,6 +9,13 @@
 //! /workspace. Diff collection runs against the PRISTINE baseline via the
 //! shared `fluidbox-workspace` engine — never against the agent's `.git`.
 
+/// The queue/lifecycle test double (design 2026-08-23 §12). Feature-gated so a
+/// release build cannot select it — see [`null`] for why that matters.
+#[cfg(feature = "test-provider")]
+pub mod null;
+#[cfg(feature = "test-provider")]
+pub use null::NullProvider;
+
 use async_trait::async_trait;
 use bollard::models::{ContainerCreateBody, HostConfig, NetworkCreateRequest};
 use bollard::query_parameters::{

--- a/crates/fluidbox-provider/src/null.rs
+++ b/crates/fluidbox-provider/src/null.rs
@@ -1,0 +1,138 @@
+//! A provider that provisions NOTHING — the queue/lifecycle test double
+//! (run admission design 2026-08-23 §12).
+//!
+//! Feature-gated behind `test-provider` so a RELEASE build cannot select it:
+//! `FLUIDBOX_PROVIDER=null` on a production binary stays an unknown-provider
+//! boot error, because the arm that would accept it does not exist there.
+//!
+//! What it is for: proving admission, dispatch, backoff and expiry over real
+//! HTTP against a real database, with zero containers and zero model spend.
+//! The queue is entirely a control-plane concern — nothing about admission
+//! depends on what a sandbox does once it exists — so a provider that returns
+//! a synthetic handle instantly exercises every path the real ones take up to
+//! and including `provision`.
+//!
+//! What it is NOT for: anything that reads a sandbox's behaviour. It never
+//! runs an agent, never produces a diff, and never dies on its own.
+
+use async_trait::async_trait;
+use fluidbox_core::traits::{
+    CollectContext, CollectedArtifacts, ExecutionProvider, ProviderError, SandboxHandle,
+    SandboxSpec, SandboxStatus,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use uuid::Uuid;
+
+/// The synthetic handle. Shaped exactly like `DockerProvider::provision`'s —
+/// `runtime` names the backend, `external_id` is the substrate's id, `attrs`
+/// carries whatever that backend needs to reattach — so nothing downstream can
+/// tell it apart structurally from a real one.
+fn null_handle(session_id: Uuid) -> SandboxHandle {
+    SandboxHandle {
+        runtime: "null".to_string(),
+        external_id: format!("null-{session_id}"),
+        attrs: serde_json::json!({ "session": session_id }),
+    }
+}
+
+pub struct NullProvider {
+    /// How many more provisions answer `CapacityDenied`
+    /// (`FLUIDBOX_NULL_CAPACITY_DENIALS`). This is the lever the bounce test
+    /// pulls: it makes a substrate quota refusal reproducible without a
+    /// Kubernetes cluster or a ResourceQuota.
+    deny_remaining: AtomicUsize,
+}
+
+impl NullProvider {
+    pub fn from_env() -> Self {
+        let n = std::env::var("FLUIDBOX_NULL_CAPACITY_DENIALS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        // Say it at boot: a test double whose injection knob silently read as
+        // zero would make a bounce test pass for the wrong reason.
+        tracing::info!("null provider: {n} injected capacity denial(s) armed");
+        Self {
+            deny_remaining: AtomicUsize::new(n),
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionProvider for NullProvider {
+    async fn provision(&self, spec: &SandboxSpec) -> Result<SandboxHandle, ProviderError> {
+        // `fetch_update` returning Err means `checked_sub` saturated at zero,
+        // i.e. no denials remain. Doing it as one atomic update rather than a
+        // load-then-store keeps the count exact under the concurrent
+        // provisions a cap above 1 produces.
+        if self
+            .deny_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+            .is_ok()
+        {
+            return Err(ProviderError::CapacityDenied(
+                "null provider: injected quota denial".into(),
+            ));
+        }
+        Ok(null_handle(spec.session_id))
+    }
+
+    /// Never dies on its own — tests drive terminal states through the API
+    /// (cancel) or the queue's own sweepers, so nothing races them.
+    async fn state(&self, _handle: &SandboxHandle) -> Result<SandboxStatus, ProviderError> {
+        Ok(SandboxStatus::Running)
+    }
+
+    /// Collection RAN and found nothing, which is materially different from
+    /// `Missing`: the finalizer treats a missing collection as something to
+    /// explain in the timeline, and a run that never had an agent has nothing
+    /// to explain.
+    async fn collect_artifacts(
+        &self,
+        _handle: Option<&SandboxHandle>,
+        _ctx: &CollectContext,
+    ) -> Result<CollectedArtifacts, ProviderError> {
+        Ok(CollectedArtifacts::Collected(vec![]))
+    }
+
+    async fn terminate(&self, _handle: &SandboxHandle) -> Result<(), ProviderError> {
+        Ok(())
+    }
+
+    /// Nothing to reconcile: no sandbox outlives the process, so the boot
+    /// orphan sweep and the periodic reconciler both correctly find nothing.
+    async fn list_managed(&self) -> Result<Vec<(Uuid, SandboxHandle)>, ProviderError> {
+        Ok(vec![])
+    }
+
+    async fn healthcheck(&self) -> Result<(), ProviderError> {
+        Ok(())
+    }
+
+    fn runtime_name(&self) -> &'static str {
+        "null"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_denial_counter_is_exhaustible_and_saturates() {
+        let p = NullProvider {
+            deny_remaining: AtomicUsize::new(2),
+        };
+        // Two denials, then handles forever — the shape the bounce test needs:
+        // a run that is refused, backs off, and eventually gets in.
+        let take = || {
+            p.deny_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                .is_ok()
+        };
+        assert!(take());
+        assert!(take());
+        assert!(!take());
+        assert!(!take(), "saturates at zero rather than wrapping");
+    }
+}

--- a/crates/fluidbox-server/Cargo.toml
+++ b/crates/fluidbox-server/Cargo.toml
@@ -4,6 +4,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# Compiles the NullProvider into the binary and adds the `null` arm to
+# `build_provider`. Test-only: without it, `FLUIDBOX_PROVIDER=null` is an
+# unknown-provider boot error, so a release build cannot be talked into
+# running a provider that provisions nothing.
+test-provider = ["fluidbox-provider/test-provider"]
+
 [dependencies]
 fluidbox-core.workspace = true
 fluidbox-db.workspace = true

--- a/crates/fluidbox-server/src/main.rs
+++ b/crates/fluidbox-server/src/main.rs
@@ -79,6 +79,12 @@ async fn build_provider(cfg: &config::Config) -> anyhow::Result<Arc<dyn Executio
                 .await?,
             ))
         }
+        // Test-only (design 2026-08-23 §12), and gated at COMPILE time rather
+        // than by a runtime flag: on a release build this arm does not exist,
+        // so `FLUIDBOX_PROVIDER=null` falls through to the error below and the
+        // binary cannot be talked into provisioning nothing.
+        #[cfg(feature = "test-provider")]
+        "null" => Ok(Arc::new(fluidbox_provider::NullProvider::from_env())),
         other => anyhow::bail!(
             "FLUIDBOX_PROVIDER='{other}' is not available in this build (known: docker, kubernetes)"
         ),

--- a/scripts/e2e-queue.sh
+++ b/scripts/e2e-queue.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Hermetic queue-admission E2E (run admission design 2026-08-23 §12, layer 3).
+#
+# Real HTTP, real Postgres, real dispatcher — and ZERO sandboxes, ZERO model
+# spend, ZERO keys. FLUIDBOX_PROVIDER=null (feature-gated, see
+# crates/fluidbox-provider/src/null.rs) provisions a synthetic handle instantly,
+# which is enough because admission is entirely a control-plane concern:
+# nothing about the queue depends on what a sandbox does once it exists.
+#
+# SELF-ISOLATED BY CONSTRUCTION, which is what makes this the one e2e safe to
+# run unprompted:
+#   * its own database (fluidbox_queue_e2e), dropped and recreated per run
+#   * its own ports (18791 / 18792), away from the dev stack's 8787/8788
+#   * its own data dir (mktemp), removed on exit
+# The only credential here is a DUMMY LiteLLM key. Boot fails closed on an empty
+# upstream key ("there is no silent fallback"), and that refusal is exactly what
+# proves the isolation works — the real key is no longer reachable. It is never
+# used: the null provider starts no agent, so no model request can be made.
+#
+#   * it never sources .env, AND it runs the server from a scratch directory —
+#     because the SERVER calls dotenvy::dotenv() itself (main.rs), so a server
+#     started with the repo root as its cwd would read the operator's real .env
+#     no matter what the script does. Running it elsewhere is what actually
+#     isolates it: no live Neon URL, no real provider key, no GitHub App secret.
+#
+# Phases:
+#   P1  cap=1 FIFO: three runs, one admitted, two parked; cancel releases the
+#       next in creation order; queue_position reports the wait
+#   P2  depth bound: a full queue answers 429 + Retry-After
+#   P3  capacity bounce: an injected provider denial re-parks with backoff
+#       instead of failing the run
+#   P4  age expiry: a run that waits past the bound fails with an explained
+#       reason, and its ledger says so
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PGBASE=${PGBASE:-postgres://fluidbox:fluidbox@127.0.0.1:5433}
+DB=fluidbox_queue_e2e
+PORT=18791
+INTERNAL_PORT=18792
+API="http://127.0.0.1:$PORT"
+TOKEN=queue-e2e-token
+H="authorization: Bearer $TOKEN"
+
+pass=0; fail=0
+ok()  { printf "  \033[1;32m✓\033[0m %s\n" "$1"; pass=$((pass+1)); }
+no()  { printf "  \033[1;31m✗\033[0m %s\n" "$1"; fail=$((fail+1)); }
+say() { printf "\n\033[1;36m== %s ==\033[0m\n" "$1"; }
+
+j() { python3 -c "import sys,json;d=json.load(sys.stdin);print(d$1)" 2>/dev/null; }
+# Trim the ends only: `tr -d ' '` would mangle the text columns these
+# assertions read (a status_reason is a sentence, not a token).
+q() { psql "$PGBASE/$DB" -tAc "$1" 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'; }
+
+DATA_DIR=$(mktemp -d)
+# Absolute, because the server is started from DATA_DIR (see start_server).
+BIN="$PWD/target/debug/fluidbox-server"
+SRV=""
+cleanup() {
+  [ -n "$SRV" ] && kill "$SRV" 2>/dev/null
+  wait "$SRV" 2>/dev/null
+  rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
+
+# Start the server with the queue knobs this phase needs. Every invocation gets
+# a fresh process, because the knobs are read once at boot.
+start_server() { # env assignments as "K=V" args
+  [ -n "$SRV" ] && { kill "$SRV" 2>/dev/null; wait "$SRV" 2>/dev/null; SRV=""; }
+  # `cd "$DATA_DIR"` is load-bearing, not tidiness: the server calls
+  # dotenvy::dotenv(), which reads `.env` FROM THE WORKING DIRECTORY. Started at
+  # the repo root it would inherit the operator's real keys and settings, and
+  # this suite would stop being hermetic. The scratch dir has no `.env`, so the
+  # only configuration is what `env -i` passes below.
+  (
+    cd "$DATA_DIR" || exit 1
+    exec env -i \
+      PATH="$PATH" HOME="$HOME" \
+      DATABASE_URL="$PGBASE/$DB" \
+      FLUIDBOX_BIND="127.0.0.1:$PORT" \
+      FLUIDBOX_INTERNAL_BIND="127.0.0.1:$INTERNAL_PORT" \
+      FLUIDBOX_ADMIN_TOKEN="$TOKEN" \
+      FLUIDBOX_PROVIDER=null \
+      FLUIDBOX_DATA_DIR="$DATA_DIR" \
+      LITELLM_MASTER_KEY=queue-e2e-unused-no-model-call-is-possible \
+      "$@" \
+      "$BIN"
+  ) >"$DATA_DIR/server.log" 2>&1 &
+  SRV=$!
+  for _ in $(seq 1 60); do
+    curl -fsS -m 2 "$API/v1/health" >/dev/null 2>&1 && return 0
+    kill -0 "$SRV" 2>/dev/null || { echo "server died:"; tail -20 "$DATA_DIR/server.log"; return 1; }
+    sleep 0.5
+  done
+  echo "server never became healthy:"; tail -20 "$DATA_DIR/server.log"; return 1
+}
+
+new_run() { # task -> session_id (empty on non-2xx; the body lands in last.json)
+  curl -s -X POST -H "$H" -H 'content-type: application/json' \
+    -d "{\"agent\":\"$AGENT\",\"task\":\"$1\",\"repo\":{\"kind\":\"none\"}}" \
+    "$API/v1/sessions" > "$DATA_DIR/last.json"
+  j "['session']['id']" < "$DATA_DIR/last.json"
+}
+
+# The agent every phase runs. Seeded at boot when the deployment has none;
+# resolved (not assumed) so a seed-name change fails here with a clear message
+# rather than as an empty session id three assertions later.
+resolve_agent() {
+  curl -s -H "$H" "$API/v1/agents" > "$DATA_DIR/agents.json"
+  AGENT=$(python3 -c \
+    "import sys,json;a=json.load(sys.stdin).get('agents') or [];print(a[0]['name'] if a else '')" \
+    < "$DATA_DIR/agents.json" 2>/dev/null)
+  [ -n "$AGENT" ] || echo "    agents list: $(cat "$DATA_DIR/agents.json")"
+}
+
+status_of() { q "select status from sessions where id = '$1'"; }
+
+# Poll until a session leaves 'queued' (or the deadline passes).
+await_status() { # session_id, wanted-regex, seconds
+  local deadline=$(( $(date +%s) + $3 )) s
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    s=$(status_of "$1")
+    [[ "$s" =~ $2 ]] && { echo "$s"; return 0; }
+    sleep 0.5
+  done
+  echo "$(status_of "$1")"; return 1
+}
+
+# A phase that begins with leftover rows is not testing what it says. Deleting
+# from `sessions` is not enough — the child tables make it a cascade question —
+# and a silently-failing delete is exactly how a phase ends up asserting against
+# the previous phase's queue (observed while writing this: P2's leftovers
+# consumed P3's injected provider denial). Recreating the database is
+# unambiguous, and the next boot re-migrates and re-seeds it.
+reset_db() {
+  [ -n "$SRV" ] && { kill "$SRV" 2>/dev/null; wait "$SRV" 2>/dev/null; SRV=""; }
+  psql "$PGBASE/postgres" -c "drop database if exists $DB with (force)" >/dev/null 2>&1 \
+    || { echo "cannot reach Postgres at $PGBASE — start it with: docker compose -f deploy/docker-compose.dev.yml up -d postgres"; return 1; }
+  psql "$PGBASE/postgres" -c "create database $DB" >/dev/null
+}
+
+say "setup"
+reset_db || exit 1
+ok "throwaway database $DB created"
+cargo build -q -p fluidbox-server --features test-provider || { no "build"; exit 1; }
+ok "server built with the test-provider feature (NullProvider available)"
+
+# ── P1 ─────────────────────────────────────────────────────────────────────
+say "P1 — cap 1: one runs, the rest queue FIFO"
+start_server FLUIDBOX_MAX_CONCURRENT_RUNS=1 FLUIDBOX_QUEUE_MAX_DEPTH=50 || exit 1
+grep -q "run admission: ENABLED" "$DATA_DIR/server.log" \
+  && ok "boot announces admission is enabled" || no "boot did not announce admission"
+resolve_agent
+[ -n "$AGENT" ] && ok "agent '$AGENT' available" || no "no agent could be resolved or created"
+
+A=$(new_run "queue A"); sleep 0.3
+B=$(new_run "queue B"); sleep 0.3
+C=$(new_run "queue C")
+[ -n "$A" ] && [ -n "$B" ] && [ -n "$C" ] || {
+  no "three runs created (A=$A B=$B C=$C)"
+  echo "    last create response: $(cat "$DATA_DIR/last.json" 2>/dev/null)"
+  echo "    server log:"; tail -15 "$DATA_DIR/server.log" | sed 's/^/      /'
+  exit 1
+}
+ok "three runs created under cap 1"
+
+SA=$(await_status "$A" '^(provisioning|initializing|running)$' 20)
+[[ "$SA" =~ ^(provisioning|initializing|running)$ ]] \
+  && ok "A was admitted (status $SA)" || no "A never left the queue (status $SA)"
+[ "$(status_of "$B")" = queued ] && ok "B is parked in 'queued'" || no "B status: $(status_of "$B")"
+[ "$(status_of "$C")" = queued ] && ok "C is parked in 'queued'" || no "C status: $(status_of "$C")"
+
+# The park is auditable through the existing ledger funnel — zero new event
+# types was a design goal, so prove the StatusChanged carries the reason.
+REASON=$(q "select status_reason from sessions where id = '$B'")
+[[ "$REASON" == *"capacity slot"* ]] \
+  && ok "B's status_reason explains the park: $REASON" || no "B reason: $REASON"
+[ -n "$(q "select queued_at from sessions where id = '$B'")" ] \
+  && ok "B carries queued_at (the wait clock)" || no "B has no queued_at"
+
+# queue_position (design §13): B is next, C is behind it.
+POS_B=$(curl -s -H "$H" "$API/v1/sessions/$B" | j "['queue_position']")
+POS_C=$(curl -s -H "$H" "$API/v1/sessions/$C" | j "['queue_position']")
+[ "$POS_B" = 0 ] && ok "B reports queue_position 0 (next up)" || no "B position: $POS_B"
+[ "$POS_C" = 1 ] && ok "C reports queue_position 1 (behind B)" || no "C position: $POS_C"
+
+# Cancelling A frees the slot; B goes next because FIFO orders by created_at.
+curl -s -o /dev/null -X POST -H "$H" "$API/v1/sessions/$A/cancel"
+SB=$(await_status "$B" '^(provisioning|initializing|running)$' 40)
+[[ "$SB" =~ ^(provisioning|initializing|running)$ ]] \
+  && ok "cancelling A admitted B next (FIFO, status $SB)" || no "B never dispatched (status $SB)"
+[ "$(status_of "$C")" = queued ] && ok "C still waits (the cap is still 1)" || no "C: $(status_of "$C")"
+
+curl -s -o /dev/null -X POST -H "$H" "$API/v1/sessions/$B/cancel"
+SC=$(await_status "$C" '^(provisioning|initializing|running)$' 40)
+[[ "$SC" =~ ^(provisioning|initializing|running)$ ]] \
+  && ok "cancelling B admitted C (status $SC)" || no "C never dispatched (status $SC)"
+curl -s -o /dev/null -X POST -H "$H" "$API/v1/sessions/$C/cancel"
+
+# ── P2 ─────────────────────────────────────────────────────────────────────
+say "P2 — depth bound: a full queue sheds with 429 + Retry-After"
+reset_db || exit 1
+start_server FLUIDBOX_MAX_CONCURRENT_RUNS=1 FLUIDBOX_QUEUE_MAX_DEPTH=3 || exit 1
+resolve_agent
+# Fill deterministically. The naive version — create four back to back and
+# hope — RACES the dispatcher: while the first run is still `queued` it counts
+# toward depth, so the fourth create is shed at the bound and the queue settles
+# at two once the first is admitted. (That race is itself the depth bound
+# working; it just makes the phase assert the wrong number.) So: put one run in
+# the SLOT first, wait until it has actually left the queue, and only then add
+# exactly `bound` runs to fill it.
+HOLD=$(new_run "holds the slot")
+await_status "$HOLD" '^(provisioning|initializing|running)$' 30 >/dev/null \
+  && ok "one run occupies the single slot" || no "the holder never dispatched"
+for i in 1 2 3; do new_run "depth $i" >/dev/null; done
+for _ in $(seq 1 40); do
+  [ "$(q "select count(*) from sessions where status = 'queued'")" -ge 3 ] && break
+  sleep 0.5
+done
+DEPTH=$(q "select count(*) from sessions where status = 'queued'")
+[ "$DEPTH" -eq 3 ] && ok "queue filled to its depth bound (3)" || no "queue depth: $DEPTH"
+
+RESP=$(curl -s -i -X POST -H "$H" -H 'content-type: application/json' \
+  -d '{"agent":"claude-fixer","task":"over the bound","repo":{"kind":"none"}}' \
+  "$API/v1/sessions")
+echo "$RESP" | head -1 | grep -q " 429 " \
+  && ok "a create past the bound answers 429" || no "expected 429, got: $(echo "$RESP" | head -1)"
+echo "$RESP" | grep -qi "^retry-after: *30" \
+  && ok "…with Retry-After: 30" || no "no Retry-After header"
+echo "$RESP" | grep -qi "at capacity" \
+  && ok "…and the house error envelope names the reason" || no "unexpected body"
+
+# The shed must not have created anything.
+BEFORE=$(q "select count(*) from sessions")
+curl -s -o /dev/null -X POST -H "$H" -H 'content-type: application/json' \
+  -d '{"agent":"claude-fixer","task":"shed again","repo":{"kind":"none"}}' "$API/v1/sessions"
+[ "$(q "select count(*) from sessions")" = "$BEFORE" ] \
+  && ok "a shed create writes no session row" || no "a shed create created a row"
+
+# ── P3 ─────────────────────────────────────────────────────────────────────
+say "P3 — capacity bounce: a provider denial re-parks instead of failing"
+reset_db || exit 1
+start_server FLUIDBOX_MAX_CONCURRENT_RUNS=2 FLUIDBOX_QUEUE_MAX_DEPTH=50 \
+  FLUIDBOX_NULL_CAPACITY_DENIALS=1 || exit 1
+resolve_agent
+grep -q "null provider: 1 injected capacity denial" "$DATA_DIR/server.log" \
+  && ok "the provider armed exactly one injected denial" \
+  || no "denial injection did not arm: $(grep -o 'null provider:.*' "$DATA_DIR/server.log" | head -1)"
+D=$(new_run "bounced run")
+[ -n "$D" ] && ok "run created against a provider that will refuse once" || no "create failed"
+
+# The dispatcher admits it, the provider refuses, and it comes BACK to queued
+# with a backoff gate — the whole point: capacity pressure is not a failure.
+BOUNCED=0
+for _ in $(seq 1 60); do
+  if [ "$(q "select dispatch_attempts from sessions where id = '$D'")" -ge 1 ] \
+     && [ "$(status_of "$D")" = queued ] \
+     && [ -n "$(q "select dispatch_after from sessions where id = '$D'")" ]; then
+    BOUNCED=1; break
+  fi
+  sleep 0.5
+done
+if [ "$BOUNCED" = 1 ]; then
+  ok "the refused run is back in 'queued' with a backoff gate"
+else
+  no "no bounce observed (status $(status_of "$D"), attempts $(q "select dispatch_attempts from sessions where id = '$D'"), after '$(q "select dispatch_after from sessions where id = '$D'")')"
+  echo "    all sessions: $(q "select id||' '||status||' a='||dispatch_attempts||' handle='||coalesce(sandbox_handle::text,'NULL') from sessions")"
+  echo "    server log tail:"
+  tail -25 "$DATA_DIR/server.log" | sed 's/^/      /'
+fi
+[ "$(status_of "$D")" != failed ] \
+  && ok "…and the run did NOT fail (this is the headline behaviour change)" || no "the run failed"
+BR=$(q "select status_reason from sessions where id = '$D'")
+[[ "$BR" == *"provider at capacity"* ]] \
+  && ok "…with the verbatim provider message in the ledger reason: $BR" || no "bounce reason: $BR"
+GATE=$(q "select extract(epoch from (dispatch_after - now()))::int from sessions where id = '$D'")
+[ -n "$GATE" ] && [ "$GATE" -gt 20 ] \
+  && ok "the backoff gate clears the lease TTL (${GATE}s out)" || no "backoff gate: ${GATE}s"
+# The bounced attempt must not leave live credentials behind.
+[ "$(q "select count(*) from api_tokens where session_id = '$D' and revoked_at is null")" = 0 ] \
+  && ok "the bounced attempt's session tokens were revoked" \
+  || no "live tokens survived the bounce: $(q "select count(*) from api_tokens where session_id = '$D' and revoked_at is null")"
+
+# ── P4 ─────────────────────────────────────────────────────────────────────
+say "P4 — age bound: a run that waits too long fails with an explained reason"
+reset_db || exit 1
+start_server FLUIDBOX_MAX_CONCURRENT_RUNS=1 FLUIDBOX_QUEUE_MAX_DEPTH=50 \
+  FLUIDBOX_QUEUE_MAX_WAIT_SECS=5 || exit 1
+resolve_agent
+E=$(new_run "holds the slot"); sleep 0.3
+F=$(new_run "waits too long")
+await_status "$E" '^(provisioning|initializing|running)$' 20 >/dev/null
+[ "$(status_of "$F")" = queued ] && ok "F is parked behind E" || no "F: $(status_of "$F")"
+# 5s age bound + the ~15s sweep cadence + margin.
+SF=$(await_status "$F" '^(cancelling|finalizing|failed)$' 45)
+[[ "$SF" =~ ^(cancelling|finalizing|failed)$ ]] \
+  && ok "F was expired by the age sweeper (status $SF)" || no "F never expired (status $SF)"
+FR=$(q "select status_reason from sessions where id = '$F'")
+[[ "$FR" == *"maximum wait"* ]] \
+  && ok "…with a reason an operator can act on: $FR" || no "expiry reason: $FR"
+[ "$(status_of "$E")" != failed ] \
+  && ok "the running run was untouched by the sweep" || no "the sweep hit a running run"
+
+say "result"
+[ -n "$SRV" ] && { kill "$SRV" 2>/dev/null; wait "$SRV" 2>/dev/null; SRV=""; }
+psql "$PGBASE/postgres" -c "drop database if exists $DB with (force)" >/dev/null 2>&1
+printf "  %d passed, %d failed\n" "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Plan Task 9 · design §12 layer 3 · **Closes #160** · depends on #157, #158, #159 (all merged)

Proves the queue over real HTTP against real Postgres with **zero containers and zero model spend** — and, in doing so, found a real bug that is fixed here.

## Verified

| Check | Result |
|---|---|
| `bash scripts/e2e-queue.sh` | **32 passed, 0 failed** — run twice, identical |
| `cargo test -p fluidbox-core` | 176 passed |
| `cargo test -p fluidbox-server` | 449 passed |
| `cargo test -p fluidbox-db` | 153 passed |
| `cargo test -p fluidbox-provider --features test-provider` | 1 passed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean **with and without** the feature |
| `cargo fmt --all --check` | clean |

## ⚠️ The suite found a real bug in the shipped requeue path — [reported on the ticket first](https://github.com/hrishikeshdkakkad/fluidbox/issues/160#issuecomment-5390018383)

**Design §4.3 and §7.4 both specify the capacity bounce as `provisioning → queued`. That edge is unreachable.** `run()` transitions to `initializing` *before* it materializes the workspace and calls `provision()`, so a capacity denial is raised while the session reads `initializing`:

```
transition_fenced(… Provisioning …)   // mint tokens
transition_fenced(… Initializing …)   // ← the status the run actually carries
materialize_workspace(…)
state.provider.provision(&sandbox_spec)   // ← the bounce happens HERE
```

Consequence before the fix: `can_transition_to` refused, `transition_fenced` returned `false`, `requeue_capacity_denied` took its "a finalizer or another replica took the session" early return, and the run was **stranded in `initializing` with revoked tokens** until the stale-launch watchdog reaped it — up to 30 minutes.

**Every unit was individually correct** — backoff arithmetic, token revoke, cleanup, fence check — which is exactly why no unit test saw it. The diagnostic signature was the *combination*: tokens revoked (so the helper ran) but status unchanged (so its transition was refused).

**Fix:** add `(Initializing, Queued)`; **keep** `(Provisioning, Queued)`. The second is dead today and I would normally delete a dead edge — but a capacity denial must never strand a run and `run()` can bail between the two transitions, so keeping both means a future reordering of the launch sequence cannot silently reintroduce this. Neither edge can leak a sandbox: both are reachable only from the requeue path, which runs when `provision` returned an **error**.

**Design-doc follow-up for the maintainer:** §4.3's state diagram and §7.4's prose should be amended to say `initializing → queued`. I have not edited the design doc, since it is the frozen spec this epic implements against.

## Two isolation findings, both handled in the script

### 1. The plan's isolation recipe was insufficient: the *server* reads `.env`

`main.rs` calls `dotenvy::dotenv()`. A server started with the repo root as its cwd inherits the operator's real `.env` **no matter what the script does** — which is how the first run of this suite ended up authenticating against the operator's admin token and answering 401 to its own.

The script now runs the server from a scratch directory. The boot then **fails closed** on the empty LLM upstream key, and that refusal is what proves the isolation works. A dummy key is passed; no model request is possible with the null provider anyway.

### 2. Clearing the sessions table between phases silently failed

That is how P3 ended up asserting against P2's leftover queue (its injected denial was consumed by an older run). Phases now recreate the database, and the next boot re-migrates and re-seeds it.

## Also worth noting

- **P2 had to be made deterministic.** Creating four runs back-to-back races the dispatcher: while the first is still `queued` it counts toward depth, so the fourth is shed at the bound and the queue settles at two. That race is the depth bound *working* — it just made the phase assert the wrong number. The phase now puts one run in the slot, waits for it to leave the queue, and only then fills.
- **The NullProvider logs how many denials it armed**, so an injection knob that silently read as zero cannot make a bounce test pass for the wrong reason — and the suite asserts that line.
- **`#160`'s script carries #161's `queue_position` assertions** (P1 checks position 0 and 1), per the [sequencing note on that ticket](https://github.com/hrishikeshdkakkad/fluidbox/issues/161#issuecomment-5389824619).