### PR TITLE
docs(gcp): correct — governed network grants are NOT possible on GKE Dataplane V2

### DIFF
--- a/docs/hosted/gcp-architecture.md
+++ b/docs/hosted/gcp-architecture.md
@@ -235,9 +235,37 @@ on concurrent runs.
   variable and a RollingUpdate would briefly run two generations with two
   different "deployment-wide" caps. That is a visible outage on every deploy.
   The sandbox `ResourceQuota` remains the capacity backstop.
-- **`networkGrants`** (governed sandbox egress). Available now that the CNI is
-  Cilium; enabling it is a deliberate posture change and needs a
-  `dnsClusterIP` allocated from the services range.
+- **`networkGrants`** (governed sandbox egress). **NOT POSSIBLE on this
+  cluster**, and the reason is worth stating precisely because it is easy to
+  get wrong:
+
+  GKE Dataplane V2 *is* Cilium, but Google manages the Cilium control plane and
+  exposes only its STATE CRDs - `ciliumendpoints`, `ciliumidentities`,
+  `ciliumnodes`, `ciliumendpointslices`, `ciliumlocalredirectpolicies`. The
+  POLICY CRDs the chart's `netgrant.yaml` renders -
+  `CiliumClusterwideNetworkPolicy` and `CiliumEgressGatewayPolicy` - are
+  **absent**, and there is no GKE-native `FQDNNetworkPolicy` on this version
+  either. Verify on any cluster before assuming otherwise:
+
+      kubectl get crd ciliumclusterwidenetworkpolicies.cilium.io
+
+  (An earlier revision of this document claimed the feature was "available now
+  that the CNI is Cilium". That was inferred from "Dataplane V2 is Cilium"
+  without checking the CRDs, and it was wrong - corrected 2026-08-25.)
+
+  Standard `NetworkPolicy` is unaffected and DOES work: it is what enforces
+  sandbox containment, and the boot probe proves it at runtime.
+
+  Consequence: every sandbox is **offline-only**. `NetworkGrantMode::Offline`
+  resolves on any deployment ("the absence of authority needs no enforcer"),
+  while `approved` and `public` are refused at create time with
+  `422 this deployment cannot enforce network grants`. That refusal is the
+  fail-closed design working - it declines to ACCEPT a grant it cannot ENFORCE,
+  rather than silently handing the sandbox open egress.
+
+  To actually get governed egress you need Cilium's policy CRDs, which on GKE
+  means a cluster built WITHOUT Dataplane V2 plus self-managed upstream Cilium.
+  That is a cluster rebuild and a self-managed CNI, not a values change.
 - **gVisor** on the sandbox pool. `values/gke.yaml` documents the
   `runtimeClassName: gvisor` switch; it needs a GKE Sandbox node pool and
   carries syscall-compatibility risk with the Node-based runner images.

--- a/docs/hosted/gcp-handoff.md
+++ b/docs/hosted/gcp-handoff.md
@@ -137,10 +137,19 @@ own registry at admin-gated `GET /v1/admin/metrics`.
 5. **Auth0 is the `hrishi-test` tenant, JP region.** Standards-conformant and
    working, but dev-named. Moving to a production tenant is a dashboard action
    plus a re-run of `scripts/cloud/gcp-auth0.sh`.
-6. **The run queue is off.** Enabling `server.maxConcurrentRuns` switches the
+6. **Sandboxes are OFFLINE-ONLY; governed network grants are impossible here.**
+   GKE Dataplane V2 exposes Cilium's state CRDs but not its POLICY CRDs
+   (`CiliumClusterwideNetworkPolicy`, `CiliumEgressGatewayPolicy`), so
+   `networkGrants` cannot be enabled. Agents declaring `approved` or `public`
+   are refused with `422 this deployment cannot enforce network grants` - the
+   fail-closed design declining a grant it cannot enforce. Agents that declare
+   no network (or `offline`) work normally. Getting real governed egress means
+   a cluster without Dataplane V2 plus self-managed upstream Cilium.
+   See gcp-architecture.md §10.
+7. **The run queue is off.** Enabling `server.maxConcurrentRuns` switches the
    Deployment to `Recreate`; the sandbox `ResourceQuota` (12 pods) is the
    capacity backstop meanwhile.
-7. **`FLUIDBOX_TRUST_FORWARDED_FOR` is off**, so audit rows record the load
+8. **`FLUIDBOX_TRUST_FORWARDED_FOR` is off**, so audit rows record the load
    balancer's address rather than the client's. Trusting it on a publicly
    reachable Ingress would let an attacker choose the identity that per-IP
    limiting records.


### PR DESCRIPTION
I claimed networkGrants was "available now that the CNI is Cilium", inferred from "DPv2 is Cilium" without checking the CRDs. Wrong: GKE exposes Cilium's **state** CRDs but withholds the **policy** ones, so `CiliumClusterwideNetworkPolicy` is absent and the feature cannot be enabled. Verified live. Standard NetworkPolicy is unaffected and still enforces sandbox containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)