### PR TITLE
fix: apply gates on the plan JSON; gcp-secrets.sh refuses silent rotations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,9 +161,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       destructive: ${{ steps.inspect.outputs.destructive }}
-      # "2" = the plan contains changes (-detailed-exitcode). Apply gates on
-      # THIS, not on the path filter, so an owed apply is never skipped.
-      exit: ${{ steps.plan.outputs.exit }}
+      # Resource changes in the REVIEWED plan, counted from its JSON. Apply
+      # gates on THIS - not on the path filter (which lost owed applies) and
+      # not on -detailed-exitcode: under setup-terraform's wrapper the captured
+      # exit code did not survive, a "Plan: 2 to add" run skipped its apply,
+      # and the JSON is the artifact the destroy gate already trusts.
+      changes: ${{ steps.inspect.outputs.changes }}
     steps:
       - uses: actions/checkout@v7
       - uses: google-github-actions/auth@v2
@@ -203,6 +206,10 @@ jobs:
           DESTRUCTIVE=$(jq '[.resource_changes[]?
             | select(.change.actions | index("delete"))] | length' plan.json)
           echo "destructive=$DESTRUCTIVE" >> "$GITHUB_OUTPUT"
+          CHANGES=$(jq '[.resource_changes[]?
+            | select(.change.actions != ["no-op"])] | length' plan.json)
+          echo "changes=$CHANGES" >> "$GITHUB_OUTPUT"
+          echo "plan: $CHANGES resource change(s), $DESTRUCTIVE destructive"
           if [ "$DESTRUCTIVE" -gt 0 ]; then
             echo "::warning::plan contains $DESTRUCTIVE destroy/replace action(s)"
             jq -r '.resource_changes[]? | select(.change.actions | index("delete"))
@@ -235,7 +242,7 @@ jobs:
     needs: [changes, plan]
     # Apply whenever the REVIEWED plan has changes - on a push or a manual
     # deploy, never on a pull request (the planner identity cannot write).
-    if: github.event_name != 'pull_request' && needs.plan.outputs.exit == '2' && inputs.rollback_to == ''
+    if: github.event_name != 'pull_request' && needs.plan.outputs.changes != '0' && inputs.rollback_to == ''
     runs-on: ubuntu-latest
     environment: Production
     steps:

--- a/deploy/cloud/gcp/README.md
+++ b/deploy/cloud/gcp/README.md
@@ -107,6 +107,9 @@ terraform apply
 #    without it (the key is read as optional; the catalog hides codex meanwhile).
 scripts/cloud/gcp-secrets.sh --from-env-file .env      # or: OPENAI_API_KEY=... scripts/cloud/gcp-secrets.sh
 scripts/cloud/gcp-secrets.sh --prompt                  # or paste, with hidden input
+#    A value that differs from a version already in place is a ROTATION and is
+#    refused unless you pass --rotate - a dotenv can carry a different key than
+#    the one production runs on.
 
 # 3. Cluster prerequisites.
 cd ../app

--- a/docs/hosted/gcp-operations.md
+++ b/docs/hosted/gcp-operations.md
@@ -317,7 +317,16 @@ cannot rotate them by accident.
 
 Adding a new version and restarting the Deployment is the rotation mechanism for
 the others (External Secrets re-syncs on its `refreshInterval`, or immediately
-if you delete the target Secret).
+if you delete the target Secret). For the out-of-band ones — the model-provider
+keys and the IdP client secret — `scripts/cloud/gcp-secrets.sh` is the whole
+procedure: it reports which have a version, adds missing ones from a dotenv /
+the environment / a hidden prompt, and after a provider key changes it syncs
+External Secrets and restarts the gateway. A value that DIFFERS from the
+version in place is refused unless you pass `--rotate`, because a dotenv can
+carry a different key than the one production runs on.
+
+The tenant LiteLLM keys are not in that list on purpose: the server mints,
+rotates (allowlist drift), and recovers them itself.
 
 ## Alerts
 

