### PR TITLE
fix(gcp): the Cilium startup taint deadlocked every scale-from-zero

### DIFF
--- a/deploy/cloud/gcp/README.md
+++ b/deploy/cloud/gcp/README.md
@@ -108,7 +108,9 @@ printf '%s' "$ANTHROPIC_API_KEY" \
 cd ../app
 terraform init \
   -backend-config="bucket=fluidbox-506603-tfstate" -backend-config="prefix=app"
-terraform apply -var "external_secrets_sa=$(terraform -chdir=../platform output -raw external_secrets_service_account)"
+terraform apply \
+  -var "external_secrets_sa=$(terraform -chdir=../platform output -raw external_secrets_service_account)" \
+  -var "cilium_agent_not_ready_taint_key=$(terraform -chdir=../platform output -raw cilium_agent_not_ready_taint_key)"
 
 # 4. DNS: point the control-plane host at the reserved GCLB address (Route 53).
 scripts/cloud/gcp-dns.sh

--- a/deploy/cloud/gcp/app/main.tf
+++ b/deploy/cloud/gcp/app/main.tf
@@ -2,7 +2,8 @@
 #
 # Installed here rather than by the fluidbox chart because it is CLUSTER
 # infrastructure: it owns the CNI, every other workload depends on it, and the
-# nodes stay tainted `node.cilium.io/agent-not-ready` until it removes the taint.
+# nodes stay tainted (`agentNotReadyTaintKey`, fed from the platform stack) until
+# it removes the taint.
 # Nothing else can schedule before this succeeds.
 #
 # Why at all: GKE Dataplane V2 exposes only CiliumClusterwideNetworkPolicy,
