### PR TITLE
docs(gcp): the startup taint, the autoscaler, and the order that matters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ production values overlay); architecture and cost:
 The older `deploy/cloud/terraform/` tree is the **AWS/EKS M1 kit**, whose
 estate was torn down 2026-08-15 — it is kept for reference, not for deploys.
 
-Four things about it are load-bearing and easy to get wrong:
+Five things about it are load-bearing and easy to get wrong:
 
 - **`platform.fluidzero.ai` is Vercel; `api.platform.fluidzero.ai` is GKE.**
   `next.config.ts` rewrites `/v1/*` to the control plane *only* when
@@ -62,6 +62,21 @@ Four things about it are load-bearing and easy to get wrong:
   only mode giving v2 envelope sealing on GCP. Disclosed residual: the KEK
   plaintext is in the pod env (unlike the `aws` backend). See
   `docs/hosted/gcp-architecture.md#sealing`.
+- **The cluster runs self-managed upstream Cilium (`cilium_mode = "upstream"`,
+  legacy datapath) because governed sandbox egress needs the NAMESPACED
+  `CiliumNetworkPolicy`, which GKE Dataplane V2 does not serve.** Two couplings
+  follow. (1) `cilium_mode` defaults to `upstream` in BOTH Terraform stacks and
+  must keep naming the deployed reality — `datapath_provider` is ForceNew, so
+  the other value plans a cluster REPLACEMENT (platform) or a CNI UNINSTALL
+  (app). (2) Every node is born with a startup taint whose key is declared once
+  (platform output `cilium_agent_not_ready_taint_key`) and fed to Cilium's
+  `agentNotReadyTaintKey`; it MUST carry the
+  `ignore-taint.cluster-autoscaler.kubernetes.io/` prefix, because the
+  autoscaler SIMULATES a pending pod against the tainted node template and
+  sandbox pods must not tolerate the taint — under Cilium's plain default key
+  the scale-to-zero pool can never leave zero (probe `Unschedulable`, dashboard
+  `503 … network isolation is not yet verified`). Sandbox pods must never be
+  given that toleration to "fix" it.
 
 Deploys are automatic on push to `main` (`.github/workflows/deploy.yml`):
 plan on PRs as a read-only identity, apply + release on main through a

--- a/docs/hosted/gcp-architecture.md
+++ b/docs/hosted/gcp-architecture.md
@@ -267,9 +267,58 @@ Verify on any cluster rather than assuming either way:
     kubectl get crd ciliumclusterwidenetworkpolicies.cilium.io # deny wall
 
 **What it costs.** GKE no longer manages the CNI. Node upgrades and reboots can
-undo Cilium's node configuration; the `node.cilium.io/agent-not-ready` taint on
-the node pools is what makes that survivable, holding pods off a node until
-Cilium has re-prepared it. Cilium version upgrades become an operator task.
+undo Cilium's node configuration; the startup taint on the node pools is what
+makes that survivable, holding pods off a node until Cilium has re-prepared it.
+Cilium version upgrades become an operator task.
+
+**The startup taint and the autoscaler — a coupling that bit on day one.**
+Every node is born tainted
+`ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute`,
+and Cilium's operator removes exactly that key once the node is prepared
+(`agentNotReadyTaintKey`, fed from the platform output — never retyped). The
+prefix is the load-bearing part. The cluster autoscaler decides a scale-up by
+SIMULATING the pending pod against the pool's node template, taints included,
+and sandbox pods must not tolerate the not-ready taint (tolerating it is the
+unmanaged-pod hole it exists to close). Under Cilium's plain default key,
+`node.cilium.io/agent-not-ready`, the simulation therefore always answered
+"does not fit" and the scale-to-zero sandbox pool could never leave zero: the
+netpol probe sat Pending with `NotTriggerScaleUp: 1 node(s) had untolerated
+taint(s)`, the gate reported `Unschedulable`, and the dashboard answered
+`503 sandbox network isolation is not yet verified on this cluster`. Real runs
+carry the same placement and would have hung identically. The
+`ignore-taint.cluster-autoscaler.kubernetes.io/` prefix marks a taint as
+startup-only — ignored in that simulation, honoured by everything else — and is
+the key Cilium's own documentation prescribes for the purpose. Measured on this
+cluster, on the pipeline apply that shipped the fix (2026-08-26): autoscaler
+`TriggeredScaleUp` on the probe pod at 01:23:25Z → node born at 01:23:56Z
+(31 s) → taint lifted by the operator ≈47 s later → probe scheduled, image
+pulled in 0.8 s, and the gate logged *verified* at 01:24:55Z — **90 s from
+decision to admitted runs**, against a 240 s probe deadline and a 300 s run-pod
+grace. The seven probes before the fix had all ended `NotTriggerScaleUp`.
+
+If the two stacks ever disagree on the key, a NEW node stays tainted NoExecute
+forever and the only symptom is that same `Unschedulable`; see the runbook's
+triage entry. Changing the key is therefore an ORDERED migration: Cilium learns
+the new key first (app stack), the pool templates follow (platform stack), and
+any node born in between must be checked. That window is not theoretical — on
+2026-08-26 it caught a node. The Cilium upgrade itself rolls `cilium-operator`,
+whose two replicas carry a required anti-affinity, so on the two-node system
+pool the surge pod cannot co-locate and the autoscaler adds a THIRD node for
+the rollout (then scales it away ~10 min later). That surge node was born with
+the old key after the operator had stopped lifting it, and had to be untainted
+by hand once its Cilium agent was ready. Expect the surge on every Cilium
+upgrade; it is bounded and harmless once both stacks agree.
+
+The order is not a preference. GKE applies a node-pool taint change to the
+pool's EXISTING nodes immediately, and `NoExecute` means the taint manager
+evicts every pod without a toleration: the apply that shipped this fix evicted
+**27 pods** across `kube-system`, `external-secrets` and `fluidbox` in eight
+seconds. Because the operator was already lifting the new key, it cleared the
+taints within seconds and everything rescheduled — a ~30 s control-plane blip
+the pipeline's smoke stage never saw. Had the pools been changed FIRST, the same
+apply would have tainted every system node with a key nothing lifts and evicted
+the entire control plane with nowhere to go. Cilium first is the difference
+between a blip and an outage.
 
 **The committed default must keep naming reality.** `cilium_mode` defaults to
 `upstream` in BOTH stacks, and that is load-bearing rather than tidy: a default

