### PR TITLE
feat(gcp): enable the codex harness — OpenAI key opted in, tenant allowlist widened

### DIFF
--- a/deploy/cloud/gcp/values/production.yaml
+++ b/deploy/cloud/gcp/values/production.yaml
@@ -139,6 +139,10 @@ web:
 litellm:
   enabled: true
   image: ghcr.io/berriai/litellm-database:main-stable
+  # OpenAI, for the codex harness. The Secret key is materialised by the
+  # externalSecrets entry below, which requires the openai-api-key secret to
+  # HAVE A VERSION (README step 2) - a versionless secret fails the whole sync.
+  openaiKeySecretKey: OPENAI_API_KEY
   database:
     enabled: true
   nodeSelector:
@@ -156,6 +160,13 @@ llm:
     models:
       - claude-haiku-4-5
       - claude-sonnet-5
+      # The codex harness. These ride the gateway's "gpt-5*" route, which is
+      # backed by litellm.openaiKeySecretKey below. Widening this list does
+      # NOT change keys already minted: rotate them after the deploy
+      # (POST /v1/admin/orgs/{slug}/llm-key/rotate).
+      - gpt-5.4-mini
+      - gpt-5.4
+      - gpt-5.6-sol
     maxBudget: "25"
     budgetDuration: "30d"
 
@@ -219,6 +230,7 @@ externalSecrets:
     - { secretKey: LITELLM_MASTER_KEY, remoteRef: litellm-master-key }
     - { secretKey: LITELLM_DATABASE_URL, remoteRef: litellm-database-url }
     - { secretKey: ANTHROPIC_API_KEY, remoteRef: anthropic-api-key }
+    - { secretKey: OPENAI_API_KEY, remoteRef: openai-api-key }
     # NO archive S3 credentials. They exist only when
     # enable_gcs_archive_store is on in the platform stack, which it is not:
     # the static HMAC key that backend needs is refused by

--- a/docs/hosted/gcp-operations.md
+++ b/docs/hosted/gcp-operations.md
@@ -179,7 +179,7 @@ widened without rotating keys.
 | cause | fix |
 |---|---|
 | the model is genuinely not served here (e.g. any `gpt-5*` with no OpenAI key) | Change the agent's model, or enable the provider (README step 2) |
-| `llm.tenant.models` was widened but keys predate it | `POST /v1/admin/orgs/{slug}/llm-key/rotate` with the admin token — a key's allowlist is fixed at mint |
+| `llm.tenant.models` was widened but keys predate it | `scripts/cloud/gcp-rotate-llm-keys.sh [slug…]` (wraps `POST /v1/admin/orgs/{slug}/llm-key/rotate`; reads the admin token from Secret Manager) — a key's allowlist is fixed at mint |
 
 ### CrashLoopBackOff {#crashloop}
 

--- a/scripts/cloud/gcp-rotate-llm-keys.sh
+++ b/scripts/cloud/gcp-rotate-llm-keys.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Rotate tenants' LiteLLM virtual keys on the GCP deployment.
+#
+# Why this exists: in llm.keyMode "tenant" every model request rides a
+# per-tenant virtual key, and that key's MODEL ALLOWLIST is fixed at mint.
+# Widening llm.tenant.models and deploying changes what NEW keys get - every
+# existing key keeps refusing the new models with
+#   403 key not allowed to access model
+# until it is rotated. Rotation mints a fresh key under the current allowlist,
+# swaps it in, and retires the old one at LiteLLM. The key is never returned
+# (the API answers {"rotated": true}) and never printed here.
+#
+#   scripts/cloud/gcp-rotate-llm-keys.sh              # every org
+#   scripts/cloud/gcp-rotate-llm-keys.sh fluidzero    # named orgs only
+#
+# Environment:
+#   CONTROL_HOST           control-plane origin  (default api.platform.fluidzero.ai)
+#   FLUIDBOX_ADMIN_TOKEN   admin token; when unset it is read from Secret
+#                          Manager (fluidbox-admin-token in GCP_PROJECT)
+#   GCP_PROJECT            (default fluidbox-506603)
+#
+# Runs are unaffected mid-flight: the facade swaps the credential per request,
+# and an in-flight stream completes on the key it started with.
+
+set -uo pipefail
+
+CONTROL_HOST="${CONTROL_HOST:-api.platform.fluidzero.ai}"
+PROJECT="${GCP_PROJECT:-fluidbox-506603}"
+API="https://$CONTROL_HOST"
+
+TOKEN="${FLUIDBOX_ADMIN_TOKEN:-}"
+if [ -z "$TOKEN" ]; then
+  TOKEN="$(gcloud secrets versions access latest --secret=fluidbox-admin-token --project "$PROJECT" 2>/dev/null)" \
+    || { echo "could not read fluidbox-admin-token from Secret Manager" >&2; exit 1; }
+fi
+[ -n "$TOKEN" ] || { echo "no admin token" >&2; exit 1; }
+
+if [ $# -gt 0 ]; then
+  SLUGS=("$@")
+else
+  mapfile -t SLUGS < <(curl -sf -m 15 -H "Authorization: Bearer $TOKEN" "$API/v1/admin/orgs" \
+    | python3 -c 'import json,sys; [print(o["slug"]) for o in json.load(sys.stdin)["orgs"]]')
+  [ ${#SLUGS[@]} -gt 0 ] || { echo "no orgs listed (auth or connectivity)" >&2; exit 1; }
+fi
+
+FAIL=0
+for slug in "${SLUGS[@]}"; do
+  out="$(curl -s -m 60 -o /dev/stderr -w '%{http_code}' -X POST \
+          -H "Authorization: Bearer $TOKEN" "$API/v1/admin/orgs/$slug/llm-key/rotate" 2>/tmp/rotate.$$)"
+  body="$(cat /tmp/rotate.$$ 2>/dev/null)"; rm -f /tmp/rotate.$$
+  if [ "$out" = "200" ] && printf '%s' "$body" | grep -q '"rotated": *true'; then
+    printf '  \033[32m✓\033[0m %s rotated\n' "$slug"
+  else
+    printf '  \033[31m✗\033[0m %s -> HTTP %s %s\n' "$slug" "$out" "$(printf '%s' "$body" | head -c 160)"
+    FAIL=$((FAIL+1))
+  fi
+done
+unset TOKEN
+[ "$FAIL" -eq 0 ] && exit 0
+echo "$FAIL rotation(s) failed" >&2; exit 1


### PR DESCRIPTION
**DRAFT — do not merge until `openai-api-key` has a version.** The ExternalSecret entry this adds points at that secret, and an entry pointing at a versionless secret fails the whole sync (the server cannot start without the other eight keys). Step 2 of the sequence in #199.

Once merged and deployed: rotate every tenant's LiteLLM key (`POST /v1/admin/orgs/{slug}/llm-key/rotate`) — a key's model allowlist is fixed at mint, so keys minted under the Claude-only list would still 403 `gpt-5*`.

Renders verified with the production values: one `OPENAI_API_KEY` env on the gateway, the ExternalSecret entry present, `FLUIDBOX_LLM_TENANT_MODELS` carries the three GPT models; `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hyJiVeXan6NvRp7BAwxVf