### PR TITLE
fix(server): a run that fails at provisioning finalizes at once

### DIFF
--- a/crates/fluidbox-server/src/orchestrator.rs
+++ b/crates/fluidbox-server/src/orchestrator.rs
@@ -66,6 +66,24 @@ const FINALIZE_CLAIM_STALE_SECS: i64 = 420;
 /// workspace never waits).
 const PROVISION_SETTLE_SECS: i64 = 120;
 
+/// Whether a handle-less session's provisioning might still be in flight — the
+/// only reason collection waits out `PROVISION_SETTLE_SECS` instead of asking
+/// the provider straight away.
+///
+/// A `failed` intent never qualifies. Only two callers record one: the run
+/// driver, from its own error path — so provisioning is over, and if it left a
+/// pod behind the provider's truth (`list_managed`) finds it immediately — and
+/// the heartbeat watchdog, whose session was running and therefore has a
+/// handle. Waiting here used to cost every provisioning failure two minutes in
+/// `finalizing` (visible on the timeline) for a race that cannot happen.
+fn provisioning_may_be_in_flight(
+    outcome: &str,
+    intent_created: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    outcome != "failed" && now < intent_created + chrono::Duration::seconds(PROVISION_SETTLE_SECS)
+}
+
 /// Terminal artifact collection is bounded: a hostile or huge worktree can
 /// waste the cap, never wedge `finalizing`.
 const COLLECT_TIMEOUT: Duration = Duration::from_secs(120);
@@ -923,8 +941,11 @@ async fn collect_and_terminalize(
             let handle = match session_handle_state(&session) {
                 StoredHandle::Handle(h) => Some(h),
                 StoredHandle::None
-                    if chrono::Utc::now()
-                        < intent.created_at + chrono::Duration::seconds(PROVISION_SETTLE_SECS) =>
+                    if provisioning_may_be_in_flight(
+                        &intent.outcome,
+                        intent.created_at,
+                        chrono::Utc::now(),
+                    ) =>
                 {
                     tracing::info!(
                         session_id = %id,
@@ -2426,6 +2447,29 @@ fn uuid_token() -> String {
 
 #[cfg(test)]
 mod tests {
+    /// A failed intent with no handle is the driver's own provisioning failure:
+    /// nothing is in flight, so collection must consult the provider at once
+    /// instead of waiting out the settle window.
+    #[test]
+    fn a_failed_intent_never_waits_for_provisioning_to_settle() {
+        let t0 = chrono::Utc::now();
+        let early = t0 + chrono::Duration::seconds(1);
+        let late = t0 + chrono::Duration::seconds(PROVISION_SETTLE_SECS + 1);
+        assert!(!provisioning_may_be_in_flight("failed", t0, early));
+        assert!(!provisioning_may_be_in_flight("failed", t0, late));
+        // Every other outcome keeps the bounded wait: a cancel can genuinely
+        // race an in-flight provision.
+        for o in ["completed", "cancelled", "budget_exceeded"] {
+            assert!(
+                provisioning_may_be_in_flight(o, t0, early),
+                "{o} inside the window"
+            );
+            assert!(
+                !provisioning_may_be_in_flight(o, t0, late),
+                "{o} past the window"
+            );
+        }
+    }
     use super::*;
     use fluidbox_core::state::SessionStatus::*;
 


### PR DESCRIPTION
Run `01a03be5` failed at provisioning at 02:29:55 and reached `failed` at 02:31:57 — it spent `PROVISION_SETTLE_SECS` (120 s) in `finalizing`, logging *"artifact collection deferred: no sandbox handle stored yet (provisioning may be in flight)"* every 20 s. Provisioning was not in flight: the driver had already reported the failure and the provider had deleted the pod.

The settle window guards a finalize that **races** an in-flight provision (a cancel, say). A `failed` intent can't be that: its only writers are the run driver's own error path and the heartbeat watchdog, whose sessions were running and hold a handle. So `failed` + no handle ⇒ ask the provider immediately. Pure predicate, decision table pinned; the wait is unchanged for every other outcome.

This was masked before #199: the reconciler used to adopt every fresh launch within seconds, handing failed provisions a handle and letting collection run at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hyJiVeXan6NvRp7BAwxVf