--- a/docs/hosted/gcp-handoff.md
+++ b/docs/hosted/gcp-handoff.md
@@ -144,10 +144,15 @@ own registry at admin-gated `GET /v1/admin/metrics`.
    because GKE Dataplane V2 serves no NAMESPACED `CiliumNetworkPolicy` and the
    per-run enforcer writes exactly that. The standing cost: GKE no longer
    patches the CNI, node upgrades can undo its node configuration (the
-   `node.cilium.io/agent-not-ready` taint is what makes that survivable), and
-   Cilium upgrades are an operator task. `cilium_mode` must keep defaulting to
-   `upstream` in both stacks — a default naming the other mode plans a cluster
-   replacement or a CNI uninstall.
+   startup taint is what makes that survivable), and Cilium upgrades are an
+   operator task. `cilium_mode` must keep defaulting to `upstream` in both
+   stacks — a default naming the other mode plans a cluster replacement or a
+   CNI uninstall. The startup taint's key is declared once (platform output
+   `cilium_agent_not_ready_taint_key`) and MUST carry the
+   `ignore-taint.cluster-autoscaler.kubernetes.io/` prefix: without it the
+   autoscaler's scale-up simulation never fits a sandbox pod and the
+   scale-to-zero pool is stuck at zero (the day-one 503). Fixed and proven
+   2026-08-26: `TriggeredScaleUp` 0→1, gate verified 90 s after the decision.
    See gcp-architecture.md#network-grants.
 7. **The run queue is off.** Enabling `server.maxConcurrentRuns` switches the
    Deployment to `Recreate`; the sandbox `ResourceQuota` (12 pods) is the

