### PR TITLE
fix(ci): pull-request plans must not share the production deploy's concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,16 @@ on:
 # apply or a helm upgrade killed halfway leaves state that is harder to reason
 # about than simply waiting. This is the opposite of the ci.yml setting, which
 # cancels superseded PR runs on purpose.
+#
+# The group is EVENT-AWARE. A pull-request run only plans, but it used to sit
+# in the same group as production deploys - and GitHub keeps at most ONE
+# pending run per group, cancelling the older pending run when a newer one
+# arrives (cancel-in-progress only governs runs already executing). Opening a
+# PR seconds after a merge therefore cancelled the queued production deploy of
+# that merge, silently: main was never deployed and nothing failed. Plans now
+# queue per PR; only pushes to main share the production group.
 concurrency:
-  group: deploy-production
+  group: ${{ github.event_name == 'pull_request' && format('deploy-plan-pr-{0}', github.event.pull_request.number) || 'deploy-production' }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
Run [32920435324](https://github.com/hrishikeshdkakkad/fluidbox/actions/runs/32920435324) — the production deploy of #199 — was **cancelled**, and nothing failed: GitHub keeps at most one *pending* run per concurrency group and cancels the older pending run when a newer one arrives (`cancel-in-progress` only governs runs already executing). Every event of this workflow, pull-request plans included, sat in the single `deploy-production` group, so opening draft #200 seconds after the merge evicted the still-queued deploy. `main` silently never deployed.

Plans now queue under `deploy-plan-pr-<n>`; only pushes to `main` share `deploy-production`, preserving the one-deploy-at-a-time guarantee. Merging this triggers the deploy that #199 should have had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hyJiVeXan6NvRp7BAwxVf