### PR TITLE
docs(web): commit .env.example — it had never been tracked

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,73 @@
+# fluidbox dashboard (apps/web) environment. Copy to .env.local for local dev
+# (`just setup` writes the control-plane pair for you). `.env.local` is
+# gitignored — never commit it.
+
+# ── Control plane ────────────────────────────────────────────────────────────
+# Where the server-side proxy forwards /api/fluidbox/* (the Rust control plane).
+FLUIDBOX_API_URL=http://127.0.0.1:8787
+# admin mode only: injected server-side on every proxied call. Never reaches
+# the browser. Must match FLUIDBOX_ADMIN_TOKEN in the repo-root .env.
+FLUIDBOX_ADMIN_TOKEN=
+
+# ── Credential mode (which identity the proxy presents to the control plane) ─
+# admin (default, unset) — local/single-admin: the operator token above.
+# sso — hosted multi-user: fluidbox session-cookie passthrough (no admin token
+#       in the environment at all). See the repo README "Local SSO" section
+#       for the three variables that must agree.
+#FLUIDBOX_WEB_MODE=admin
+
+# ── Web-tier authentication (whether /app requires a WorkOS session) ─────────
+# none (default, unset) — no web-tier gate (today's local behavior).
+# workos — WorkOS AuthKit protects /app/* and /api/fluidbox/*. Requires ALL
+#          four WORKOS_* variables below; the app refuses to start otherwise
+#          (fail closed — never an unprotected /app). Incompatible with
+#          FLUIDBOX_WEB_MODE=sso (fluidbox SSO already authenticates the
+#          browser; configure WorkOS as the org's OIDC IdP instead).
+#FLUIDBOX_WEB_AUTH=workos
+
+# WorkOS credentials — dashboard.workos.com → your environment.
+#   WORKOS_API_KEY         secret key (sk_…). Server-only; never NEXT_PUBLIC.
+#   WORKOS_CLIENT_ID       the environment's client id (client_…).
+#   WORKOS_COOKIE_PASSWORD ≥32 chars: `openssl rand -base64 24`.
+#WORKOS_API_KEY=sk_test_...
+#WORKOS_CLIENT_ID=client_...
+#WORKOS_COOKIE_PASSWORD=
+
+# The AuthKit callback on THIS deployment's origin. Register the exact value
+# as a Redirect URI in the WorkOS dashboard (per environment), and the origin
+# as a Logout URI:
+#   dev        http://localhost:3000/callback     (logout http://localhost:3000)
+#   preview    https://<preview-host>/callback    (logout https://<preview-host>)
+#   production https://<prod-host>/callback       (logout https://<prod-host>)
+# NEXT_PUBLIC_* values are inlined at BUILD time — deploy/web.Dockerfile
+# images must receive this as a build arg; runtime-only env is not enough.
+#NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback
+
+# ── Public site ──────────────────────────────────────────────────────────────
+# Browser-facing base URL: canonical links, Open Graph, sitemap, robots.
+#NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# ── Production (GCP deployment, platform.fluidzero.ai) ───────────────────────
+#
+# The live values, recorded because two of them are load-bearing in ways that
+# are invisible until something breaks:
+#
+#   FLUIDBOX_WEB_MODE=sso
+#   FLUIDBOX_API_URL=https://api.platform.fluidzero.ai
+#   NEXT_PUBLIC_SITE_URL=https://platform.fluidzero.ai
+#
+# FLUIDBOX_API_URL must be present at BUILD time. next.config.ts bakes the
+# `/v1/*` rewrite during the build, so setting it as runtime-only env produces a
+# deployment with NO rewrite - and the OIDC callback then 404s on an origin that
+# looks completely healthy.
+#
+# The rewrite is not a convenience. `__Host-` cookies are host-locked and the
+# control plane refuses cookie-authenticated writes whose Origin is not an exact
+# match for FLUIDBOX_PUBLIC_URL, so the callback HAS to land on the dashboard's
+# own origin. That is why the control plane answers on a different hostname
+# (api.platform.fluidzero.ai) and is reached through this one.
+#
+# FLUIDBOX_WEB_AUTH stays unset (`none`): the fluidbox session already
+# authenticates the browser in sso mode, and the two are mutually exclusive.
+# Auth0 is configured as the ORG'S OIDC ISSUER inside the control plane, not as
+# a web-tier gate here. See docs/hosted/gcp-architecture.md.

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -30,8 +30,12 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
+# env files. `.env*` would also swallow .env.example, which is DOCUMENTATION,
+# not a secret - the root .gitignore deliberately un-ignores it and this file
+# was silently overriding that. The result: the web app's environment contract
+# was invisible to anyone cloning the repo.
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
`apps/web/.gitignore` had a bare `.env*` overriding the root's `!.env.example`, so the web app's environment contract was invisible to anyone cloning the repo. Scanned for secrets first (two placeholder assignments, nothing sensitive). Also records the live production values and why two of them are load-bearing.

Exercises the pipeline's `vercel` job — the last one not yet proven end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)