### PR TITLE
fix(evidence): the verification suites were quietly verifying less than they claimed

### DIFF
--- a/scripts/cloud/gcp-isolation-check.sh
+++ b/scripts/cloud/gcp-isolation-check.sh
@@ -37,8 +37,16 @@ say "1. Row-level security is ENFORCED, not merely applied"
 # The server states this at boot after inspecting the EFFECTIVE role of a
 # pooled connection. That is the authoritative answer: it is the role Postgres
 # will actually evaluate policies for, after any SET ROLE.
-LOG="$(kubectl -n "$NS" logs -l app.kubernetes.io/component=server --tail=500 2>/dev/null)"
-if grep -q "row-level security is ENFORCED" <<<"$LOG"; then
+# Whole log for the NEWEST server pod: the RLS and netpol verdicts are boot
+# lines, emitted once, and a --tail window silently misses them on a pod that
+# has been logging since - which turns a real check into a skip.
+POD="$(kubectl -n "$NS" get pod -l app.kubernetes.io/component=server \
+        --sort-by=.metadata.creationTimestamp -o name 2>/dev/null | tail -1)"
+LOG="$(kubectl -n "$NS" logs "$POD" 2>/dev/null)"
+# Structured FIELD first, prose as fallback. Field names outlive wording: the
+# observability rewrite moved these to JSON and reworded them, silently turning
+# real checks into skips.
+if grep -qE '"rls":"enforced"|row-level security is ENFORCED' <<<"$LOG"; then
   ok "boot log: RLS enforced (pool role has neither SUPERUSER nor BYPASSRLS)"
 elif grep -q "bypasses RLS\|SUPERUSER or has BYPASSRLS" <<<"$LOG"; then
   bad "the pool role BYPASSES RLS — migration 0018's policies are decoration" \
@@ -47,7 +55,9 @@ else
   skip "RLS posture line" "outside the retained log window"
 fi
 
-if grep -q "app pool runs under non-owner role" <<<"$LOG"; then
+# The rewrite inserted an article ("a non-owner role"), which broke an
+# exact-phrase match.
+if grep -qE '"rls":"role_split"|non-owner role' <<<"$LOG"; then
   ok "pool runs as the non-owner runtime role (RLS role split active)"
 else
   skip "runtime-role line" "outside the retained log window"
@@ -123,7 +133,7 @@ say "3. Sandbox containment (governed egress)"
 
 # The server refuses to start ANY run until a boot probe proves the CNI
 # actually drops traffic. That refusal is the containment guarantee.
-if grep -qiE 'netpol.*(enforced|verified)|network policy enforcement' <<<"$LOG"; then
+if grep -qiE '"worker":"netpol_gate"|NetworkPolicy enforcement verified' <<<"$LOG"; then
   ok "boot probe proved the CNI enforces NetworkPolicy (runs are gated on this)"
 else
   skip "boot netpol line" "outside the retained log window"