--- a/scripts/cloud/gcp-secrets.sh
+++ b/scripts/cloud/gcp-secrets.sh
@@ -12,11 +12,15 @@
 #   scripts/cloud/gcp-secrets.sh --from-env-file .env    # add versions from a dotenv
 #   OPENAI_API_KEY=... scripts/cloud/gcp-secrets.sh      # add versions from the environment
 #   scripts/cloud/gcp-secrets.sh --prompt                # ask, with hidden input
+#   scripts/cloud/gcp-secrets.sh --rotate ...            # allow REPLACING a version
 #
 # For each secret with a value on hand it adds a version - refusing an EMPTY
 # value up front, because `gcloud secrets versions add` reports that as a bare
 # "Secret Payload cannot be empty" that hides which variable was unset. A value
-# identical to the current version is skipped, so re-running is free.
+# identical to the current version is skipped, so re-running is free. A value
+# that DIFFERS from an existing version is a rotation of a production key, and
+# a dotenv can easily carry a different key than the one the deployment runs
+# on: that is refused with a warning unless --rotate says it is intended.
 #
 # Provider keys are read by the LiteLLM gateway at START, so after adding one
 # this also asks the External Secrets operator to sync now and restarts the
@@ -42,11 +46,12 @@ SECRETS=(
   "auth0-client-secret|AUTH0_CLIENT_SECRET|OIDC client secret for the org IdP|no"
 )
 
-ENV_FILE=""; PROMPT=0
+ENV_FILE=""; PROMPT=0; ROTATE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --from-env-file) ENV_FILE="${2:-}"; shift 2;;
     --prompt) PROMPT=1; shift;;
+    --rotate) ROTATE=1; shift;;
     -h|--help) sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
     *) die "unknown argument: $1";;
   esac
@@ -88,8 +93,15 @@ for row in "${SECRETS[@]}"; do
     continue
   fi
   new_fp="$(printf '%s' "$val" | shasum -a 256 | cut -c1-12)"
-  if [ "$n" -gt 0 ] && [ "$(fingerprint "$id")" = "$new_fp" ]; then
-    ok "$id: current version already matches $var (fingerprint $new_fp)"; continue
+  if [ "$n" -gt 0 ]; then
+    cur_fp="$(fingerprint "$id")"
+    if [ "$cur_fp" = "$new_fp" ]; then
+      ok "$id: current version already matches $var (fingerprint $new_fp)"; continue
+    fi
+    if [ "$ROTATE" != 1 ]; then
+      warn "$id: $var DIFFERS from the current version (fingerprints $cur_fp vs $new_fp) - that would be a rotation; re-run with --rotate if intended"
+      continue
+    fi
   fi
   if printf '%s' "$val" | gcloud secrets versions add "$id" --data-file=- --project "$PROJECT" >/dev/null 2>&1; then
     ok "$id: version added from $var (fingerprint $new_fp)"


### PR DESCRIPTION
Two fixes surfaced by the last deploy cycle.

**`apply` skipped after `Plan: 2 to add`.** The `-detailed-exitcode` captured under setup-terraform's wrapper did not reach the job output as `2`, so the `openai-api-key` secret that plan would have created had to be applied locally (same Terraform, same remote state; `Apply complete! 2 added`). The inspect step already renders the reviewed plan to JSON for the destroy gate; it now counts non-no-op resource changes and `apply` gates on that — deterministic, wrapper-independent, logged.

**`gcp-secrets.sh` could rotate a production key by accident.** A value that differs from the version in place is a rotation, and a dotenv can carry a different key than the one production runs on — `--from-env-file .env` would have replaced the hosted Anthropic key with the local one. Refused now unless `--rotate`; verified against the project with a deliberately different value (refused, version count unchanged). Runbook's Secrets section points at the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hyJiVeXan6NvRp7BAwxVf