### PR TITLE
fix(ci): helm waits for workloads and jobs, not for every custom resource

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -408,8 +408,18 @@ jobs:
             -f deploy/cloud/gcp/values/production.yaml \
             "${ARGS[@]}" \
             --rollback-on-failure \
-            --wait --wait-for-jobs \
+            --wait=legacy --wait-for-jobs \
             --timeout 20m
+          # --wait=legacy, EXPLICITLY. With --rollback-on-failure set, Helm 4
+          # defaults --wait to "watcher", which also waits for every CUSTOM
+          # RESOURCE to report Ready. The optional ExternalSecret is Ready=False
+          # by design until its provider key has a version, so rev 8 sat in
+          # pending-upgrade for 19 of its 20 minutes - one minute from a
+          # rollback of a perfectly healthy release. "legacy" is the readiness
+          # this chart means: pods, Deployments, Services, and (with
+          # --wait-for-jobs) the migration hook. A ManagedCertificate still
+          # provisioning would have blocked the first install the same way.
+          #
           # --rollback-on-failure (Helm 4's name for --atomic) is the readiness
           # gate AND the automatic rollback: if the
           # pre-upgrade migration Job fails, or any pod never becomes ready

--- a/docs/hosted/gcp-operations.md
+++ b/docs/hosted/gcp-operations.md
@@ -36,6 +36,26 @@ matter most:
 3. **`--atomic`** (`deploy`). If any pod fails to become ready inside the
    timeout, Helm restores the previous revision automatically.
 
+### `helm history` shows `pending-upgrade` while every pod is Ready {#pending-upgrade}
+
+Helm 4's `watcher` wait strategy (the default whenever `--rollback-on-failure`
+is set) waits for every CUSTOM RESOURCE in the release to report Ready, not
+just workloads. A CR that is legitimately not Ready — the optional
+ExternalSecret before its provider key has a version, a ManagedCertificate
+still provisioning — holds the release in `pending-upgrade` until
+`--timeout`, and then `--rollback-on-failure` reverts a healthy release. The
+pipeline passes `--wait=legacy` since 2026-08-26 for exactly this reason. If
+you ever see it anyway:
+
+```
+kubectl -n fluidbox get externalsecret,managedcertificate      # which one is not Ready?
+kubectl -n fluidbox describe externalsecret fluidbox-optional  # its reason
+```
+
+Making the CR Ready (add the missing secret version, wait out certificate
+provisioning) completes the upgrade immediately — rev 8 flipped to `deployed`
+within seconds of the OpenAI key landing.
+
 ### A push run that ends `cancelled` with no failed job {#cancelled-run}
 
 `main` was not deployed, and nothing failed. GitHub keeps at most ONE pending


### PR DESCRIPTION
Release 8 sat in `pending-upgrade` for **19 of its 20 minutes** with every pod Ready. Cause: Helm 4 defaults `--wait` to `watcher` whenever `--rollback-on-failure` is set (its own `--help` says so), and `watcher` waits for every **custom resource** to report Ready — the optional ExternalSecret is `Ready=False` by design until its key has a version. One more minute and `--rollback-on-failure` would have reverted a healthy release. Adding the key flipped it to `deployed` within seconds.

`--wait=legacy --wait-for-jobs`: pods, Deployments, Services, and the migration hook — the readiness this chart actually means. A ManagedCertificate still provisioning would have blocked a first install the same way. Runbook entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hyJiVeXan6NvRp7BAwxVf