### PR TITLE
fix(ci): smoke needs always() — a green pipeline was verifying nothing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -392,7 +392,13 @@ jobs:
   # ── Post-deploy proof ─────────────────────────────────────────────────────
   smoke:
     needs: [deploy]
-    if: needs.deploy.result == 'success'
+    # `always()` is REQUIRED here, not decorative. Skips propagate transitively
+    # through `needs`: `apply` is skipped when no infrastructure changed, and
+    # although `deploy` overrides that with always() and succeeds, a downstream
+    # job whose own `if` lacks always() still inherits the upstream skip. Without
+    # this, every application-only deploy silently shipped with NO smoke tests -
+    # a green pipeline that verified nothing.
+    if: always() && needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     environment: Production
     steps:


### PR DESCRIPTION
Skips propagate transitively through `needs`: `apply` skips on an app-only commit, and `smoke` inherited it despite `deploy` succeeding. Every app-only deploy shipped with no post-deploy verification.

Also records the migration-gate payoff: the pre-upgrade Job **completed** (exited 0 without serving) on the newly built image, and the Deployment now runs a digest-pinned image from Artifact Registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)