@@ -55,6 +56,14 @@ resource "helm_release" "cilium" {
   set {
     name  = "ipv4NativeRoutingCIDR"
     value = var.pods_cidr
+  }
+  # The key the operator removes once a node is prepared. Must be the key the
+  # node pools are born with - fed from the platform output, never retyped -
+  # and must carry the cluster-autoscaler ignore-taint prefix, or a
+  # scale-to-zero pool can never scale up (see platform/gke.tf).
+  set {
+    name  = "agentNotReadyTaintKey"
+    value = var.cilium_agent_not_ready_taint_key
   }
 
   # NOT atomic: a rollback here would uninstall the CNI from a running cluster,

--- a/deploy/cloud/gcp/app/variables.tf
+++ b/deploy/cloud/gcp/app/variables.tf
@@ -70,3 +70,15 @@ variable "cilium_chart_version" {
   type        = string
   default     = "1.18.1"
 }
+
+variable "cilium_agent_not_ready_taint_key" {
+  description = <<-EOT
+    The startup taint every node is born with (platform stack output
+    cilium_agent_not_ready_taint_key). Cilium's operator removes exactly this
+    key once a node is prepared. Deliberately no default: it is fed from the
+    platform output the way external_secrets_sa is, because a retyped value
+    that drifts leaves every NEW node tainted NoExecute forever, with the netpol
+    probe's "Unschedulable" as the only symptom.
+  EOT
+  type        = string
+}

--- a/deploy/cloud/gcp/platform/gke.tf
+++ b/deploy/cloud/gcp/platform/gke.tf
@@ -13,6 +13,29 @@
 # traffic (netpol.requireEnforced), and DPv2 is Cilium - enforcing natively,
 # with no add-on to forget.
 
+# ── The Cilium startup taint ────────────────────────────────────────────────
+#
+# Under cilium_mode = "upstream" every node is born carrying this taint, and
+# Cilium's operator removes exactly this key once it has prepared the node. The
+# app stack feeds the SAME value to Cilium (`agentNotReadyTaintKey`) from the
+# output below - it is never retyped, because if the two ever disagree a new
+# node stays tainted NoExecute forever and the only symptom is the netpol probe
+# reporting Unschedulable.
+#
+# The prefix is load-bearing, not cosmetic. The cluster autoscaler decides a
+# scale-up by SIMULATING the pending pod against the pool's node template,
+# taints included. Sandbox pods must not tolerate the not-ready taint (that is
+# the whole point of it), so under the plain `node.cilium.io/agent-not-ready`
+# key the simulation always answered "does not fit" and a scale-to-zero pool
+# could never leave zero: every probe and every run sat Pending with
+# "1 node(s) had untolerated taint(s)". The autoscaler treats a key under
+# ignore-taint.cluster-autoscaler.kubernetes.io/ as startup-only and ignores it
+# in that simulation; nothing else reads the prefix. Cilium documents this key
+# for exactly this purpose.
+locals {
+  cilium_agent_not_ready_taint_key = "ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready"
+}
+
 resource "google_container_cluster" "fluidbox" {
   provider = google-beta
 
@@ -241,7 +264,7 @@ resource "google_container_node_pool" "system" {
     dynamic "taint" {
       for_each = var.cilium_mode == "upstream" ? [1] : []
       content {
-        key    = "node.cilium.io/agent-not-ready"
+        key    = local.cilium_agent_not_ready_taint_key
         value  = "true"
         effect = "NO_EXECUTE"
       }
@@ -332,7 +355,7 @@ resource "google_container_node_pool" "sandbox" {
     dynamic "taint" {
       for_each = var.cilium_mode == "upstream" ? [1] : []
       content {
-        key    = "node.cilium.io/agent-not-ready"
+        key    = local.cilium_agent_not_ready_taint_key
         value  = "true"
         effect = "NO_EXECUTE"
       }

--- a/deploy/cloud/gcp/platform/outputs.tf
+++ b/deploy/cloud/gcp/platform/outputs.tf
@@ -77,3 +77,8 @@ output "archive_endpoint" {
   description = "GCS XML API endpoint. Path-style addressing (the chart defaults to it whenever an endpoint is set)."
   value       = "https://storage.googleapis.com"
 }
+
+output "cilium_agent_not_ready_taint_key" {
+  description = "The startup taint the node pools carry. Pass it to the app stack's cilium_agent_not_ready_taint_key so Cilium removes the SAME key it finds."
+  value       = local.cilium_agent_not_ready_taint_key
+}


### PR DESCRIPTION
Closes the `503 sandbox network isolation is not yet verified on this cluster` reported from the dashboard.

## What was wrong

The autoscaler's own event on the netpol probe pod says it:

```
NotTriggerScaleUp: 1 node(s) had untolerated taint(s)
```

The cluster autoscaler decides a scale-up by **simulating** the pending pod against the pool's node template — taints included. Yesterday's rebuild put `node.cilium.io/agent-not-ready=true:NoExecute` on both pools so nothing lands on a node before Cilium has prepared it. Sandbox pods must **not** tolerate that taint (tolerating it is exactly the unmanaged-pod hole it closes), so the simulation always answered "does not fit" and the scale-to-zero pool could never leave zero. The probe sat Pending → `Unschedulable` → gate closed. Real runs carry the **same** placement env, so they would have hung identically.

## The fix

Cilium's `agentNotReadyTaintKey` lets the taint be named under the autoscaler's `ignore-taint.cluster-autoscaler.kubernetes.io/` prefix, which marks it **startup-only**: ignored in the simulation, honoured by everything else. This is the key Cilium's own docs prescribe for this purpose ([Considerations on Node Pool Taints](https://docs.cilium.io/en/stable/installation/taints/)); cilium/cilium#19241 is this exact problem on GKE.

- declared **once** in `platform/gke.tf`, exported as `cilium_agent_not_ready_taint_key`
- the app stack takes it as a **required** variable (no default — fed from the output like `external_secrets_sa`), so the two can't drift by retyping; drift would leave every new node tainted forever
- both pools update **in-place**: `0 to add, 2 to change, 0 to destroy`

## Order of operations (done)

Cilium had to learn the new key **before** any node is born with it. The app stack was applied first, per the README's documented step 3: rolled out in 25s, zero evictions, zero workload restarts, `/v1/health` 200 throughout; `cilium-config` now reads `agent-not-ready-taint-key: ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready`. The pools follow through this PR.

## Proof still to come (after merge)

A scale-from-zero exercised for real: pool at 0 → pending sandbox-placed pod → `TriggeredScaleUp` → node born with the new key → operator removes it → pod Running; then a cold server boot with the pool at 0 flipping the gate to *verified*. Numbers will be recorded in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hyJiVeXan6NvRp7BAwxVf