--- a/docs/hosted/gcp-operations.md
+++ b/docs/hosted/gcp-operations.md
@@ -115,6 +115,54 @@ these now fail **in the Job**, before any pod rolls — read the Job's log:
 kubectl -n fluidbox logs job/fluidbox-server-migrate
 ```
 
+### Runs blocked: "network isolation is not yet verified" {#netpol-unschedulable}
+
+The dashboard answers `503 sandbox network isolation is not yet verified on
+this cluster — runs are blocked until the NetworkPolicy enforcement probe
+passes`. The server refuses to admit a run until a probe pod, placed exactly
+like a sandbox, has PROVED the CNI drops traffic — so first read what the probe
+concluded, then why:
+
+```
+kubectl -n fluidbox logs -l app.kubernetes.io/component=server --tail=2000 \
+  | grep '"worker":"netpol_gate"' | tail -3
+kubectl -n fluidbox-sandboxes describe pod fluidbox-netpol-probe | sed -n '/^Events/,$p'
+```
+
+| gate result | probe event | cause | fix |
+|---|---|---|---|
+| `Unschedulable` | `NotTriggerScaleUp: … untolerated taint(s)` | The sandbox pool is at zero and the autoscaler's scale-up simulation refuses the pod because the pool template carries a taint it does not tolerate. On this cluster that is the Cilium startup taint, whose key **must** sit under `ignore-taint.cluster-autoscaler.kubernetes.io/` (the autoscaler ignores that prefix in the simulation). Check `gcloud container node-pools describe sandbox --format='value(config.taints[].key)'`. | Restore the prefix in `platform/gke.tf` (`local.cilium_agent_not_ready_taint_key`) and re-apply — **never** "fix" it by giving sandbox pods a toleration for the not-ready taint; that reopens the unmanaged-pod hole the taint closes. |
+| `Unschedulable` | pod Pending on a node that keeps the not-ready taint | The node was born with a taint key Cilium's operator is not configured to remove: the platform and app stacks disagree on `cilium_agent_not_ready_taint_key`. `kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.agent-not-ready-taint-key}'` vs the pool template. | Re-apply the app stack with the key from `terraform -chdir=platform output -raw cilium_agent_not_ready_taint_key`; the operator lifts the taint from stuck nodes on its next pass. |
+| `Unschedulable` | `TriggeredScaleUp`, pod still Pending | Cold start from zero is legitimately in progress. Measured: autoscaler decision → node ≈30 s, Cilium prepares the node and lifts the taint ≈50 s, gate verified ≈90 s after the decision. The gate's deadline is 240 s and it retries 30 s after a miss, so even a slow cold start heals on the next attempt. | Wait one cycle. Persisting past ~6 min is one of the rows above. |
+| `NotEnforced` | probe `Failed`, exit 3 | The CNI is not dropping traffic. | Runs stay blocked by design; check Cilium agent health on the sandbox node. |
+
+#### Changing the startup taint key (or upgrading Cilium) {#cilium-taint-migration}
+
+Order matters, for two reasons. The operator lifts exactly ONE key, so a node
+born with any other stays tainted `NoExecute` forever. And GKE applies a pool
+taint change to the pool's EXISTING nodes immediately — `NoExecute` evicts every
+pod without a toleration on the spot (27 pods in 8 s when this fix shipped). With
+Cilium already lifting the new key that is a ~30 s blip; with the pools changed
+first it is the whole control plane evicted with nowhere to go.
+
+```
+# 1. Cilium first - it must be lifting the NEW key before any node is born with it.
+terraform -chdir=deploy/cloud/gcp/app apply \
+  -var "external_secrets_sa=$(terraform -chdir=deploy/cloud/gcp/platform output -raw external_secrets_service_account)" \
+  -var "cilium_agent_not_ready_taint_key=<the new key>"
+kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.agent-not-ready-taint-key}'
+
+# 2. Pool templates - merge the platform change; the pipeline applies it in-place.
+
+# 3. Sweep for nodes born in between. A Cilium upgrade rolls cilium-operator,
+#    whose anti-affinity makes the autoscaler add a surge node to the two-node
+#    system pool - born with whichever key the template had at that moment.
+kubectl get nodes -o custom-columns='NAME:.metadata.name,TAINTS:.spec.taints[*].key'
+#    A node still carrying the OLD key with a Ready cilium agent: lift it by hand,
+#    which is exactly what the operator would have done under the old config.
+kubectl taint node <node> <old-key>-
+```
+
 ### CrashLoopBackOff {#crashloop}
 
 ```


### PR DESCRIPTION
Follow-up to #197 with what the fix proved and what shipping it taught. Docs + CLAUDE.md only — no deploy trigger paths.

**Measured on the apply that shipped #197:** `TriggeredScaleUp` on the probe pod at 01:23:25Z (the seven probes before the fix all ended `NotTriggerScaleUp: untolerated taint(s)`) → node born 31 s later → operator lifted the startup taint ≈47 s after that → gate logged *verified* at 01:24:55Z. **90 s from decision to admitted runs**, against a 240 s probe deadline and a 300 s run-pod grace.

**Two things the apply taught, now in the runbook:**
- GKE pushes a pool taint change onto **existing** nodes immediately, and `NoExecute` evicted 27 pods in 8 s. Because Cilium was already lifting the new key it was a ~30 s blip the pipeline's smoke stage never saw; pools-first would have evicted the entire control plane with nowhere to go. The migration order is documented as load-bearing, not a preference.
- A Cilium upgrade rolls `cilium-operator`, whose anti-affinity makes the autoscaler add a surge node to the two-node system pool — born with whatever key the template had at that moment. One was, and had to be untainted by hand; the procedure now ends with that sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hyJiVeXan6NvRp7BAwxVf