--- a/scripts/cloud/gcp-smoke.sh
+++ b/scripts/cloud/gcp-smoke.sh
@@ -30,11 +30,33 @@ bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; [ $# -gt 1 ] && printf '      
 skip() { printf '  \033[33m–\033[0m %s (%s)\n' "$1" "${2:-skipped}"; SKIP=$((SKIP+1)); }
 say()  { printf '\n\033[1m%s\033[0m\n' "$1"; }
 
+# Boot-time lines (RLS posture, netpol gate) are emitted ONCE at start, so a
+# --tail window can miss them entirely on a pod that has been logging since.
+# Read the whole log for the newest server pod instead, and cache it - three
+# checks below need it and each `kubectl logs` is a round trip.
+# Captured ONCE into a variable, and every check below reads it with a
+# here-string rather than a pipe.
+#
+# `server_log | grep -q …` looks natural and is wrong under `set -o pipefail`:
+# grep -q exits the moment it matches, closing the pipe; the producer then dies
+# on SIGPIPE, and pipefail propagates THAT as the pipeline's status. The
+# condition therefore reports failure precisely BECAUSE the pattern matched.
+# The earlier --tail=400 form hid it - the output was small enough that the
+# producer finished before grep exited.
+SERVER_LOG=""
+load_server_log() {
+  local pod
+  pod="$(kubectl -n "$NAMESPACE" get pod -l app.kubernetes.io/component=server \
+           --sort-by=.metadata.creationTimestamp -o name 2>/dev/null | tail -1)"
+  [ -n "$pod" ] && SERVER_LOG="$(kubectl -n "$NAMESPACE" logs "$pod" 2>/dev/null)"
+}
+
 # ── 1. Workloads ────────────────────────────────────────────────────────────
 say "1. Cluster workloads"
 if [ "${SKIP_CLUSTER:-}" = "1" ] || ! command -v kubectl >/dev/null; then
   skip "kubectl checks" "no cluster access"
 else
+  load_server_log
   for d in "$RELEASE-server" "$RELEASE-litellm"; do
     if ! kubectl -n "$NAMESPACE" get deploy "$d" >/dev/null 2>&1; then
       skip "deployment $d" "not present"; continue
@@ -56,8 +78,7 @@ else
 
   # The fail-closed boot gates print this and then exit. A pod that is Ready
   # cannot have hit one, but a CrashLoopBackOff behind a stale ReplicaSet can.
-  if kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=server --tail=400 2>/dev/null \
-       | grep -q "REFUSING TO BOOT"; then
+  if grep -q "REFUSING TO BOOT" <<<"$SERVER_LOG"; then
     bad "a server pod logged REFUSING TO BOOT" "read the line - it names the exact gate"
   else
     ok "no boot refusals in recent server logs"
@@ -65,8 +86,8 @@ else
 
   # NetworkPolicy enforcement is a RUNTIME property the server proves at boot
   # by probing; runs are gated until it does.
-  if kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=server --tail=400 2>/dev/null \
-       | grep -qiE "netpol.*(enforced|verified)|network policy enforcement (verified|confirmed)"; then
+  # Anchor on the STRUCTURED FIELD (worker=netpol_gate) as well as the prose.
+  if grep -qiE '"worker":"netpol_gate"|NetworkPolicy enforcement verified' <<<"$SERVER_LOG"; then
     ok "CNI NetworkPolicy enforcement proven by the boot probe"
   else
     skip "netpol enforcement line" "not in the retained log window"
@@ -74,8 +95,8 @@ else
 
   # Tenant isolation's database floor is only real if the pool role cannot
   # bypass RLS. The server logs which case it is.
-  if kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=server --tail=400 2>/dev/null \
-       | grep -q "row-level security is ENFORCED"; then
+  # Structured field first; the prose is the fallback.
+  if grep -qE '"rls":"enforced"|row-level security is ENFORCED' <<<"$SERVER_LOG"; then
     ok "RLS is ENFORCED for the application pool (role has neither SUPERUSER nor BYPASSRLS)"
   else
     skip "RLS posture line" "not in the retained log window"

--- a/tests/browser/journeys.spec.ts
+++ b/tests/browser/journeys.spec.ts
@@ -167,26 +167,45 @@ test.describe("authenticated journey", () => {
     });
     expect(status, "POST /v1/auth/logout must be accepted").toBeLessThan(400);
 
-    // Require the cookie to be GONE, not merely empty. `?? ""` would pass for a
-    // cookie that is still present with an empty value - and the navigation
-    // gate uses cookies.has(), which is TRUE for exactly that case, so the weak
-    // form would report a pass on a session that still gates as signed-in.
-    const after = (await context.cookies()).find((c) => c.name === "__Host-fbx_web");
-    expect(after, `the session cookie must be removed, got ${JSON.stringify(after)}`).toBeUndefined();
-
-    // CACHE-BUST the navigation. We are already ON /app, and Chromium will
-    // happily satisfy `goto` for the same URL from its cache without issuing a
-    // request - so the server-side gate never runs and the page appears
-    // unprotected when it is not. A unique query string forces a real trip.
+    // POLL for the cookie's removal rather than reading once. Chromium applies
+    // a Set-Cookie from a fetch() asynchronously, so a single immediate read
+    // races it - which is exactly how this test flaked (failed, passed on
+    // retry). A flaky gate is worse than a missing one: it either blocks good
+    // deploys or teaches people to re-run until green.
     //
-    // The gate also redirects mid-navigation, which Chromium reports as
-    // ERR_ABORTED on the original goto; that is the redirect working.
-    const bust = `/app?_=${process.hrtime.bigint()}`;
-    await page.goto(bust, { waitUntil: "domcontentloaded" }).catch(() => {});
-    await page.waitForLoadState("domcontentloaded").catch(() => {});
+    // Require the cookie to be GONE, not merely empty: the navigation gate uses
+    // cookies.has(), which is TRUE for a present-but-empty cookie, so an
+    // "is it blank" assertion would pass a session that still gates as
+    // signed-in.
+    await expect
+      .poll(
+        async () => (await context.cookies()).some((c) => c.name === "__Host-fbx_web"),
+        { timeout: 15_000, message: "the session cookie must be removed by logout" }
+      )
+      .toBe(false);
+
+    // Assert the SERVER's decision, not the browser's final URL.
+    //
+    // Navigating and reading page.url() was flaky for reasons that have nothing
+    // to do with the gate: Chromium can satisfy a goto to the URL it is already
+    // on from cache, and the app's client-side router rewrites /app?_=N back to
+    // /app - so the observed URL says little about what the server decided. The
+    // security property is "does the server redirect an unauthenticated /app to
+    // login", and a manual-redirect fetch answers exactly that, deterministically.
+    const gate = await page.evaluate(async () => {
+      const r = await fetch(`/app?_=${Date.now()}`, {
+        credentials: "include",
+        redirect: "manual",
+        headers: { "cache-control": "no-cache" },
+      });
+      // A `manual` redirect surfaces as an opaqueredirect response, whose status
+      // is 0 by design - the browser refuses to expose cross-origin redirect
+      // details. `type` is what distinguishes it from a real 200.
+      return { type: r.type, status: r.status };
+    });
     expect(
-      /\/login|\/sign-in|auth0\.com/.test(page.url()),
-      `/app must be protected again, landed on ${page.url()}`
+      gate.type === "opaqueredirect" || (gate.status >= 300 && gate.status < 400),
+      `/app must be REDIRECTED for a logged-out session, got type=${gate.type} status=${gate.status}`
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
Three defects, each turning a real check into a silent skip: a `pipefail`+`grep -q` SIGPIPE trap that made a pipeline fail *because* the pattern matched; `--tail` windows missing once-only boot lines; and prose-anchored greps broken by the observability rewording. Now anchored on structured fields. Smoke 22/0/2 → 23/0/1, isolation 9/0/2 → 11/0/0. Also de-flaked the logout journey (4/4 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)