### PR TITLE
fix(ci): WIF audience + pnpm — unblock the deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -390,8 +390,26 @@ jobs:
         env:
           CONTROL_HOST: ${{ vars.CONTROL_PLANE_HOST }}
           DASHBOARD_HOST: ${{ vars.DASHBOARD_HOST }}
-          EXPECT_SERVER_DIGEST: ${{ needs.deploy.outputs.revision && '' || '' }}
-        run: bash scripts/cloud/gcp-smoke.sh
+        run: |
+          # Read the admin token from Secret Manager so the smoke run can
+          # exercise the checks that MATTER most: that the admin token is
+          # REFUSED on tenant data under FLUIDBOX_REQUIRE_SSO and still works on
+          # /v1/admin/*. Without it those two skip, and the multi-user
+          # confinement claim goes unverified on every deploy.
+          #
+          # ::add-mask:: first so the value cannot be echoed by anything later
+          # in the job, and it is never written to a file.
+          TOKEN="$(gcloud secrets versions access latest                      --secret=fluidbox-admin-token --project "${{ vars.GCP_PROJECT_ID }}")"
+          echo "::add-mask::$TOKEN"
+          export FLUIDBOX_ADMIN_TOKEN="$TOKEN"
+          bash scripts/cloud/gcp-smoke.sh
+
+      - name: tenant isolation + governed egress
+        env:
+          CONTROL_HOST: ${{ vars.CONTROL_PLANE_HOST }}
+          ORG_SLUG: ${{ vars.ORG_SLUG }}
+          GCP_PROJECT: ${{ vars.GCP_PROJECT_ID }}
+        run: bash scripts/cloud/gcp-isolation-check.sh
 
   # ── Browser journeys ─────────────────────────────────────────────────────
   #
@@ -496,6 +514,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: enable pnpm
+        # The Vercel build runs the project's own install command, which is
+        # `pnpm install` - and the runner ships npm only, so the build died on
+        # a bare `spawn pnpm ENOENT` that named neither pnpm nor the build.
+        # corepack ships with Node and provisions the pinned version.
+        run: corepack enable && corepack prepare pnpm@latest --activate
       - name: deploy to Vercel production
         # REPO ROOT, not apps/web. The Vercel project's rootDirectory is
         # already "apps/web", so running the CLI from inside that directory

--- a/deploy/cloud/gcp/bootstrap/iam.tf
+++ b/deploy/cloud/gcp/bootstrap/iam.tf
@@ -43,8 +43,21 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   attribute_condition = "assertion.repository == \"${var.github_repository}\""
 
   oidc {
-    issuer_uri        = "https://token.actions.githubusercontent.com"
-    allowed_audiences = ["https://github.com/${split("/", var.github_repository)[0]}"]
+    issuer_uri = "https://token.actions.githubusercontent.com"
+
+    # allowed_audiences is deliberately OMITTED.
+    #
+    # Left unset, the provider accepts the DEFAULT audience
+    # "https://iam.googleapis.com/{provider_resource_name}" - which is exactly
+    # what google-github-actions/auth requests. Setting it to anything else
+    # (the org URL is the tempting choice) makes every token fail with
+    #   invalid_grant: The audience in ID Token [...] does not match the
+    #   expected audience
+    # naming an audience that LOOKS correct, because the message echoes the
+    # token's audience rather than the configured one.
+    #
+    # Restricting the repository is the job of attribute_condition above, which
+    # already pins it. Audience adds nothing here.
   }
 }
 


### PR DESCRIPTION
The first deploy run from main gated correctly (verify passed; plan/images failed; apply/deploy/smoke/browser skipped). Both failures were mine: a WIF `allowed_audiences` that contradicted what `google-github-actions/auth` sends, and a missing pnpm on the runner. Also wires the admin token (masked) into the smoke job so the REQUIRE_SSO confinement checks actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)